### PR TITLE
feat: add Claude Cowork plugin marketplace approach

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,31 @@
+{
+  "name": "promptexecution-tools",
+  "owner": {
+    "name": "PromptExecution",
+    "email": "opensource@promptexecution.io"
+  },
+  "metadata": {
+    "description": "PromptExecution plugin catalog for Claude/Cowork workflows",
+    "version": "1.0.0",
+    "pluginRoot": "./plugins"
+  },
+  "plugins": [
+    {
+      "name": "l3dg3rr-plugin-create",
+      "source": "./l3dg3rr-plugin-create",
+      "description": "Install l3dg3rr MCP capabilities for connector/plugin-create workflows in Cowork",
+      "version": "1.0.0",
+      "author": {
+        "name": "PromptExecution"
+      },
+      "license": "GPL-3.0-only",
+      "category": "finance",
+      "tags": [
+        "cowork",
+        "mcp",
+        "plugin-create",
+        "ledger"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
         "name": "PromptExecution",
         "email": "brianh@promptexecution.com"
       },
-      "license": "GPL-3.0-only",
+      "license": "MIT",
       "category": "finance",
       "tags": [
         "cowork",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
-  "name": "promptexecution-tools",
+  "name": "promptexecution-fdkms",
   "owner": {
     "name": "PromptExecution",
-    "email": "opensource@promptexecution.io"
+    "email": "brianh@promptexecution.com"
   },
   "metadata": {
     "description": "PromptExecution plugin catalog for Claude/Cowork workflows",
@@ -16,7 +16,8 @@
       "description": "Install l3dg3rr MCP capabilities for connector/plugin-create workflows in Cowork",
       "version": "1.0.0",
       "author": {
-        "name": "PromptExecution"
+        "name": "PromptExecution",
+        "email": "brianh@promptexecution.com"
       },
       "license": "GPL-3.0-only",
       "category": "finance",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,100 @@
+name: Publish Artifacts
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish-ghcr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=ref,event=tag
+            type=sha
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  publish-crates:
+    runs-on: ubuntu-latest
+    needs: publish-ghcr
+    if: ${{ secrets.CRATES_IO_TOKEN != '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish ledger-core
+        run: cargo publish -p ledger-core --token "${CRATES_IO_TOKEN}"
+        env:
+          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+
+      - name: Wait for crates.io index propagation
+        run: sleep 20
+
+      - name: Publish turbo-mcp
+        run: cargo publish -p turbo-mcp --token "${CRATES_IO_TOKEN}"
+        env:
+          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+
+  publish-pypi:
+    runs-on: ubuntu-latest
+    needs: publish-ghcr
+    if: ${{ secrets.PYPI_API_TOKEN != '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build Python package
+        working-directory: plugins/l3dg3rr-plugin-create/python
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: plugins/l3dg3rr-plugin-create/python/dist/
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,16 @@
+set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
+
+mcp-build:
+    cargo build -p turbo-mcp --bin turbo-mcp-server
+
+mcp-start:
+    cargo run -p turbo-mcp --bin turbo-mcp-server
+
+mcp-start-release:
+    ./target/release/turbo-mcp-server
+
+mcp-stop:
+    pkill -f turbo-mcp-server || true
+
+mcp-e2e:
+    ./scripts/mcp_e2e.sh

--- a/README.md
+++ b/README.md
@@ -56,3 +56,12 @@ This validates the full ingest -> classify -> audit -> schedule summary flow.
 - Approach and operator workflow: `docs/claude-cowork-plugin-marketplace.md`
 - Marketplace catalog: `.claude-plugin/marketplace.json`
 - MCP runtime helpers: `Justfile` (`just mcp-start`, `just mcp-stop`, `just mcp-e2e`)
+
+## CI/CD Publish Targets
+
+- Workflow: `.github/workflows/publish.yml`
+- Trigger: GitHub Release `published` (or manual `workflow_dispatch`)
+- Targets:
+  - GHCR image: `ghcr.io/promptexecution/l3dg3rr`
+  - crates.io crates: `ledger-core`, `turbo-mcp` (requires `CRATES_IO_TOKEN`)
+  - PyPI package: `l3dg3rr-mcp-launcher` (requires `PYPI_API_TOKEN`)

--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ This validates the full ingest -> classify -> audit -> schedule summary flow.
 
 - Approach and operator workflow: `docs/claude-cowork-plugin-marketplace.md`
 - Marketplace catalog: `.claude-plugin/marketplace.json`
+- MCP runtime helpers: `Justfile` (`just mcp-start`, `just mcp-stop`, `just mcp-e2e`)

--- a/README.md
+++ b/README.md
@@ -50,3 +50,8 @@ cog bump --auto
 ```
 
 This validates the full ingest -> classify -> audit -> schedule summary flow.
+
+## Claude Cowork Plugin Marketplace
+
+- Approach and operator workflow: `docs/claude-cowork-plugin-marketplace.md`
+- Marketplace catalog: `.claude-plugin/marketplace.json`

--- a/docs/claude-cowork-plugin-marketplace.md
+++ b/docs/claude-cowork-plugin-marketplace.md
@@ -1,54 +1,109 @@
-# Claude Cowork Plugin Marketplace Approach
+# Claude Cowork Plugin Marketplace for l3dg3rr
 
-## Goal
+## What this delivers
 
-Distribute this repository as an installable Cowork plugin marketplace entry, with a dedicated `l3dg3rr-plugin-create` plugin that exposes `turbo-mcp-server`.
+This repo now includes a Claude plugin marketplace and a plugin entry intended for Cowork + Plugin Create workflows:
 
-## Artifacts in this repo
+- Marketplace: `promptexecution-fdkms`
+- Plugin: `l3dg3rr-plugin-create`
 
-- Marketplace catalog: `.claude-plugin/marketplace.json`
-- Plugin manifest: `plugins/l3dg3rr-plugin-create/.claude-plugin/plugin.json`
-- Plugin skill: `plugins/l3dg3rr-plugin-create/skills/plugin-create-for-l3dg3rr/SKILL.md`
+## Key files
 
-## Cowork install flow
+- Marketplace catalog: [marketplace.json](/home/brianh/promptexecution/mbse/l3dg3rr/.claude-plugin/marketplace.json)
+- Plugin manifest: [plugin.json](/home/brianh/promptexecution/mbse/l3dg3rr/plugins/l3dg3rr-plugin-create/.claude-plugin/plugin.json)
+- Plugin skill: [SKILL.md](/home/brianh/promptexecution/mbse/l3dg3rr/plugins/l3dg3rr-plugin-create/skills/plugin-create-for-l3dg3rr/SKILL.md)
+- MCP server entrypoint: [turbo-mcp-server.rs](/home/brianh/promptexecution/mbse/l3dg3rr/crates/turbo-mcp/src/bin/turbo-mcp-server.rs)
+- Runtime helper commands: [Justfile](/home/brianh/promptexecution/mbse/l3dg3rr/Justfile)
+- MCP regression script: [mcp_e2e.sh](/home/brianh/promptexecution/mbse/l3dg3rr/scripts/mcp_e2e.sh)
+- Container build: [Dockerfile](/home/brianh/promptexecution/mbse/l3dg3rr/Dockerfile)
+- Python launcher package: [pyproject.toml](/home/brianh/promptexecution/mbse/l3dg3rr/plugins/l3dg3rr-plugin-create/python/pyproject.toml)
 
-In Claude Code/Cowork:
+## Install in Cowork
 
 ```text
 /plugin marketplace add https://github.com/PromptExecution/l3dg3rr
-/plugin install l3dg3rr-plugin-create@promptexecution-tools
+/plugin install l3dg3rr-plugin-create@promptexecution-fdkms
 ```
 
-Then validate:
+Validate:
 
 ```text
 /plugin list
 /plugin show l3dg3rr-plugin-create
 ```
 
-In a Cowork task, run:
+## MCP runtime profiles
+
+The plugin manifest ships multiple MCP server profiles:
+
+- `l3dg3rr-cargo` (default development path)
+- `l3dg3rr-binary` (compiled release binary)
+- `l3dg3rr-docker` (container runtime)
+- `l3dg3rr-python` (python launcher wrapper)
+
+### 1) Cargo
+
+```bash
+just mcp-build
+just mcp-start
+```
+
+### 2) Compiled binary
+
+```bash
+cargo build --release -p turbo-mcp --bin turbo-mcp-server
+just mcp-start-release
+```
+
+### 3) Docker
+
+```bash
+docker build -t tax-ledger:dev .
+docker run -i --rm -v "$PWD:/workspace" -w /workspace tax-ledger:dev \
+  cargo run -p turbo-mcp --bin turbo-mcp-server
+```
+
+### 4) Python packaging / launcher
+
+Install local launcher package:
+
+```bash
+pip install -e plugins/l3dg3rr-plugin-create/python
+```
+
+Run:
+
+```bash
+l3dg3rr-mcp --mode cargo
+l3dg3rr-mcp --mode binary --binary ./target/release/turbo-mcp-server
+l3dg3rr-mcp --mode docker --image tax-ledger:dev
+```
+
+## Start/stop MCP interface
+
+- Start (foreground): one of the runtime commands above.
+- Stop (foreground): `Ctrl+C`.
+- Stop (best-effort process kill): `just mcp-stop`.
+
+In Cowork, process lifecycle is typically managed by Claude once the plugin is installed and selected.
+
+## Validation in Cowork
+
+After install, in a Cowork task:
 
 ```text
 tools/list
 tools/call l3dg3rr_context_summary {}
 ```
 
-## Organization distribution model
+Then run deeper checks from shell:
 
-1. Host this marketplace on GitHub (recommended distribution path).
-2. Team admins add it as an approved marketplace.
-3. Users install `l3dg3rr-plugin-create` from the marketplace catalog.
-4. For stricter controls, combine with managed marketplace restrictions in team settings.
+```bash
+just mcp-e2e
+```
 
-## CI publication assist
+## References
 
-Use the official Claude Code GitHub Action for PR/issue automation while maintaining this marketplace catalog in-repo:
-
-- Marketplace listing: `https://github.com/marketplace/actions/claude-code-action-official`
-- Keep plugin artifacts versioned and reviewed via PR before publishing updates.
-
-## Notes
-
-- This approach uses Git-hosted marketplace distribution and relative plugin source paths.
-- The MCP server command currently assumes `cargo` availability on the host running Cowork/plugin execution.
-- For container-first environments, replace `mcpServers.l3dg3rr.command` with a docker launcher profile.
+- Plugin marketplaces docs: https://code.claude.com/docs/en/plugin-marketplaces
+- Cowork plugin usage: https://support.claude.com/en/articles/13837440-use-plugins-in-cowork
+- Claude Code GitHub Action: https://github.com/marketplace/actions/claude-code-action-official

--- a/docs/claude-cowork-plugin-marketplace.md
+++ b/docs/claude-cowork-plugin-marketplace.md
@@ -1,0 +1,54 @@
+# Claude Cowork Plugin Marketplace Approach
+
+## Goal
+
+Distribute this repository as an installable Cowork plugin marketplace entry, with a dedicated `l3dg3rr-plugin-create` plugin that exposes `turbo-mcp-server`.
+
+## Artifacts in this repo
+
+- Marketplace catalog: `.claude-plugin/marketplace.json`
+- Plugin manifest: `plugins/l3dg3rr-plugin-create/.claude-plugin/plugin.json`
+- Plugin skill: `plugins/l3dg3rr-plugin-create/skills/plugin-create-for-l3dg3rr/SKILL.md`
+
+## Cowork install flow
+
+In Claude Code/Cowork:
+
+```text
+/plugin marketplace add https://github.com/PromptExecution/l3dg3rr
+/plugin install l3dg3rr-plugin-create@promptexecution-tools
+```
+
+Then validate:
+
+```text
+/plugin list
+/plugin show l3dg3rr-plugin-create
+```
+
+In a Cowork task, run:
+
+```text
+tools/list
+tools/call l3dg3rr_context_summary {}
+```
+
+## Organization distribution model
+
+1. Host this marketplace on GitHub (recommended distribution path).
+2. Team admins add it as an approved marketplace.
+3. Users install `l3dg3rr-plugin-create` from the marketplace catalog.
+4. For stricter controls, combine with managed marketplace restrictions in team settings.
+
+## CI publication assist
+
+Use the official Claude Code GitHub Action for PR/issue automation while maintaining this marketplace catalog in-repo:
+
+- Marketplace listing: `https://github.com/marketplace/actions/claude-code-action-official`
+- Keep plugin artifacts versioned and reviewed via PR before publishing updates.
+
+## Notes
+
+- This approach uses Git-hosted marketplace distribution and relative plugin source paths.
+- The MCP server command currently assumes `cargo` availability on the host running Cowork/plugin execution.
+- For container-first environments, replace `mcpServers.l3dg3rr.command` with a docker launcher profile.

--- a/plugins/l3dg3rr-plugin-create/.claude-plugin/plugin.json
+++ b/plugins/l3dg3rr-plugin-create/.claude-plugin/plugin.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://github.com/PromptExecution/l3dg3rr",
   "repository": "https://github.com/PromptExecution/l3dg3rr",
-  "license": "GPL-3.0-only",
+  "license": "MIT",
   "category": "finance",
   "keywords": [
     "cowork",

--- a/plugins/l3dg3rr-plugin-create/.claude-plugin/plugin.json
+++ b/plugins/l3dg3rr-plugin-create/.claude-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "l3dg3rr-plugin-create",
+  "description": "Claude Cowork plugin for l3dg3rr MCP operations and plugin-create acceleration",
+  "version": "1.0.0",
+  "author": {
+    "name": "PromptExecution",
+    "email": "opensource@promptexecution.io"
+  },
+  "homepage": "https://github.com/PromptExecution/l3dg3rr",
+  "repository": "https://github.com/PromptExecution/l3dg3rr",
+  "license": "GPL-3.0-only",
+  "category": "finance",
+  "keywords": [
+    "cowork",
+    "mcp",
+    "plugin-create",
+    "fdkms",
+    "ledger"
+  ],
+  "strict": true,
+  "skills": "./skills",
+  "mcpServers": {
+    "l3dg3rr": {
+      "command": "cargo",
+      "args": [
+        "run",
+        "-p",
+        "turbo-mcp",
+        "--bin",
+        "turbo-mcp-server"
+      ],
+      "env": {
+        "RUST_LOG": "info"
+      }
+    }
+  }
+}

--- a/plugins/l3dg3rr-plugin-create/.claude-plugin/plugin.json
+++ b/plugins/l3dg3rr-plugin-create/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": {
     "name": "PromptExecution",
-    "email": "opensource@promptexecution.io"
+    "email": "brianh@promptexecution.com"
   },
   "homepage": "https://github.com/PromptExecution/l3dg3rr",
   "repository": "https://github.com/PromptExecution/l3dg3rr",
@@ -20,7 +20,7 @@
   "strict": true,
   "skills": "./skills",
   "mcpServers": {
-    "l3dg3rr": {
+    "l3dg3rr-cargo": {
       "command": "cargo",
       "args": [
         "run",
@@ -32,6 +32,41 @@
       "env": {
         "RUST_LOG": "info"
       }
+    },
+    "l3dg3rr-binary": {
+      "command": "./target/release/turbo-mcp-server",
+      "args": [],
+      "env": {
+        "RUST_LOG": "info"
+      }
+    },
+    "l3dg3rr-docker": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-v",
+        ".:/workspace",
+        "-w",
+        "/workspace",
+        "tax-ledger:dev",
+        "cargo",
+        "run",
+        "-p",
+        "turbo-mcp",
+        "--bin",
+        "turbo-mcp-server"
+      ]
+    },
+    "l3dg3rr-python": {
+      "command": "python",
+      "args": [
+        "-m",
+        "l3dg3rr_mcp_launcher",
+        "--mode",
+        "cargo"
+      ]
     }
   }
 }

--- a/plugins/l3dg3rr-plugin-create/python/README.md
+++ b/plugins/l3dg3rr-plugin-create/python/README.md
@@ -1,0 +1,15 @@
+# l3dg3rr-mcp-launcher
+
+Small launcher package for running `turbo-mcp-server` via:
+
+- `cargo`
+- `binary`
+- `docker`
+
+Examples:
+
+```bash
+python -m l3dg3rr_mcp_launcher --mode cargo
+python -m l3dg3rr_mcp_launcher --mode binary --binary ./target/release/turbo-mcp-server
+python -m l3dg3rr_mcp_launcher --mode docker --image tax-ledger:dev
+```

--- a/plugins/l3dg3rr-plugin-create/python/pyproject.toml
+++ b/plugins/l3dg3rr-plugin-create/python/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "l3dg3rr-mcp-launcher"
+version = "0.1.0"
+description = "Launcher for l3dg3rr turbo-mcp server runtime profiles"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [
+  { name = "PromptExecution", email = "brianh@promptexecution.com" }
+]
+license = { text = "GPL-3.0-only" }
+
+[project.scripts]
+l3dg3rr-mcp = "l3dg3rr_mcp_launcher.__main__:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/plugins/l3dg3rr-plugin-create/python/src/l3dg3rr_mcp_launcher/__init__.py
+++ b/plugins/l3dg3rr-plugin-create/python/src/l3dg3rr_mcp_launcher/__init__.py
@@ -1,0 +1,1 @@
+"""l3dg3rr MCP launcher package."""

--- a/plugins/l3dg3rr-plugin-create/python/src/l3dg3rr_mcp_launcher/__main__.py
+++ b/plugins/l3dg3rr-plugin-create/python/src/l3dg3rr_mcp_launcher/__main__.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def build_command(args: argparse.Namespace) -> list[str]:
+    if args.mode == "cargo":
+        return ["cargo", "run", "-p", "turbo-mcp", "--bin", "turbo-mcp-server"]
+    if args.mode == "binary":
+        return [args.binary]
+    if args.mode == "docker":
+        return [
+            "docker",
+            "run",
+            "-i",
+            "--rm",
+            "-v",
+            f"{os.getcwd()}:/workspace",
+            "-w",
+            "/workspace",
+            args.image,
+            "cargo",
+            "run",
+            "-p",
+            "turbo-mcp",
+            "--bin",
+            "turbo-mcp-server",
+        ]
+    raise ValueError(f"unsupported mode: {args.mode}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Launch l3dg3rr turbo-mcp server")
+    parser.add_argument(
+        "--mode",
+        choices=["cargo", "binary", "docker"],
+        default="cargo",
+        help="Runtime profile to launch",
+    )
+    parser.add_argument(
+        "--binary",
+        default="./target/release/turbo-mcp-server",
+        help="Path to compiled server binary when --mode binary",
+    )
+    parser.add_argument(
+        "--image",
+        default="tax-ledger:dev",
+        help="Docker image to use when --mode docker",
+    )
+    args = parser.parse_args()
+
+    cmd = build_command(args)
+    completed = subprocess.run(cmd, check=False)
+    sys.exit(completed.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/l3dg3rr-plugin-create/skills/plugin-create-for-l3dg3rr/SKILL.md
+++ b/plugins/l3dg3rr-plugin-create/skills/plugin-create-for-l3dg3rr/SKILL.md
@@ -2,19 +2,52 @@
 description: Bootstrap and validate l3dg3rr MCP usage in Claude Cowork Plugin Create workflows
 ---
 
-Use this skill to set up and verify `l3dg3rr` MCP access in Cowork:
+Use this skill when setting up or troubleshooting `l3dg3rr` in Claude Cowork Plugin Create.
 
-1. Confirm the plugin is installed from `promptexecution-tools`.
-2. Run `tools/list` and verify `l3dg3rr_*` entries exist.
-3. Run one safe capability call first:
-   - `l3dg3rr_context_summary`
-4. If MCP is unavailable, check:
-   - `cargo` is installed
-   - repository path is correct
-   - `turbo-mcp-server` starts cleanly
+## Install and activate
 
-When extending the plugin:
+1. Add marketplace:
+   - `/plugin marketplace add https://github.com/PromptExecution/l3dg3rr`
+2. Install plugin:
+   - `/plugin install l3dg3rr-plugin-create@promptexecution-fdkms`
+3. Validate install:
+   - `/plugin list`
+   - `/plugin show l3dg3rr-plugin-create`
 
-- Keep responses deterministic and concise for small models.
-- Prefer l3dg3rr service tools over ad-hoc shell parsing of financial data.
-- Preserve permission boundaries and surface explicit blocked diagnostics.
+## MCP runtime choices
+
+- Cargo (default in plugin manifest):
+  - `cargo run -p turbo-mcp --bin turbo-mcp-server`
+- Prebuilt binary:
+  - `./target/release/turbo-mcp-server`
+- Docker:
+  - `docker run -i --rm -v "$PWD:/workspace" -w /workspace tax-ledger:dev cargo run -p turbo-mcp --bin turbo-mcp-server`
+- Python launcher (local package in plugin):
+  - `python -m l3dg3rr_mcp_launcher --mode cargo`
+
+## First-call validation
+
+1. `tools/list` and confirm at least one `l3dg3rr_*` tool appears.
+2. `tools/call l3dg3rr_context_summary {}`.
+3. If available, run one domain call such as `l3dg3rr_ontology_export_snapshot`.
+
+## Start/stop behavior
+
+- In Cowork, MCP process lifecycle is managed by Claude.
+- Manual start is foreground stdio (`cargo run ...`); stop with `Ctrl+C`.
+- Optional helper commands (repo root):
+  - `just mcp-start`
+  - `just mcp-stop`
+
+## Troubleshooting checklist
+
+- Confirm `cargo --version` or selected runtime binary exists.
+- Confirm working directory is repository root.
+- Confirm manifest path: `plugins/l3dg3rr-plugin-create/.claude-plugin/plugin.json`.
+- Run MCP regression: `./scripts/mcp_e2e.sh`.
+
+## Quality bar
+
+- Keep outputs deterministic, concise, and machine-readable.
+- Do not bypass l3dg3rr capability boundaries with ad-hoc file parsing.
+- Preserve explicit blocked diagnostics for permission or invariant failures.

--- a/plugins/l3dg3rr-plugin-create/skills/plugin-create-for-l3dg3rr/SKILL.md
+++ b/plugins/l3dg3rr-plugin-create/skills/plugin-create-for-l3dg3rr/SKILL.md
@@ -1,0 +1,20 @@
+---
+description: Bootstrap and validate l3dg3rr MCP usage in Claude Cowork Plugin Create workflows
+---
+
+Use this skill to set up and verify `l3dg3rr` MCP access in Cowork:
+
+1. Confirm the plugin is installed from `promptexecution-tools`.
+2. Run `tools/list` and verify `l3dg3rr_*` entries exist.
+3. Run one safe capability call first:
+   - `l3dg3rr_context_summary`
+4. If MCP is unavailable, check:
+   - `cargo` is installed
+   - repository path is correct
+   - `turbo-mcp-server` starts cleanly
+
+When extending the plugin:
+
+- Keep responses deterministic and concise for small models.
+- Prefer l3dg3rr service tools over ad-hoc shell parsing of financial data.
+- Preserve permission boundaries and surface explicit blocked diagnostics.


### PR DESCRIPTION
## Summary
- add Claude marketplace catalog at .claude-plugin/marketplace.json
- add l3dg3rr-plugin-create plugin manifest with turbo-mcp mcpServers wiring
- add plugin skill scaffold for Plugin Create workflows
- document Cowork install/distribution approach and validation commands
- link marketplace approach from README

## References
- https://code.claude.com/docs/en/plugin-marketplaces
- https://support.claude.com/en/articles/13837440-use-plugins-in-cowork
- https://github.com/marketplace/actions/claude-code-action-official