### PR TITLE
feat(skills): add agent skills scaffold — 5 SKILL.md runbooks

### DIFF
--- a/skills/ledgerr-classify/SKILL.md
+++ b/skills/ledgerr-classify/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: ledgerr-classify
+description: Use this skill to classify transactions in the l3dg3rr tax ledger using Rhai rules, review the flag queue, and apply manual per-transaction corrections via MCP. Covers rule authoring, batch classification, flag querying, and audit trail.
+---
+
+# ledgerr-classify
+
+## Classification Flow
+
+### Step 1 — Write a Rhai rule file
+
+Rules live in a `.rhai` file. The `classify` function receives a transaction map and must return a result map:
+
+```rhai
+fn classify(tx) {
+    let desc = tx["description"];
+    let category = if desc.contains("Coffee") { "Meals" }
+                   else if desc.contains("AWS") { "Software" }
+                   else { "Uncategorized" };
+    let confidence = if category == "Uncategorized" { 0.33 } else { 0.92 };
+    #{
+        category: category,
+        confidence: confidence,   // 0.0–1.0; values below review_threshold → flagged
+        review: confidence < 0.80,
+        reason: "auto-rule-v1"
+    }
+}
+```
+
+Valid categories (from `TaxCategory` enum): `Meals`, `Travel`, `Software`, `OfficeSupplies`, `Utilities`, `Salary`, `Uncategorized`, and others — check `mcp_adapter.rs` for full list.
+
+### Step 2 — Run batch classification
+
+```json
+{
+  "name": "l3dg3rr_classify_ingested",
+  "arguments": {
+    "rule_file": "/path/to/classify.rhai",
+    "review_threshold": 0.80
+  }
+}
+```
+
+Response includes `classifications` array. Each entry has `tx_id`, `category`, `confidence`, `review` flag.
+
+### Step 3 — Check the review queue
+
+```json
+{ "name": "l3dg3rr_query_flags", "arguments": { "year": 2023, "status": "open" } }
+```
+
+Returns `flags` array of transactions needing human review.
+
+### Step 4 — Manual correction
+
+For individual transactions that need a different category:
+
+```json
+{
+  "name": "l3dg3rr_classify_transaction",
+  "arguments": {
+    "tx_id": "blake3-hash-here",
+    "category": "Travel",
+    "confidence": "0.95",
+    "actor": "agent",
+    "note": "override: vendor is airline"
+  }
+}
+```
+
+Every manual classification is appended to the audit log automatically.
+
+### Step 5 — Verify audit trail
+
+```json
+{ "name": "l3dg3rr_query_audit_log", "arguments": {} }
+```
+
+## Confidence Invariant
+
+`confidence` must be a decimal string in `[0.0, 1.0]`. Values stored as `rust_decimal::Decimal` — no float precision loss. Do not pass `f64` values; pass string representations like `"0.92"`.
+
+## Excel Reconciliation
+
+If a CPA edits categories in the Excel workbook, sync back via:
+
+```json
+{
+  "name": "l3dg3rr_reconcile_excel_classification",
+  "arguments": { "tx_id": "...", "category": "...", "confidence": "1.00", "actor": "cpa", "note": "CPA override" }
+}
+```

--- a/skills/ledgerr-devops/SKILL.md
+++ b/skills/ledgerr-devops/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: ledgerr-devops
+description: Use this skill for release management, CI/CD operations, Docker/Podman image publishing, branch/PR workflow, and justfile task execution on the l3dg3rr repo. Covers the full devops loop from branch creation through GitHub release to GHCR image verification.
+---
+
+# ledgerr-devops
+
+## Branch + PR Workflow
+
+Always work on a named branch — never commit directly to main.
+
+```bash
+git checkout -b fix/<topic>     # or feat/<topic>, chore/<topic>
+# ... make changes ...
+git add <specific files>        # never git add -A
+git commit -m "type(scope): message"
+git push -u origin <branch>
+gh pr create --title "..." --body "..."
+gh pr checks <number> --watch   # wait for CI
+gh pr merge <number> --squash --delete-branch
+git checkout main && git pull
+```
+
+## Release
+
+```bash
+just release patch    # runs cargo test + e2e, bumps version via cog, pushes tag
+just release minor
+just release major
+```
+
+Release auto-triggers CI → `podman-publish` → GHCR image push → `mcpb-publish` multi-platform bundles.
+
+## CI Workflow Names (exact — must match workflow_run triggers)
+
+| File | name: field |
+|------|-------------|
+| `ci.yml` | `CI with MCP Registry Publish` |
+| `release.yml` | `Release` |
+| `publish.yml` | `Publish Artifacts` |
+| `mcpb-publish.yml` | `MCPB Multi-Platform Publish` |
+| `podman-publish.yml` | `Publish Podman Image` |
+
+## Justfile Quick Reference
+
+```bash
+just test                  # full workspace test suite + mcp-outcome-test
+just mcp-start             # run MCP server (stdio, dev build)
+just mcp-start-release     # run release binary
+just mcp-podman-run        # pull + run latest GHCR image via podman
+just mcp-podman-run v0.2.0 # specific release tag
+just mcp-podman-verify     # inspect manifest without full pull
+just bundle                # build .mcpb for x86_64-unknown-linux-musl
+just bundle-all            # all tier-1 targets (requires cross toolchains)
+just v                     # print current version
+just validate              # check conventional commits via cog
+just changelog             # show cog changelog
+```
+
+## Verifying a Release Image
+
+```bash
+just mcp-podman-verify main            # manifest inspect (no pull)
+just mcp-podman-run main               # pull + run, mount $PWD/data:/data
+```
+
+The container runs `/usr/local/bin/ledgerr-mcp-server` (stdio MCP transport).
+Mount `-v $PWD/data:/data` for workbook and PDF inbox.
+Env vars: `LEDGER_WORKBOOK_PATH`, `LEDGER_PDF_INBOX`.
+
+## Secrets Required (CI)
+
+| Secret | Purpose |
+|--------|---------|
+| `GITHUB_TOKEN` | Auto-provided; GHCR push, release creation |
+| `CRATES_IO_TOKEN` | crates.io publish (optional) |
+| `PYPI_API_TOKEN` | PyPI publish (optional) |
+
+Set via: `just gh-secrets-set-repo` (reads from `.env`).
+
+## Workspace Crates
+
+| Crate | Purpose |
+|-------|---------|
+| `ledger-core` | Domain types, ingest, classify, workbook |
+| `ledgerr-mcp` | MCP adapter + stdio server binary |
+| `xtask-mcpb` | Bundle/publish automation |

--- a/skills/ledgerr-ingest/SKILL.md
+++ b/skills/ledgerr-ingest/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: ledgerr-ingest
+description: Use this skill to ingest PDF financial statements into the l3dg3rr tax ledger via MCP. Covers filename contract, Docling extraction, row ingestion, idempotency verification, and raw context sidecar handling.
+---
+
+# ledgerr-ingest
+
+## Filename Contract (required before any ingest)
+
+Every source file must follow: `VENDOR--ACCOUNT--YYYY-MM--DOCTYPE.ext`
+
+Examples:
+- `WF--BH-CHK--2023-01--statement.pdf`  ✓
+- `chase--savings--2023-06--statement.pdf`  ✓
+- `statement_jan2023.pdf`  ✗ — will be rejected by preflight
+
+Validate first:
+```json
+{ "name": "proxy_docling_ingest_pdf", "arguments": { "source_ref": "WF--BH-CHK--2023-01--statement.pdf" } }
+```
+
+## Ingest Flow
+
+### Step 1 — Docling extraction (PDF → rows)
+Call `proxy_docling_ingest_pdf` with:
+- `source_ref`: filename following contract above
+- `raw_context_bytes`: PDF bytes as integer array (optional if already stored)
+- `extracted_rows`: pre-extracted transactions (optional if Docling handles it)
+
+Each row needs: `account_id`, `date` (YYYY-MM-DD), `amount` (decimal string e.g. `"-42.11"`), `description`, `source_ref`.
+
+### Step 2 — Verify idempotency
+Re-ingesting the same rows must return `inserted_count: 0`. If it returns > 0 on second call, something is wrong with the content-hash IDs.
+
+```json
+{ "name": "l3dg3rr_list_accounts", "arguments": {} }
+```
+Check the account appears in the list.
+
+### Step 3 — Retrieve raw context
+```json
+{ "name": "l3dg3rr_get_raw_context", "arguments": { "path": "path/to/stmt.rkyv" } }
+```
+
+## Transaction ID Format
+
+IDs are Blake3 content hashes over `account_id + date + amount + description`. Same input always yields the same ID — this is the dedup guarantee.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `invalid_filename` | Filename doesn't match contract | Rename file to VENDOR--ACCOUNT--YYYY-MM--DOCTYPE |
+| `inserted_count: 0` on first ingest | Rows already exist (good — idempotent) | Check if prior session already ingested |
+| `missing raw_context_bytes` | First ingest without bytes, no prior sidecar | Pass `raw_context_bytes` |

--- a/skills/ledgerr-qa/SKILL.md
+++ b/skills/ledgerr-qa/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: ledgerr-qa
+description: Use this skill for adversarial quality inspection of the l3dg3rr repo. Covers MCP protocol compliance, CI/CD correctness, Dockerfile, dependency versions, README completeness, and test coverage. Run this before any release or when reviewing a contractor's work.
+---
+
+# ledgerr-qa
+
+## Inspection Checklist
+
+Run these checks in order. Each has caused a real bug in this repo.
+
+### 1. Compile + Tests
+
+```bash
+cargo test --workspace --all-targets --all-features
+# Expect: zero errors, zero FAILED
+cargo clippy --workspace --all-targets --all-features --message-format=json | grep '"level":"error"'
+# Expect: no output
+```
+
+### 2. MCP Protocol Compliance
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"qa","version":"1"}}}
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | ./target/debug/ledgerr-mcp-server
+```
+
+Check the tools/list response:
+- No `tools/list` or `tools/call` in the tool names (those are JSON-RPC methods, not tools)
+- Every tool has `"inputSchema"` field
+- No duplicate tool names (`l3dg3rr_query_audit_log` appeared twice — was in both CLASSIFICATION and AUDIT groups)
+- Tool count should be 27
+
+### 3. CI Workflow Trigger Names
+
+`release.yml` must reference the EXACT `name:` field of the CI workflow:
+
+```bash
+grep "^name:" .github/workflows/ci.yml
+grep "workflows:" .github/workflows/release.yml
+# These must match exactly
+```
+
+Current correct value: `"CI with MCP Registry Publish"`
+
+### 4. server.json Artifact URL
+
+```bash
+grep "identifier" server.json
+grep "target:" .github/workflows/mcpb-publish.yml
+# Must use same target suffix (linux-musl, not linux-gnu)
+```
+
+### 5. publish.yml Crate Names
+
+```bash
+grep "cargo publish -p" .github/workflows/publish.yml
+# Must match actual workspace members: ledger-core, ledgerr-mcp
+# NOT turbo-mcp (old name, doesn't exist)
+```
+
+### 6. Dockerfile
+
+```bash
+grep "CMD\|cargo test\|cargo-chef\|COPY --from" Dockerfile
+```
+
+- `CMD` must run the binary (`/usr/local/bin/ledgerr-mcp-server`), not `cargo test`
+- Must use `cargo-chef` for dependency layer caching
+- Runtime stage must copy only the binary, not the full builder filesystem
+
+### 7. Dependency Versions (CLAUDE.md spec)
+
+```bash
+grep "calamine\|thiserror" crates/*/Cargo.toml
+# calamine must be 0.34.x (not 0.26)
+# thiserror must be 2.x (not 1.x)
+grep -A2 "name = \"calamine\"\|name = \"thiserror\"" Cargo.lock | grep version
+```
+
+### 8. Justfile Portability
+
+```bash
+grep "/home/" justfile
+# Must be empty — no hardcoded absolute user paths
+# cog, just, cargo must be bare commands, not full paths
+```
+
+### 9. README Prerequisites
+
+```bash
+grep -i "rust\|just\|cog\|cross\|prerequisites" README.md
+# Must have a prerequisites section listing: Rust 1.88+, just, cocogitto, cross, mcp-publisher
+```
+
+### 10. Phase 6 Exposure Gaps
+
+```bash
+RUSTFLAGS="--cfg phase6_gap_tests" cargo test -p ledgerr-mcp --test phase6_mcp_exposure_gaps
+# All 20 tests must pass — these are the MCP tool acceptance criteria
+```
+
+## Scoring
+
+Count FAILs. 0 = shippable. Any FAIL on items 1–6 = block release.
+Items 7–10 = should fix before merge.

--- a/skills/ledgerr-reconcile/SKILL.md
+++ b/skills/ledgerr-reconcile/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: ledgerr-reconcile
+description: Use this skill to run the validate → reconcile → commit guardrail sequence in l3dg3rr. Covers posting balance checks, HSM lifecycle transitions, CPA workbook export, and schedule summaries. Required before any tax output is considered final.
+---
+
+# ledgerr-reconcile
+
+## The Guardrail Sequence
+
+Commit is blocked until validate and reconcile pass. Never skip steps.
+
+```
+validate → reconcile → commit
+```
+
+### Step 1 — Validate
+
+```json
+{
+  "name": "l3dg3rr_validate_reconciliation",
+  "arguments": {
+    "source_total": "-1842.50",
+    "extracted_total": "-1842.50",
+    "posting_amounts": ["-42.00", "-800.50", "-1000.00"]
+  }
+}
+```
+
+`source_total` = total from the original PDF/statement.
+`extracted_total` = sum of all ingested rows.
+`posting_amounts` = individual line amounts (must balance to `extracted_total`).
+
+On mismatch: returns `isError: false` but with `status: "blocked"` and `reason` keys (`totals_mismatch`, `imbalance_postings`). Fix the discrepancy before proceeding.
+
+### Step 2 — Reconcile
+
+Same arguments as validate. Transitions internal state to `reconciled` if clean.
+
+```json
+{ "name": "l3dg3rr_reconcile_postings", "arguments": { ... same ... } }
+```
+
+### Step 3 — Commit (guarded)
+
+Only succeeds if both prior stages passed. Returns `commit_ready: true` on success.
+
+```json
+{ "name": "l3dg3rr_commit_guarded", "arguments": { ... same ... } }
+```
+
+## HSM Lifecycle
+
+The session state machine tracks the overall pipeline phase. Check current state:
+
+```json
+{ "name": "l3dg3rr_hsm_status", "arguments": {} }
+```
+
+Transition to next state:
+```json
+{ "name": "l3dg3rr_hsm_transition", "arguments": { "target_state": "reconciled", "target_substate": "clean" } }
+```
+
+Resume from last checkpoint if a session was interrupted:
+```json
+{ "name": "l3dg3rr_hsm_resume", "arguments": { "state_marker": "checkpoint-id-here" } }
+```
+
+## Tax Outputs (after commit)
+
+### Schedule summary
+```json
+{ "name": "l3dg3rr_get_schedule_summary", "arguments": { "year": 2023, "schedule": "ScheduleC" } }
+```
+Valid schedules: `ScheduleC`, `ScheduleD`, `ScheduleE`, `Fbar`
+
+### CPA workbook export
+```json
+{ "name": "l3dg3rr_export_cpa_workbook", "arguments": { "workbook_path": "/data/tax-2023-final.xlsx" } }
+```
+
+Returns `sheets_written` count and writes the `.xlsx` to the given path.
+
+### Tax assist (full derivation)
+```json
+{
+  "name": "l3dg3rr_tax_assist",
+  "arguments": {
+    "ontology_path": "/data/ontology.json",
+    "from_entity_id": "WF-BH-CHK",
+    "reconciliation": { "source_total": "-1842.50", "extracted_total": "-1842.50", "posting_amounts": [...] }
+  }
+}
+```
+
+## Blocked State Diagnostics
+
+If any tool returns `status: "blocked"`, read `reason` and `blockers` fields. Common reasons:
+- `totals_mismatch` — source_total ≠ extracted_total
+- `imbalance_postings` — posting_amounts don't sum to extracted_total
+- `reconciliation_not_ready` — validate/reconcile not yet passed


### PR DESCRIPTION
## Summary

- Adds `skills/` directory with 5 agent skills following the Claude SKILL.md spec
- Each skill: YAML frontmatter (`name` ≤64 chars, `description` ≤1024 chars) + procedural runbook body
- Skills are loaded automatically by Claude when the task matches the description — no explicit invocation

| Skill | Triggers on |
|-------|------------|
| `ledgerr-devops` | Release, CI/CD, branch/PR workflow, Docker/Podman |
| `ledgerr-qa` | Adversarial inspection, pre-release checks |
| `ledgerr-ingest` | PDF ingestion, filename contract, Docling flow |
| `ledgerr-classify` | Rhai rules, batch classify, flag queue, corrections |
| `ledgerr-reconcile` | validate→reconcile→commit, HSM, tax outputs |

## Note on Phase 6 tools

Verified all 20 phase6 gap tests pass on current main — all P0/P1/P2 tools were already wired before PR #10 was created. No code changes needed for task #12.

## Test plan

- [ ] CI passes (no Rust changes, but validate no file conflicts)
- [ ] `ls skills/*/SKILL.md` shows all 5 files
- [ ] Frontmatter name/description lengths verified (all pass ≤64/≤1024 constraints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)