### PR TITLE
fix(devops): clear QA backlog — MCP spec, CI wiring, Dockerfile, deps, docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,8 +69,8 @@ jobs:
       - name: Wait for crates.io index propagation
         run: sleep 20
 
-      - name: Publish turbo-mcp
-        run: cargo publish -p turbo-mcp --token "${CRATES_IO_TOKEN}"
+      - name: Publish ledgerr-mcp
+        run: cargo publish -p ledgerr-mcp --token "${CRATES_IO_TOKEN}"
         env:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["CI with MCP Registry Publish"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "atoi_simd"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ad17c7c205c2c28b527b9845eeb91cf1b4d008b438f98ce0e628227a822758e"
+dependencies = [
+ "debug_unsafe",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,17 +262,19 @@ dependencies = [
 
 [[package]]
 name = "calamine"
-version = "0.26.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138646b9af2c5d7f1804ea4bf93afc597737d2bd4f7341d67c48b03316976eb1"
+checksum = "20ae05a4e39297eecf9a994210d27501318c37a9318201f8e11050add82bb6f0"
 dependencies = [
+ "atoi_simd",
  "byteorder",
  "codepage",
  "encoding_rs",
+ "fast-float2",
  "log",
  "quick-xml",
  "serde",
- "zip 2.4.2",
+ "zip 7.2.0",
 ]
 
 [[package]]
@@ -443,6 +454,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
+
+[[package]]
 name = "deflate64"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +531,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
@@ -718,7 +741,7 @@ dependencies = [
  "rust_xlsxwriter",
  "serde",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror",
  "toml",
 ]
 
@@ -734,7 +757,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -909,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "encoding_rs",
  "memchr",
@@ -1273,31 +1296,11 @@ checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1724,7 +1727,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror",
  "zip 2.4.2",
 ]
 
@@ -1799,7 +1802,7 @@ dependencies = [
  "memchr",
  "pbkdf2",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "xz2",
  "zeroize",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,36 @@
 # syntax=docker/dockerfile:1.7
 
-FROM rust:1-bookworm AS builder
+# ── dependency cache layer (cargo-chef) ──────────────────────────────────────
+FROM rust:1-bookworm AS chef
+RUN cargo install cargo-chef --locked
 WORKDIR /app
+
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
+COPY xtask ./xtask
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ── build ─────────────────────────────────────────────────────────────────────
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 COPY xtask ./xtask
 
-RUN cargo test --workspace
+RUN cargo test --workspace --all-features
+RUN cargo build -p ledgerr-mcp --release --bin ledgerr-mcp-server
 
+# ── runtime ───────────────────────────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
-COPY --from=builder /app /app
+COPY --from=builder /app/target/release/ledgerr-mcp-server /usr/local/bin/ledgerr-mcp-server
 
-CMD ["/bin/bash", "-lc", "cargo test --workspace && echo 'tax-ledger workspace ready' "]
+ENV LEDGER_WORKBOOK_PATH=/data/tax-ledger.xlsx
+ENV LEDGER_PDF_INBOX=/data/inbox
+
+CMD ["/usr/local/bin/ledgerr-mcp-server"]

--- a/Justfile
+++ b/Justfile
@@ -13,6 +13,21 @@ mcp-start-release:
 mcp-stop:
     pkill -f ledgerr-mcp-server || true
 
+# Pull and run the MCP server from GHCR using podman (stdio transport)
+# Usage: just mcp-podman-run        — latest image on main
+#        just mcp-podman-run v0.2.0 — specific release tag
+mcp-podman-run tag="main":
+    @command -v podman >/dev/null || { echo "error: podman not found — install podman first"; exit 1; }
+    podman pull ghcr.io/promptexecution/l3dg3rr:{{tag}}
+    podman run --rm -i \
+      -v "${LEDGER_DATA_DIR:-$PWD/data}:/data" \
+      ghcr.io/promptexecution/l3dg3rr:{{tag}}
+
+# Verify the GHCR image exists for a given tag without pulling the full image
+mcp-podman-verify tag="main":
+    @command -v podman >/dev/null || { echo "error: podman not found"; exit 1; }
+    podman manifest inspect ghcr.io/promptexecution/l3dg3rr:{{tag}}
+
 mcp-e2e:
     ./scripts/mcp_e2e.sh
 
@@ -28,7 +43,8 @@ mcp-doc-demo:
     ./scripts/mcp_e2e.sh
 
 test:
-    cargo build -p ledgerr-mcp --bin ledgerr-mcp-server --bin mcp-outcome-test
+    cargo test --workspace --all-targets --all-features
+    cargo build -p ledgerr-mcp --bin mcp-outcome-test
     ./target/debug/mcp-outcome-test
 
 gh-secrets-help:
@@ -163,22 +179,22 @@ release version="patch":
     cargo test --workspace --all-targets --all-features
     ./scripts/e2e_mvp.sh
     echo "Bumping {{version}} version with cocogitto..."
-    /home/wendy/.cargo/bin/cog bump {{version}}
-    /home/wendy/.cargo/bin/cog changelog
+    cog bump {{version}}
+    cog changelog
     echo "Pushing tags..."
     git push --follow-tags
 
 # Show current version
 v:
-    @/home/wendy/.cargo/bin/cog get-version
+    @cog get-version
 
 # Validate commits
 validate:
-    @/home/wendy/.cargo/bin/cog check
+    @cog check
 
 # Show changelog
 changelog:
-    @/home/wendy/.cargo/bin/cog changelog
+    @cog changelog
 
 # Show release stats
 stats:

--- a/README.md
+++ b/README.md
@@ -18,20 +18,40 @@ See [docs/mcp-capability-contract.md](docs/mcp-capability-contract.md) for the c
 - Git-friendly plain-text ingest output via Beancount journal entries (rustledger-compatible)
 - Idiomatic turbo MCP interface surface for `list_accounts` and `ingest_statement_rows`
 
+## Prerequisites
+
+| Tool | Install | Purpose |
+|------|---------|---------|
+| Rust 1.88+ | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh` | Build toolchain |
+| [just](https://github.com/casey/just) | `cargo install just` | Task runner (all `just *` recipes) |
+| [cocogitto](https://docs.cocogitto.io/) | `cargo install cocogitto` | Conventional commits + version bumps |
+| [cross](https://github.com/cross-rs/cross) | `cargo install cross --locked` | Cross-compilation for musl/macOS release bundles |
+| [mcp-publisher](https://github.com/modelcontextprotocol/registry) | See registry releases | MCP Registry submission (`just publish-registry`) |
+
+Optional: Docker or Podman for container builds.
+
 ## Quickstart
 
 ```bash
-cargo test
+# Run the full test suite
+cargo test --workspace --all-features
+
+# Or via just (also runs mcp-outcome-test)
+just test
+
+# Start the MCP server (stdio transport)
+just mcp-start
 ```
 
 ## Docker
 
+The container runs the `ledgerr-mcp-server` binary (stdio MCP transport).
+Mount `/data` for the workbook and PDF inbox.
+
 ```bash
 docker build -t tax-ledger:dev .
-docker run --rm \
+docker run --rm -i \
   -v "$PWD/data:/data" \
-  -v "$PWD/rules:/rules" \
-  -v "$PWD/tax-years:/tax-years" \
   tax-ledger:dev
 ```
 
@@ -67,5 +87,5 @@ This validates the full ingest -> classify -> audit -> schedule summary flow.
 - Trigger: GitHub Release `published` (or manual `workflow_dispatch`)
 - Targets:
   - GHCR image: `ghcr.io/promptexecution/l3dg3rr`
-  - crates.io crates: `ledger-core`, `turbo-mcp` (requires `CRATES_IO_TOKEN`)
+  - crates.io crates: `ledger-core`, `ledgerr-mcp` (requires `CRATES_IO_TOKEN`)
   - PyPI package: `l3dg3rr-mcp-launcher` (requires `PYPI_API_TOKEN`)

--- a/crates/ledger-core/Cargo.toml
+++ b/crates/ledger-core/Cargo.toml
@@ -8,8 +8,8 @@ license.workspace = true
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 rust_xlsxwriter = { workspace = true }
-calamine = "0.26"
-thiserror = "1"
+calamine = "0.34"
+thiserror = "2"
 blake3 = "1"
 rhai = "1.24.0"
 

--- a/crates/ledgerr-mcp/Cargo.toml
+++ b/crates/ledgerr-mcp/Cargo.toml
@@ -11,7 +11,7 @@ rust_decimal = "1.41.0"
 rust_xlsxwriter = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "1"
+thiserror = "2"
 
 [features]
 default = ["core", "events", "reconciliation", "hsm", "ontology", "classification", "audit", "tax"]
@@ -27,7 +27,7 @@ full = ["core", "events", "reconciliation", "hsm", "ontology", "classification",
 
 [dev-dependencies]
 tempfile = "3"
-calamine = "0.26"
+calamine = "0.34"
 
 [lints]
 workspace = true

--- a/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs
+++ b/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs
@@ -46,10 +46,7 @@ fn handle_request(request: Value) -> Option<Value> {
         })),
         "notifications/initialized" => None,
         "tools/list" => {
-            let tools: Vec<Value> = mcp_adapter::tool_catalog()
-                .into_iter()
-                .map(|name| json!({ "name": name }))
-                .collect();
+            let tools = mcp_adapter::tool_list_entries();
             Some(json!({
                 "jsonrpc": "2.0",
                 "id": id,

--- a/crates/ledgerr-mcp/src/mcp_adapter.rs
+++ b/crates/ledgerr-mcp/src/mcp_adapter.rs
@@ -46,8 +46,6 @@ pub const EXPORT_CPA_WORKBOOK_TOOL: &str = "l3dg3rr_export_cpa_workbook";
 pub const ONTOLOGY_UPSERT_ENTITIES_TOOL: &str = "l3dg3rr_ontology_upsert_entities";
 pub const ONTOLOGY_UPSERT_EDGES_TOOL: &str = "l3dg3rr_ontology_upsert_edges";
 
-pub const MCP_LIFECYCLE_METHODS: &[&str] = &["initialize", "tools/list", "tools/call"];
-
 pub const TOOL_GROUP_CORE: &[&str] = &[
     LIST_ACCOUNTS_TOOL,
     GET_RAW_CONTEXT_TOOL,
@@ -63,7 +61,6 @@ pub const TOOL_GROUP_EVENTS: &[&str] = &[EVENT_REPLAY_TOOL, EVENT_HISTORY_TOOL];
 pub const TOOL_GROUP_CLASSIFICATION: &[&str] = &[
     CLASSIFY_INGESTED_TOOL,
     QUERY_FLAGS_TOOL,
-    QUERY_AUDIT_LOG_TOOL,
     CLASSIFY_TRANSACTION_TOOL,
     RECONCILE_EXCEL_CLASSIFICATION_TOOL,
 ];
@@ -77,8 +74,6 @@ pub const TOOL_GROUP_TAX: &[&str] = &[
 pub const TOOL_GROUP_AUDIT: &[&str] = &[QUERY_AUDIT_LOG_TOOL];
 pub const TOOL_GROUP_ONTOLOGY_WRITE: &[&str] =
     &[ONTOLOGY_UPSERT_ENTITIES_TOOL, ONTOLOGY_UPSERT_EDGES_TOOL];
-
-const MCP_LIFECYCLE: &[&str] = &["tools/list", "tools/call"];
 
 pub fn tool_catalog() -> Vec<String> {
     let mut features = Vec::new();
@@ -138,8 +133,273 @@ pub fn tool_catalog_with_features(features: &[&str]) -> Vec<String> {
         tools.extend(TOOL_GROUP_ONTOLOGY_WRITE.iter().map(|s| s.to_string()));
     }
 
-    tools.extend(MCP_LIFECYCLE.iter().map(|s| s.to_string()));
     tools
+}
+
+/// Return the full MCP-spec tool objects (name + inputSchema) for all enabled tools.
+/// Use this in tools/list responses — do NOT use tool_catalog() directly for that.
+pub fn tool_list_entries() -> Vec<Value> {
+    tool_catalog()
+        .into_iter()
+        .map(|name| {
+            let schema = tool_input_schema(&name);
+            json!({ "name": name, "inputSchema": schema })
+        })
+        .collect()
+}
+
+/// Returns the JSON Schema for the input arguments of a named tool.
+pub fn tool_input_schema(name: &str) -> Value {
+    match name {
+        // ── no-argument tools ──────────────────────────────────────────────
+        LIST_ACCOUNTS_TOOL
+        | "l3dg3rr_get_pipeline_status"
+        | ONTOLOGY_EXPORT_SNAPSHOT_TOOL
+        | HSM_STATUS_TOOL
+        | QUERY_AUDIT_LOG_TOOL => json!({ "type": "object", "properties": {} }),
+
+        // ── get_raw_context ───────────────────────────────────────────────
+        GET_RAW_CONTEXT_TOOL => json!({
+            "type": "object",
+            "required": ["path"],
+            "properties": {
+                "path": { "type": "string", "description": "Path to the rkyv context file" }
+            }
+        }),
+
+        // ── proxy_docling_ingest_pdf ───────────────────────────────────────
+        "proxy_docling_ingest_pdf" => json!({
+            "type": "object",
+            "required": ["source_ref"],
+            "properties": {
+                "source_ref": { "type": "string", "description": "VENDOR--ACCOUNT--YYYY-MM--DOCTYPE source filename" },
+                "raw_context_bytes": {
+                    "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 255 },
+                    "description": "Raw PDF bytes as a byte array (optional if source_ref already exists)"
+                },
+                "extracted_rows": {
+                    "type": "array", "items": { "type": "object" },
+                    "description": "Pre-extracted transaction rows from Docling (optional)"
+                }
+            }
+        }),
+
+        // ── proxy_rustledger_ingest_statement_rows ────────────────────────
+        "proxy_rustledger_ingest_statement_rows" => json!({
+            "type": "object",
+            "required": ["rows"],
+            "properties": {
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["account_id", "date", "amount", "description", "source_ref"],
+                        "properties": {
+                            "account_id": { "type": "string" },
+                            "date": { "type": "string", "format": "date" },
+                            "amount": { "type": "string", "description": "Decimal string, e.g. \"-42.11\"" },
+                            "description": { "type": "string" },
+                            "source_ref": { "type": "string" }
+                        }
+                    }
+                }
+            }
+        }),
+
+        // ── ontology_query_path ───────────────────────────────────────────
+        ONTOLOGY_QUERY_PATH_TOOL => json!({
+            "type": "object",
+            "required": ["path"],
+            "properties": {
+                "path": { "type": "string", "description": "Filesystem path to the ontology file" },
+                "max_depth": { "type": "integer", "minimum": 0, "description": "Maximum traversal depth (optional)" }
+            }
+        }),
+
+        // ── reconciliation tools (validate / reconcile / commit) ──────────
+        RECON_VALIDATE_TOOL | RECON_RECONCILE_TOOL | RECON_COMMIT_TOOL => json!({
+            "type": "object",
+            "required": ["source_total", "extracted_total", "posting_amounts"],
+            "properties": {
+                "source_total": { "type": "string", "description": "Total from source document (decimal string)" },
+                "extracted_total": { "type": "string", "description": "Total of extracted rows (decimal string)" },
+                "posting_amounts": {
+                    "type": "array", "items": { "type": "string" },
+                    "description": "Individual posting amounts as decimal strings"
+                }
+            }
+        }),
+
+        // ── hsm_transition ────────────────────────────────────────────────
+        HSM_TRANSITION_TOOL => json!({
+            "type": "object",
+            "required": ["target_state", "target_substate"],
+            "properties": {
+                "target_state": { "type": "string" },
+                "target_substate": { "type": "string" }
+            }
+        }),
+
+        // ── hsm_resume ────────────────────────────────────────────────────
+        HSM_RESUME_TOOL => json!({
+            "type": "object",
+            "required": ["state_marker"],
+            "properties": {
+                "state_marker": { "type": "string" }
+            }
+        }),
+
+        // ── event_history ─────────────────────────────────────────────────
+        EVENT_HISTORY_TOOL => json!({
+            "type": "object",
+            "properties": {
+                "tx_id": { "type": "string" },
+                "document_ref": { "type": "string" },
+                "time_start": { "type": "string", "format": "date-time" },
+                "time_end": { "type": "string", "format": "date-time" }
+            }
+        }),
+
+        // ── event_replay ──────────────────────────────────────────────────
+        EVENT_REPLAY_TOOL => json!({
+            "type": "object",
+            "properties": {
+                "tx_id": { "type": "string" },
+                "document_ref": { "type": "string" }
+            }
+        }),
+
+        // ── classify_ingested ─────────────────────────────────────────────
+        CLASSIFY_INGESTED_TOOL => json!({
+            "type": "object",
+            "required": ["rule_file", "review_threshold"],
+            "properties": {
+                "rule_file": { "type": "string", "description": "Path to the Rhai rule file" },
+                "review_threshold": { "type": "number", "description": "Confidence threshold below which transactions are flagged for review" }
+            }
+        }),
+
+        // ── query_flags ───────────────────────────────────────────────────
+        QUERY_FLAGS_TOOL => json!({
+            "type": "object",
+            "required": ["year", "status"],
+            "properties": {
+                "year": { "type": "integer" },
+                "status": { "type": "string", "enum": ["open", "resolved"] }
+            }
+        }),
+
+        // ── classify_transaction / reconcile_excel_classification ─────────
+        CLASSIFY_TRANSACTION_TOOL | RECONCILE_EXCEL_CLASSIFICATION_TOOL => json!({
+            "type": "object",
+            "required": ["tx_id", "category", "confidence", "actor"],
+            "properties": {
+                "tx_id": { "type": "string" },
+                "category": { "type": "string" },
+                "confidence": { "type": "string" },
+                "note": { "type": "string" },
+                "actor": { "type": "string" }
+            }
+        }),
+
+        // ── tax_assist / tax_ambiguity_review ─────────────────────────────
+        TAX_ASSIST_TOOL | TAX_AMBIGUITY_REVIEW_TOOL => json!({
+            "type": "object",
+            "required": ["ontology_path", "from_entity_id", "reconciliation"],
+            "properties": {
+                "ontology_path": { "type": "string" },
+                "from_entity_id": { "type": "string" },
+                "max_depth": { "type": "integer", "minimum": 0 },
+                "reconciliation": {
+                    "type": "object",
+                    "required": ["source_total", "extracted_total", "posting_amounts"],
+                    "properties": {
+                        "source_total": { "type": "string" },
+                        "extracted_total": { "type": "string" },
+                        "posting_amounts": { "type": "array", "items": { "type": "string" } }
+                    }
+                }
+            }
+        }),
+
+        // ── tax_evidence_chain ────────────────────────────────────────────
+        TAX_EVIDENCE_CHAIN_TOOL => json!({
+            "type": "object",
+            "required": ["ontology_path", "from_entity_id"],
+            "properties": {
+                "ontology_path": { "type": "string" },
+                "from_entity_id": { "type": "string" },
+                "tx_id": { "type": "string" },
+                "document_ref": { "type": "string" }
+            }
+        }),
+
+        // ── get_schedule_summary ──────────────────────────────────────────
+        GET_SCHEDULE_SUMMARY_TOOL => json!({
+            "type": "object",
+            "required": ["year", "schedule"],
+            "properties": {
+                "year": { "type": "integer" },
+                "schedule": { "type": "string", "enum": ["ScheduleC", "ScheduleD", "ScheduleE", "Fbar"] }
+            }
+        }),
+
+        // ── export_cpa_workbook ───────────────────────────────────────────
+        EXPORT_CPA_WORKBOOK_TOOL => json!({
+            "type": "object",
+            "required": ["workbook_path"],
+            "properties": {
+                "workbook_path": { "type": "string", "description": "Output path for the Excel workbook" }
+            }
+        }),
+
+        // ── ontology_upsert_entities ──────────────────────────────────────
+        ONTOLOGY_UPSERT_ENTITIES_TOOL => json!({
+            "type": "object",
+            "required": ["path", "entities"],
+            "properties": {
+                "path": { "type": "string" },
+                "entities": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["kind"],
+                        "properties": {
+                            "kind": { "type": "string", "enum": ["Document", "Account", "Institution", "Transaction", "TaxCategory", "EvidenceReference"] },
+                            "id": { "type": "string" },
+                            "label": { "type": "string" },
+                            "properties": { "type": "object" }
+                        }
+                    }
+                }
+            }
+        }),
+
+        // ── ontology_upsert_edges ─────────────────────────────────────────
+        ONTOLOGY_UPSERT_EDGES_TOOL => json!({
+            "type": "object",
+            "required": ["path", "edges"],
+            "properties": {
+                "path": { "type": "string" },
+                "edges": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["from_id", "to_id", "relation"],
+                        "properties": {
+                            "from_id": { "type": "string" },
+                            "to_id": { "type": "string" },
+                            "relation": { "type": "string" },
+                            "provenance": { "type": "object" }
+                        }
+                    }
+                }
+            }
+        }),
+
+        // ── unknown / future tools ────────────────────────────────────────
+        _ => json!({ "type": "object" }),
+    }
 }
 
 pub fn list_accounts_tool_result(service: &TurboLedgerService) -> Value {

--- a/crates/ledgerr-mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ledgerr-mcp/tests/mcp_adapter_contract.rs
@@ -10,8 +10,10 @@ fn doc_01_mcp_boundary_tool_catalog_exposes_passthrough_proxy_surface() {
     assert!(tools.contains(&"l3dg3rr_list_accounts".to_string()));
     assert!(tools.contains(&"l3dg3rr_get_raw_context".to_string()));
     assert!(tools.contains(&"l3dg3rr_get_pipeline_status".to_string()));
-    assert!(tools.contains(&"tools/list".to_string()));
-    assert!(tools.contains(&"tools/call".to_string()));
+    // MCP lifecycle methods (tools/list, tools/call) are JSON-RPC methods, not tools —
+    // they must NOT appear in the tool catalog per MCP spec.
+    assert!(!tools.contains(&"tools/list".to_string()));
+    assert!(!tools.contains(&"tools/call".to_string()));
 }
 
 // DOC-02 (D-02, D-04): Canonical rows + provenance fields must be deterministic.

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/PromptExecution/l3dg3rr/releases/download/v0.1.0/ledgerr-mcp-x86_64-unknown-linux-gnu.mcpb",
+      "identifier": "https://github.com/PromptExecution/l3dg3rr/releases/download/v0.1.0/ledgerr-mcp-x86_64-unknown-linux-musl.mcpb",
       "fileSha256": "a21ca4312f18da93fd715716ccd207168496a15625c1c71854973e1a7e180ed1",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- **MCP spec fixes**: remove `tools/list`/`tools/call` from tool catalog; add `inputSchema` to all 27 tools; deduplicate `l3dg3rr_query_audit_log`
- **CI wiring**: `release.yml` workflow_run trigger name corrected; `publish.yml` crate name `turbo-mcp` → `ledgerr-mcp`; `server.json` artifact URL `linux-gnu` → `linux-musl`
- **Dockerfile**: rewritten with `cargo-chef` dependency caching; runtime stage now runs the MCP server binary instead of `cargo test`
- **Dependencies**: `calamine` 0.26 → 0.34.0, `thiserror` 1 → 2.0.18 per CLAUDE.md spec
- **Justfile**: portable `cog` path; `just test` runs full workspace suite; new `mcp-podman-run` and `mcp-podman-verify` recipes for GHCR image
- **README**: prerequisites table (Rust 1.88+, just, cog, cross, mcp-publisher); corrected Docker quickstart; fixed stale `turbo-mcp` reference

## Test plan

- [ ] CI passes on this branch (cargo test --workspace, clippy, e2e)
- [ ] `tools/list` response: 27 tools, all with `inputSchema`, no `tools/list`/`tools/call` entries
- [ ] `release.yml` auto-fires after CI green on merge to main
- [ ] `podman-publish` workflow triggers correctly after CI (trigger name now aligned)
- [ ] `just mcp-podman-run` pulls and starts server from GHCR after release image is published
- [ ] Docker build completes with cargo-chef layer cache on second build

🤖 Generated with [Claude Code](https://claude.com/claude-code)