### PR TITLE
feat(mcp): expose accounts/raw-context tools and publish capability contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ For product scope and status, read `README.md` first, then use this file for exe
 ### MCP Capability Training (Concrete)
 
 Use `TurboLedgerService` in `crates/turbo-mcp/src/lib.rs` as the canonical contract.
+Use `docs/mcp-capability-contract.md` as the canonical MCP surface map (tool names, arg contracts, service mapping, contrived usage flow).
 
 Core methods:
 - `list_accounts` / `list_accounts_tool`: enumerate account ids from manifest.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Rust workspace for a local-first, Excel-first tax ledger system.
 ## Agent Guide
 
 See [AGENTS.md](AGENTS.md) for agent-facing purpose, capability boundaries, operating expectations, and persistent session-learning rules.
+See [docs/mcp-capability-contract.md](docs/mcp-capability-contract.md) for the concrete MCP tool matrix, API relationships, and contrived end-to-end usage.
 
 ## Current scope
 

--- a/crates/turbo-mcp/src/bin/turbo-mcp-server.rs
+++ b/crates/turbo-mcp/src/bin/turbo-mcp-server.rs
@@ -60,6 +60,7 @@ fn handle_request(request: Value) -> Option<Value> {
             let params = request.get("params").cloned().unwrap_or(Value::Null);
             let tool_name = params.get("name").and_then(Value::as_str).unwrap_or("");
             let result = match tool_name {
+                mcp_adapter::LIST_ACCOUNTS_TOOL => mcp_adapter::list_accounts_tool_result(global_service()),
                 "l3dg3rr_get_pipeline_status" => {
                     let status = mcp_adapter::get_pipeline_status(true, true, true, Vec::new());
                     json!({
@@ -85,6 +86,10 @@ fn handle_request(request: Value) -> Option<Value> {
                         &arguments,
                         Some(format!("mcp-call-{id}")),
                     )
+                }
+                mcp_adapter::GET_RAW_CONTEXT_TOOL => {
+                    let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+                    mcp_adapter::get_raw_context_tool_result(global_service(), &arguments)
                 }
                 mcp_adapter::ONTOLOGY_QUERY_PATH_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
@@ -141,7 +146,7 @@ fn handle_request(request: Value) -> Option<Value> {
 fn global_service() -> &'static TurboLedgerService {
     static SERVICE: OnceLock<TurboLedgerService> = OnceLock::new();
     SERVICE.get_or_init(|| {
-        let manifest = "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n";
+        let manifest = "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n\n[accounts]\nWF-BH-CHK = { institution = \"Wells Fargo\", type = \"checking\", currency = \"USD\" }\n";
         TurboLedgerService::from_manifest_str(manifest).expect("default manifest must parse")
     })
 }

--- a/crates/turbo-mcp/src/lib.rs
+++ b/crates/turbo-mcp/src/lib.rs
@@ -960,7 +960,31 @@ impl TurboLedgerTools for TurboLedgerService {
         &self,
         request: GetRawContextRequest,
     ) -> Result<GetRawContextResponse, ToolError> {
-        let bytes = std::fs::read(&request.rkyv_ref).map_err(|e| ToolError::Internal(e.to_string()))?;
+        let allowed_base = self.workbook_path()
+            .parent()
+            .ok_or_else(|| ToolError::InvalidInput("workbook_path must have a parent directory".to_string()))?
+            .to_path_buf();
+
+        let rkyv_path = &request.rkyv_ref;
+        if rkyv_path.components().any(|c| c == std::path::Component::ParentDir) {
+            return Err(ToolError::InvalidInput(format!(
+                "rkyv_ref '{}' contains path traversal components",
+                rkyv_path.display()
+            )));
+        }
+        let resolved = if rkyv_path.is_absolute() {
+            if !rkyv_path.starts_with(&allowed_base) {
+                return Err(ToolError::InvalidInput(format!(
+                    "rkyv_ref '{}' resolves outside the allowed directory",
+                    rkyv_path.display()
+                )));
+            }
+            rkyv_path.to_path_buf()
+        } else {
+            allowed_base.join(rkyv_path)
+        };
+
+        let bytes = std::fs::read(&resolved).map_err(|e| ToolError::Internal(e.to_string()))?;
         Ok(GetRawContextResponse { bytes })
     }
 

--- a/crates/turbo-mcp/src/mcp_adapter.rs
+++ b/crates/turbo-mcp/src/mcp_adapter.rs
@@ -5,12 +5,14 @@ use serde::Serialize;
 use serde_json::{json, Value};
 
 use crate::{
-    EventHistoryFilter, HsmResumeRequest, HsmStatusRequest, HsmTransitionRequest, IngestPdfRequest,
-    IngestStatementRowsRequest, OntologyQueryPathRequest, OntologyStore, ReconciliationStageRequest,
-    ReplayLifecycleRequest, TaxAmbiguityReviewRequest, TaxAssistRequest, TaxEvidenceChainRequest,
-    ToolError, TurboLedgerService, TurboLedgerTools,
+    EventHistoryFilter, GetRawContextRequest, HsmResumeRequest, HsmStatusRequest, HsmTransitionRequest,
+    IngestPdfRequest, IngestStatementRowsRequest, ListAccountsRequest, OntologyQueryPathRequest,
+    OntologyStore, ReconciliationStageRequest, ReplayLifecycleRequest, TaxAmbiguityReviewRequest,
+    TaxAssistRequest, TaxEvidenceChainRequest, ToolError, TurboLedgerService, TurboLedgerTools,
 };
 
+pub const LIST_ACCOUNTS_TOOL: &str = "l3dg3rr_list_accounts";
+pub const GET_RAW_CONTEXT_TOOL: &str = "l3dg3rr_get_raw_context";
 pub const ONTOLOGY_QUERY_PATH_TOOL: &str = "l3dg3rr_ontology_query_path";
 pub const ONTOLOGY_EXPORT_SNAPSHOT_TOOL: &str = "l3dg3rr_ontology_export_snapshot";
 pub const RECON_VALIDATE_TOOL: &str = "l3dg3rr_validate_reconciliation";
@@ -29,6 +31,8 @@ pub const MCP_LIFECYCLE_METHODS: &[&str] = &["initialize", "tools/list", "tools/
 
 pub fn tool_catalog() -> Vec<String> {
     vec![
+        LIST_ACCOUNTS_TOOL.to_string(),
+        GET_RAW_CONTEXT_TOOL.to_string(),
         "proxy_docling_ingest_pdf".to_string(),
         "proxy_rustledger_ingest_statement_rows".to_string(),
         "l3dg3rr_get_pipeline_status".to_string(),
@@ -48,6 +52,64 @@ pub fn tool_catalog() -> Vec<String> {
         "tools/list".to_string(),
         "tools/call".to_string(),
     ]
+}
+
+pub fn list_accounts_tool_result(service: &TurboLedgerService) -> Value {
+    match service.list_accounts_tool(ListAccountsRequest) {
+        Ok(response) => {
+            let accounts = response
+                .accounts
+                .into_iter()
+                .map(|account| json!({ "account_id": account.account_id }))
+                .collect::<Vec<_>>();
+            json!({
+                "content": [{
+                    "type": "json",
+                    "json": { "accounts": accounts }
+                }],
+                "isError": false
+            })
+        }
+        Err(err) => json!({
+            "content": [{
+                "type": "json",
+                "json": map_tool_error(&err)
+            }],
+            "isError": true
+        }),
+    }
+}
+
+pub fn get_raw_context_tool_result(service: &TurboLedgerService, arguments: &Value) -> Value {
+    let request = match parse_get_raw_context_request(arguments) {
+        Ok(request) => request,
+        Err(err) => {
+            return json!({
+                "content": [{
+                    "type": "json",
+                    "json": map_tool_error(&err)
+                }],
+                "isError": true
+            });
+        }
+    };
+
+    match service.get_raw_context(request) {
+        Ok(response) => json!({
+            "content": [{
+                "type": "json",
+                "json": { "bytes": response.bytes }
+            }],
+            "isError": false
+        }),
+        Err(err) => json!({
+            "content": [{
+                "type": "json",
+                "json": map_tool_error(&err)
+            }],
+            "isError": true
+        }),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -897,6 +959,12 @@ fn required_str<'a>(obj: &'a Value, key: &str) -> Result<&'a str, ToolError> {
 
 fn parse_ontology_path(arguments: &Value) -> Result<PathBuf, ToolError> {
     Ok(PathBuf::from(required_str(arguments, "ontology_path")?))
+}
+
+fn parse_get_raw_context_request(arguments: &Value) -> Result<GetRawContextRequest, ToolError> {
+    Ok(GetRawContextRequest {
+        rkyv_ref: PathBuf::from(required_str(arguments, "rkyv_ref")?),
+    })
 }
 
 fn parse_ontology_query_path_request(arguments: &Value) -> Result<OntologyQueryPathRequest, ToolError> {

--- a/crates/turbo-mcp/tests/mcp_adapter_contract.rs
+++ b/crates/turbo-mcp/tests/mcp_adapter_contract.rs
@@ -7,6 +7,8 @@ fn doc_01_mcp_boundary_tool_catalog_exposes_passthrough_proxy_surface() {
 
     assert!(tools.contains(&"proxy_rustledger_ingest_statement_rows".to_string()));
     assert!(tools.contains(&"proxy_docling_ingest_pdf".to_string()));
+    assert!(tools.contains(&"l3dg3rr_list_accounts".to_string()));
+    assert!(tools.contains(&"l3dg3rr_get_raw_context".to_string()));
     assert!(tools.contains(&"l3dg3rr_get_pipeline_status".to_string()));
     assert!(tools.contains(&"tools/list".to_string()));
     assert!(tools.contains(&"tools/call".to_string()));

--- a/crates/turbo-mcp/tests/mcp_stdio_e2e.rs
+++ b/crates/turbo-mcp/tests/mcp_stdio_e2e.rs
@@ -275,3 +275,63 @@ fn rustledger_proxy_ingest_statement_rows_over_transport() {
     assert!(canonical.get("backend_version").is_some());
     assert!(canonical.get("backend_call_id").is_some());
 }
+
+#[test]
+fn mcp_lists_and_calls_accounts_and_raw_context_tools() {
+    let mut client = McpStdioClient::spawn();
+    initialize_client(&mut client);
+
+    let tools = client.request("tools/list", json!({}));
+    let tool_names = tools["result"]["tools"]
+        .as_array()
+        .expect("tools list")
+        .iter()
+        .filter_map(|entry| entry.get("name").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+    assert!(tool_names.contains(&"l3dg3rr_list_accounts"));
+    assert!(tool_names.contains(&"l3dg3rr_get_raw_context"));
+
+    let list_accounts = client.request(
+        "tools/call",
+        json!({
+            "name": "l3dg3rr_list_accounts",
+            "arguments": {}
+        }),
+    );
+    assert_eq!(list_accounts["result"]["isError"], Value::Bool(false));
+    let accounts = list_accounts["result"]["content"][0]["json"]["accounts"]
+        .as_array()
+        .expect("accounts array");
+    assert!(!accounts.is_empty());
+    assert!(accounts
+        .iter()
+        .any(|entry| entry["account_id"] == json!("WF-BH-CHK")));
+
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let ingest_args = build_ingest_arguments(tempdir.path());
+    let source_ref = ingest_args["extracted_rows"][0]["source_ref"]
+        .as_str()
+        .expect("source_ref")
+        .to_string();
+    let ingest = client.request(
+        "tools/call",
+        json!({
+            "name": "proxy_docling_ingest_pdf",
+            "arguments": ingest_args
+        }),
+    );
+    assert_eq!(ingest["result"]["isError"], Value::Bool(false));
+
+    let raw_context = client.request(
+        "tools/call",
+        json!({
+            "name": "l3dg3rr_get_raw_context",
+            "arguments": { "rkyv_ref": source_ref }
+        }),
+    );
+    assert_eq!(raw_context["result"]["isError"], Value::Bool(false));
+    assert_eq!(
+        raw_context["result"]["content"][0]["json"]["bytes"],
+        json!([99, 116, 120])
+    );
+}

--- a/docs/mcp-capability-contract.md
+++ b/docs/mcp-capability-contract.md
@@ -38,16 +38,16 @@ MCP boundary:
 | `l3dg3rr_tax_ambiguity_review` | ambiguity review queue payload | `ontology_path`, `from_entity_id`, `reconciliation` | `tax_ambiguity_review_tool` |
 
 Input parsing and validation live in:
-[crates/turbo-mcp/src/mcp_adapter.rs](/home/brianh/promptexecution/mbse/l3dg3rr/crates/turbo-mcp/src/mcp_adapter.rs:160)
+[crates/turbo-mcp/src/mcp_adapter.rs](crates/turbo-mcp/src/mcp_adapter.rs#L160)
 
 ## 2) Internal Rust Service API (Wider Than MCP)
 
 Canonical trait:
-[TurboLedgerTools in crates/turbo-mcp/src/lib.rs](/home/brianh/promptexecution/mbse/l3dg3rr/crates/turbo-mcp/src/lib.rs:275)
+[TurboLedgerTools in crates/turbo-mcp/src/lib.rs](crates/turbo-mcp/src/lib.rs#L275)
 
 Important distinction:
 - Some service capabilities exist but are not exposed as MCP tools yet.
-- Examples currently service-only: `list_accounts`, `get_raw_context`, `run_rhai_rule`, `classify_ingested`, `query_flags`, `classify_transaction`, `query_audit_log`, `export_cpa_workbook`, `get_schedule_summary`, ontology upserts.
+- Examples currently service-only: `run_rhai_rule`, `classify_ingested`, `query_flags`, `classify_transaction`, `query_audit_log`, `export_cpa_workbook`, `get_schedule_summary`, ontology upserts.
 
 This is the current API layering:
 1. `turbo-mcp-server` (stdio transport)
@@ -58,14 +58,14 @@ This is the current API layering:
 ## 3) CLI / Runtime Entry Points
 
 Operational CLI helpers are lifecycle-oriented, not business-domain verbs:
-- [Justfile](/home/brianh/promptexecution/mbse/l3dg3rr/Justfile:3)
+- [Justfile](Justfile#L3)
   - `just mcp-build`
   - `just mcp-start`
   - `just mcp-start-release`
   - `just mcp-stop`
   - `just mcp-e2e`
 - Python launcher:
-  [plugins/l3dg3rr-plugin-create/python/src/l3dg3rr_mcp_launcher/__main__.py](/home/brianh/promptexecution/mbse/l3dg3rr/plugins/l3dg3rr-plugin-create/python/src/l3dg3rr_mcp_launcher/__main__.py:35)
+  [plugins/l3dg3rr-plugin-create/python/src/l3dg3rr_mcp_launcher/__main__.py](plugins/l3dg3rr-plugin-create/python/src/l3dg3rr_mcp_launcher/__main__.py#L35)
   - `--mode cargo|binary|docker`
 
 ## 4) Functional Relationships (Contrived Sample)

--- a/docs/mcp-capability-contract.md
+++ b/docs/mcp-capability-contract.md
@@ -11,8 +11,8 @@ It is intentionally concrete and code-aligned.
 
 MCP boundary:
 - Methods: `initialize`, `tools/list`, `tools/call`
-- Server: [crates/turbo-mcp/src/bin/turbo-mcp-server.rs](/home/brianh/promptexecution/mbse/l3dg3rr/crates/turbo-mcp/src/bin/turbo-mcp-server.rs:8)
-- Tool catalog: [crates/turbo-mcp/src/mcp_adapter.rs](/home/brianh/promptexecution/mbse/l3dg3rr/crates/turbo-mcp/src/mcp_adapter.rs:30)
+- Server: [crates/turbo-mcp/src/bin/turbo-mcp-server.rs](crates/turbo-mcp/src/bin/turbo-mcp-server.rs#L8)
+- Tool catalog: [crates/turbo-mcp/src/mcp_adapter.rs](crates/turbo-mcp/src/mcp_adapter.rs#L30)
 
 ### Tool Matrix
 

--- a/docs/mcp-capability-contract.md
+++ b/docs/mcp-capability-contract.md
@@ -1,0 +1,183 @@
+# MCP Capability Contract (Operator View)
+
+This document describes what is currently exposed through:
+- MCP transport (`turbo-mcp-server`)
+- local CLI/runtime entrypoints (`Justfile`, Python launcher)
+- internal Rust service API (`TurboLedgerTools`)
+
+It is intentionally concrete and code-aligned.
+
+## 1) MCP Surface (What an Agent Can Call)
+
+MCP boundary:
+- Methods: `initialize`, `tools/list`, `tools/call`
+- Server: [crates/turbo-mcp/src/bin/turbo-mcp-server.rs](/home/brianh/promptexecution/mbse/l3dg3rr/crates/turbo-mcp/src/bin/turbo-mcp-server.rs:8)
+- Tool catalog: [crates/turbo-mcp/src/mcp_adapter.rs](/home/brianh/promptexecution/mbse/l3dg3rr/crates/turbo-mcp/src/mcp_adapter.rs:30)
+
+### Tool Matrix
+
+| MCP tool name | Primary purpose | Required arguments | Backing service/API |
+|---|---|---|---|
+| `l3dg3rr_list_accounts` | enumerate manifest account ids for tool planning and routing | none | `TurboLedgerService::list_accounts_tool` |
+| `l3dg3rr_get_raw_context` | fetch stored raw context bytes by reference path | `rkyv_ref` | `TurboLedgerTools::get_raw_context` |
+| `l3dg3rr_get_pipeline_status` | readiness hint for workflow start | none | `get_pipeline_status` adapter helper |
+| `proxy_docling_ingest_pdf` | ingest rows extracted from PDF, persist raw bytes fallback, emit canonical rows + tx ids | `pdf_path`, `journal_path`, `workbook_path`, `extracted_rows` | `TurboLedgerTools::ingest_pdf` |
+| `proxy_rustledger_ingest_statement_rows` | ingest normalized rows through rustledger-compatible path | `journal_path`, `workbook_path`, `rows` | `TurboLedgerTools::ingest_statement_rows` |
+| `l3dg3rr_ontology_query_path` | query ontology path traversal | `ontology_path`, `from_entity_id` | `TurboLedgerService::ontology_query_path_tool` |
+| `l3dg3rr_ontology_export_snapshot` | export deterministic ontology snapshot | `ontology_path` | `OntologyStore::load` + snapshot |
+| `l3dg3rr_validate_reconciliation` | validation stage checks | `source_total`, `extracted_total`, `posting_amounts` | `validate_stage` |
+| `l3dg3rr_reconcile_postings` | reconcile stage checks | `source_total`, `extracted_total`, `posting_amounts` | `reconcile_stage` |
+| `l3dg3rr_commit_guarded` | commit gate for balanced/ready stage | `source_total`, `extracted_total`, `posting_amounts` | `commit_stage` |
+| `l3dg3rr_hsm_transition` | deterministic lifecycle transition | `target_state`, `target_substate` | `hsm_transition_tool` |
+| `l3dg3rr_hsm_status` | current state + concise hints | none | `hsm_status_tool` |
+| `l3dg3rr_hsm_resume` | resume from checkpoint marker | `state_marker` | `hsm_resume_tool` |
+| `l3dg3rr_event_history` | filtered append-only event query | optional `tx_id`, `document_ref`, `time_start`, `time_end` | `event_history` |
+| `l3dg3rr_event_replay` | reconstruct lifecycle state from events | optional `tx_id`, `document_ref` | `replay_lifecycle` |
+| `l3dg3rr_tax_assist` | tax summary/schedule guidance gated by reconciliation | `ontology_path`, `from_entity_id`, `reconciliation` | `tax_assist_tool` |
+| `l3dg3rr_tax_evidence_chain` | source->events->current_state chain | `ontology_path`, `from_entity_id` | `tax_evidence_chain_tool` |
+| `l3dg3rr_tax_ambiguity_review` | ambiguity review queue payload | `ontology_path`, `from_entity_id`, `reconciliation` | `tax_ambiguity_review_tool` |
+
+Input parsing and validation live in:
+[crates/turbo-mcp/src/mcp_adapter.rs](/home/brianh/promptexecution/mbse/l3dg3rr/crates/turbo-mcp/src/mcp_adapter.rs:160)
+
+## 2) Internal Rust Service API (Wider Than MCP)
+
+Canonical trait:
+[TurboLedgerTools in crates/turbo-mcp/src/lib.rs](/home/brianh/promptexecution/mbse/l3dg3rr/crates/turbo-mcp/src/lib.rs:275)
+
+Important distinction:
+- Some service capabilities exist but are not exposed as MCP tools yet.
+- Examples currently service-only: `list_accounts`, `get_raw_context`, `run_rhai_rule`, `classify_ingested`, `query_flags`, `classify_transaction`, `query_audit_log`, `export_cpa_workbook`, `get_schedule_summary`, ontology upserts.
+
+This is the current API layering:
+1. `turbo-mcp-server` (stdio transport)
+2. `mcp_adapter` (argument parsing + envelope shaping)
+3. `TurboLedgerService` (domain logic, guardrails, state/event/HSM ops)
+4. `ledger-core` (ingest, filename validation, classification primitives)
+
+## 3) CLI / Runtime Entry Points
+
+Operational CLI helpers are lifecycle-oriented, not business-domain verbs:
+- [Justfile](/home/brianh/promptexecution/mbse/l3dg3rr/Justfile:3)
+  - `just mcp-build`
+  - `just mcp-start`
+  - `just mcp-start-release`
+  - `just mcp-stop`
+  - `just mcp-e2e`
+- Python launcher:
+  [plugins/l3dg3rr-plugin-create/python/src/l3dg3rr_mcp_launcher/__main__.py](/home/brianh/promptexecution/mbse/l3dg3rr/plugins/l3dg3rr-plugin-create/python/src/l3dg3rr_mcp_launcher/__main__.py:35)
+  - `--mode cargo|binary|docker`
+
+## 4) Functional Relationships (Contrived Sample)
+
+Scenario: an MCP client ingests one synthetic statement row, validates reconciliation, checks lifecycle state, then asks for tax evidence.
+
+### Step A: initialize and discover tools
+```json
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"demo","version":"0.1.0"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+```
+
+### Step B: ingest a row through rustledger proxy
+```json
+{
+  "jsonrpc":"2.0",
+  "id":3,
+  "method":"tools/call",
+  "params":{
+    "name":"proxy_rustledger_ingest_statement_rows",
+    "arguments":{
+      "journal_path":"/tmp/demo.beancount",
+      "workbook_path":"/tmp/demo.xlsx",
+      "rows":[
+        {
+          "account_id":"WF-BH-CHK",
+          "date":"2023-01-05",
+          "amount":"-42.50",
+          "description":"Coffee Beans",
+          "source_ref":"/tmp/raw/wf-2023-01.rkyv"
+        }
+      ]
+    }
+  }
+}
+```
+
+Relationship here:
+- MCP tool -> adapter normalization/provenance (`provider=rustledger`) ->
+  `TurboLedgerService::ingest_statement_rows` ->
+  `ledger-core` ingest/idempotency.
+
+### Step C: run reconciliation gate
+```json
+{
+  "jsonrpc":"2.0",
+  "id":4,
+  "method":"tools/call",
+  "params":{
+    "name":"l3dg3rr_commit_guarded",
+    "arguments":{
+      "source_total":"42.50",
+      "extracted_total":"42.50",
+      "posting_amounts":["-42.50","42.50"]
+    }
+  }
+}
+```
+
+Relationship here:
+- Reconciliation status gates downstream tax-oriented operations.
+- Blocked states return deterministic `isError` envelopes with typed reasons.
+
+### Step D: inspect HSM status and event replay
+```json
+{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"l3dg3rr_hsm_status","arguments":{}}}
+{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"l3dg3rr_event_replay","arguments":{"document_ref":"/tmp/raw/wf-2023-01.rkyv"}}}
+```
+
+Relationship here:
+- HSM provides concise lifecycle hints for small-model agent orchestration.
+- Event replay reconstructs deterministically computable lifecycle state from append-only history.
+
+### Step E: ask for tax evidence chain
+```json
+{
+  "jsonrpc":"2.0",
+  "id":7,
+  "method":"tools/call",
+  "params":{
+    "name":"l3dg3rr_tax_evidence_chain",
+    "arguments":{
+      "ontology_path":"/tmp/ontology.json",
+      "from_entity_id":"WF-BH-CHK",
+      "document_ref":"/tmp/raw/wf-2023-01.rkyv"
+    }
+  }
+}
+```
+
+Relationship here:
+- Ontology path + event history + replay projection are merged into one evidence payload:
+  `source -> events -> current_state (+ ambiguity)`.
+
+## 5) Practical Gaps To Keep In Mind
+
+1. Classification/audit/schedule methods are implemented in service API but not yet surfaced over MCP.
+2. Ontology upsert methods exist in service API but are not MCP-exposed (`ontology_upsert_entities_tool`, `ontology_upsert_edges_tool`).
+3. CLI is mostly runtime/start-stop orchestration; domain operations are MCP-first.
+
+## 6) Proposal: Next MCP Exposure Gaps (Mission-Aligned)
+
+The following are high-value MCP additions for an AI-first financial document knowledge workflow.
+
+| Priority | Proposed MCP tool | Existing backend method | Why it matters |
+|---|---|---|---|
+| P0 | `l3dg3rr_classify_ingested` | `classify_ingested` | turns ingestion output into review-queue-ready classifications without direct code execution |
+| P0 | `l3dg3rr_query_flags` | `query_flags` | gives agents deterministic open/resolved review queues by year |
+| P0 | `l3dg3rr_query_audit_log` | `query_audit_log` | provides explainability and mutation trace required for CPA/agent trust |
+| P1 | `l3dg3rr_classify_transaction` | `classify_transaction` | lets agents apply explicit corrections through guarded, auditable mutations |
+| P1 | `l3dg3rr_reconcile_excel_classification` | `reconcile_excel_classification` | syncs manual Excel edits back into deterministic audit/event chain |
+| P1 | `l3dg3rr_get_schedule_summary` | `get_schedule_summary` | provides compact tax summary materialization for downstream tax-agent orchestration |
+| P2 | `l3dg3rr_export_cpa_workbook` | `export_cpa_workbook` | gives a single MCP-triggered handoff artifact for CPA review cycles |
+| P2 | `l3dg3rr_ontology_upsert_entities` / `l3dg3rr_ontology_upsert_edges` | `ontology_upsert_entities_tool` / `ontology_upsert_edges_tool` | enables agent-driven ontology curation instead of read-only graph usage |


### PR DESCRIPTION
- [x] Fix absolute local filesystem paths in docs/mcp-capability-contract.md to repo-relative links (lines 14-15, 47, 54, 60-69)
- [x] Remove `list_accounts` and `get_raw_context` from the service-only examples list (they are now MCP-exposed)
- [x] Add path traversal / allowed-base validation to `TurboLedgerService::get_raw_context` in lib.rs (security fix matching ingest_pdf pattern)
- [x] Deduplicate `..`-component check by hoisting it before the absolute/relative branch
- [x] All turbo-mcp tests pass