### PR TITLE
feat(ci): add Windows binary to release matrix + claude mcp add install docs

### DIFF
--- a/.github/workflows/mcpb-publish.yml
+++ b/.github/workflows/mcpb-publish.yml
@@ -26,12 +26,19 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             use_cross: true
+            binary_name: ledgerr-mcp-server
           - os: macos-13        # Intel runner
             target: x86_64-apple-darwin
             use_cross: false
+            binary_name: ledgerr-mcp-server
           - os: macos-latest    # Apple Silicon runner
             target: aarch64-apple-darwin
             use_cross: false
+            binary_name: ledgerr-mcp-server
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            use_cross: false
+            binary_name: ledgerr-mcp-server.exe
 
     steps:
       - uses: actions/checkout@v4
@@ -52,6 +59,7 @@ jobs:
 
       - name: Resolve release tag
         id: tag
+        shell: bash
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
@@ -64,17 +72,20 @@ jobs:
         run: cross build -p ledgerr-mcp --release --bin ledgerr-mcp-server --target ${{ matrix.target }}
 
       - name: Build binary (native)
-        if: '!matrix.use_cross'
+        if: "!matrix.use_cross"
         run: cargo build -p ledgerr-mcp --release --bin ledgerr-mcp-server --target ${{ matrix.target }}
 
       - name: Bundle .mcpb via xtask
+        shell: bash
         run: |
+          mkdir -p dist
           cargo xtask-mcpb bundle \
-            --binary target/${{ matrix.target }}/release/ledgerr-mcp-server \
+            --binary target/${{ matrix.target }}/release/${{ matrix.binary_name }} \
             --output dist/ledgerr-mcp-${{ matrix.target }}.mcpb \
             --version ${{ steps.tag.outputs.tag }}
 
       - name: Verify bundle
+        shell: bash
         run: cargo xtask-mcpb verify dist/ledgerr-mcp-${{ matrix.target }}.mcpb
 
       - name: Upload bundle artifact

--- a/README.md
+++ b/README.md
@@ -43,6 +43,41 @@ just test
 just mcp-start
 ```
 
+## Install in Claude Code
+
+Download the pre-built binary for your platform from the [latest GitHub Release](https://github.com/PromptExecution/l3dg3rr/releases/latest), then register it with Claude Code:
+
+### macOS / Linux
+
+```bash
+# Replace VERSION with the latest release tag, e.g. v0.1.1
+VERSION=v0.1.1
+
+# macOS (Apple Silicon)
+curl -fsSL "https://github.com/PromptExecution/l3dg3rr/releases/download/${VERSION}/ledgerr-mcp-aarch64-apple-darwin.mcpb" -o /tmp/ledgerr-mcp.mcpb
+
+# macOS (Intel)
+curl -fsSL "https://github.com/PromptExecution/l3dg3rr/releases/download/${VERSION}/ledgerr-mcp-x86_64-apple-darwin.mcpb" -o /tmp/ledgerr-mcp.mcpb
+
+# Linux (x86_64)
+curl -fsSL "https://github.com/PromptExecution/l3dg3rr/releases/download/${VERSION}/ledgerr-mcp-x86_64-unknown-linux-musl.mcpb" -o /tmp/ledgerr-mcp.mcpb
+
+# Register with Claude Code
+claude mcp add ledgerr /tmp/ledgerr-mcp.mcpb
+```
+
+### Windows (PowerShell)
+
+```powershell
+$v = "v0.1.1"   # replace with latest
+Invoke-WebRequest `
+  "https://github.com/PromptExecution/l3dg3rr/releases/download/$v/ledgerr-mcp-x86_64-pc-windows-msvc.mcpb" `
+  -OutFile "$env:TEMP\ledgerr-mcp.mcpb"
+claude mcp add ledgerr "$env:TEMP\ledgerr-mcp.mcpb"
+```
+
+After adding, restart Claude Code. The `l3dg3rr_*` tools will appear automatically.
+
 ## Docker
 
 The container runs the `ledgerr-mcp-server` binary (stdio MCP transport).


### PR DESCRIPTION
## Summary

- Adds `x86_64-pc-windows-msvc` to the `mcpb-publish.yml` build matrix (`windows-latest` runner, native cargo build)
- Introduces `binary_name` matrix field to handle the `.exe` extension on Windows — the bundle step now uses `target/<target>/release/${{ matrix.binary_name }}` rather than a hardcoded name
- Adds `shell: bash` to tag-resolve, bundle, and verify steps so Git Bash is used consistently on Windows runners
- Adds `mkdir -p dist` before bundling (Windows runners don't auto-create output dirs)
- Adds **Install in Claude Code** section to README with one-liner install commands for macOS (arm64 + intel), Linux musl, and Windows PowerShell

## Result

After the next release, users on Windows can install via:

```powershell
$v = "v0.1.1"
Invoke-WebRequest "https://github.com/PromptExecution/l3dg3rr/releases/download/$v/ledgerr-mcp-x86_64-pc-windows-msvc.mcpb" -OutFile "$env:TEMP\ledgerr-mcp.mcpb"
claude mcp add ledgerr "$env:TEMP\ledgerr-mcp.mcpb"
```

## Test plan

- [ ] CI passes on all 4 matrix targets (ubuntu musl, macos intel, macos arm64, windows msvc)
- [ ] Windows bundle artifact appears in GitHub release assets
- [ ] `mcpb-publish.yml` verify step passes on Windows runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)