### PR TITLE
refactor(mcp-adapter): clarify naming, extract helpers, fix abstraction boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 - - -
+## refactor/mcp-adapter-clarity - 2026-04-16
+#### Refactor
+- (**ledgerr-mcp**) extracted `error_envelope` private helper — ~29 duplicated parse-error/service-error JSON construction blocks collapsed to a single call site
+- (**ledgerr-mcp**) renamed 23 handler functions: single-tool handlers `*_tool_result` → `handle_*`; multi-tool dispatchers `reconciliation_tool_result`/`hsm_tool_result` → `dispatch_reconciliation`/`dispatch_hsm`
+- (**ledgerr-mcp**) renamed `map_tool_error` → `error_payload`; name now reflects JSON rendering, not error transformation
+- (**ledgerr-mcp**) renamed `normalize_rows_with_provenance` → `rows_to_json_with_provenance`; rows are already normalised — the function converts them to JSON with provenance annotation
+- (**ledgerr-mcp**) removed `pub` from `parse_ingest_pdf_request` and `parse_ingest_statement_rows_request`; both had no external callers
+- (**ledgerr-mcp**) renamed catalog/descriptor trio: `tool_catalog` → `tool_names`, `tool_catalog_with_features` → `tool_names_for`, `tool_list_entries` → `tool_descriptors`; names now distinguish "names only" from "names + schemas"
+- (**ledgerr-mcp**) routed `handle_ontology_export_snapshot` through `TurboLedgerService` instead of calling `OntologyStore::load` directly; added `OntologyExportSnapshotRequest`/`OntologyExportSnapshotResponse` types, service method, and covering test
+- (**ledgerr-mcp**) removed vestigial `McpAdapter` struct — only method discarded its service reference immediately; no call sites existed in the crate
+
+- - -
 ## v1.3.5 - 2026-04-16
 #### Bug Fixes
 - (**mcpb**) drop ./ from command; set author to Prompt Execution Pty Ltd. - (a421da0) - Claude Sonnet (coordinator)

--- a/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs
+++ b/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs
@@ -46,7 +46,7 @@ fn handle_request(request: Value) -> Option<Value> {
         })),
         "notifications/initialized" => None,
         "tools/list" => {
-            let tools = mcp_adapter::tool_list_entries();
+            let tools = mcp_adapter::tool_descriptors();
             Some(json!({
                 "jsonrpc": "2.0",
                 "id": id,
@@ -58,7 +58,7 @@ fn handle_request(request: Value) -> Option<Value> {
             let tool_name = params.get("name").and_then(Value::as_str).unwrap_or("");
             let result = match tool_name {
                 mcp_adapter::LIST_ACCOUNTS_TOOL => {
-                    mcp_adapter::list_accounts_tool_result(global_service())
+                    mcp_adapter::handle_list_accounts(global_service())
                 }
                 "l3dg3rr_get_pipeline_status" => {
                     let status = mcp_adapter::get_pipeline_status(true, true, true, Vec::new());
@@ -72,7 +72,7 @@ fn handle_request(request: Value) -> Option<Value> {
                 }
                 "proxy_docling_ingest_pdf" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::ingest_pdf_tool_result(
+                    mcp_adapter::handle_ingest_pdf(
                         global_service(),
                         &arguments,
                         Some(format!("mcp-call-{id}")),
@@ -80,7 +80,7 @@ fn handle_request(request: Value) -> Option<Value> {
                 }
                 "proxy_rustledger_ingest_statement_rows" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::ingest_statement_rows_tool_result(
+                    mcp_adapter::handle_ingest_statement_rows(
                         global_service(),
                         &arguments,
                         Some(format!("mcp-call-{id}")),
@@ -88,89 +88,89 @@ fn handle_request(request: Value) -> Option<Value> {
                 }
                 mcp_adapter::GET_RAW_CONTEXT_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::get_raw_context_tool_result(global_service(), &arguments)
+                    mcp_adapter::handle_get_raw_context(global_service(), &arguments)
                 }
                 mcp_adapter::ONTOLOGY_QUERY_PATH_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::ontology_query_path_tool_result(global_service(), &arguments)
+                    mcp_adapter::handle_ontology_query_path(global_service(), &arguments)
                 }
                 mcp_adapter::ONTOLOGY_EXPORT_SNAPSHOT_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::ontology_export_snapshot_tool_result(&arguments)
+                    mcp_adapter::handle_ontology_export_snapshot(global_service(), &arguments)
                 }
                 mcp_adapter::RECON_VALIDATE_TOOL
                 | mcp_adapter::RECON_RECONCILE_TOOL
                 | mcp_adapter::RECON_COMMIT_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::reconciliation_tool_result(global_service(), tool_name, &arguments)
+                    mcp_adapter::dispatch_reconciliation(global_service(), tool_name, &arguments)
                 }
                 mcp_adapter::HSM_TRANSITION_TOOL
                 | mcp_adapter::HSM_STATUS_TOOL
                 | mcp_adapter::HSM_RESUME_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::hsm_tool_result(global_service(), tool_name, &arguments)
+                    mcp_adapter::dispatch_hsm(global_service(), tool_name, &arguments)
                 }
                 mcp_adapter::EVENT_HISTORY_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::event_history_tool_result(global_service(), &arguments)
+                    mcp_adapter::handle_event_history(global_service(), &arguments)
                 }
                 mcp_adapter::EVENT_REPLAY_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::event_replay_tool_result(global_service(), &arguments)
+                    mcp_adapter::handle_event_replay(global_service(), &arguments)
                 }
                 mcp_adapter::TAX_ASSIST_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::tax_assist_tool_result(global_service(), &arguments)
+                    mcp_adapter::handle_tax_assist(global_service(), &arguments)
                 }
                 mcp_adapter::TAX_EVIDENCE_CHAIN_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::tax_evidence_chain_tool_result(global_service(), &arguments)
+                    mcp_adapter::handle_tax_evidence_chain(global_service(), &arguments)
                 }
                 mcp_adapter::TAX_AMBIGUITY_REVIEW_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::tax_ambiguity_review_tool_result(global_service(), &arguments)
+                    mcp_adapter::handle_tax_ambiguity_review(global_service(), &arguments)
                 }
                 // P0 tools
                 mcp_adapter::CLASSIFY_INGESTED_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::classify_ingested_tool_result(global_service(), &arguments)
+                    mcp_adapter::handle_classify_ingested(global_service(), &arguments)
                 }
                 mcp_adapter::QUERY_FLAGS_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::query_flags_tool_result(global_service(), &arguments)
+                    mcp_adapter::handle_query_flags(global_service(), &arguments)
                 }
                 mcp_adapter::QUERY_AUDIT_LOG_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::query_audit_log_tool_result(global_service(), &arguments)
+                    mcp_adapter::handle_query_audit_log(global_service(), &arguments)
                 }
                 // P1 tools
                 mcp_adapter::CLASSIFY_TRANSACTION_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::classify_transaction_tool_result(global_service(), &arguments)
+                    mcp_adapter::handle_classify_transaction(global_service(), &arguments)
                 }
                 mcp_adapter::RECONCILE_EXCEL_CLASSIFICATION_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::reconcile_excel_classification_tool_result(
+                    mcp_adapter::handle_reconcile_excel_classification(
                         global_service(),
                         &arguments,
                     )
                 }
                 mcp_adapter::GET_SCHEDULE_SUMMARY_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::get_schedule_summary_tool_result(global_service(), &arguments)
+                    mcp_adapter::handle_get_schedule_summary(global_service(), &arguments)
                 }
                 // P2 tools
                 mcp_adapter::EXPORT_CPA_WORKBOOK_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::export_cpa_workbook_tool_result(global_service(), &arguments)
+                    mcp_adapter::handle_export_cpa_workbook(global_service(), &arguments)
                 }
                 mcp_adapter::ONTOLOGY_UPSERT_ENTITIES_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::ontology_upsert_entities_tool_result(global_service(), &arguments)
+                    mcp_adapter::handle_ontology_upsert_entities(global_service(), &arguments)
                 }
                 mcp_adapter::ONTOLOGY_UPSERT_EDGES_TOOL => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::ontology_upsert_edges_tool_result(global_service(), &arguments)
+                    mcp_adapter::handle_ontology_upsert_edges(global_service(), &arguments)
                 }
                 _ => mcp_adapter::unknown_tool_result(tool_name),
             };

--- a/crates/ledgerr-mcp/src/lib.rs
+++ b/crates/ledgerr-mcp/src/lib.rs
@@ -230,6 +230,19 @@ pub struct ExportCpaWorkbookResponse {
     pub sheets_written: usize,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OntologyExportSnapshotRequest {
+    pub ontology_path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct OntologyExportSnapshotResponse {
+    pub entities: Vec<OntologyEntity>,
+    pub edges: Vec<OntologyEdge>,
+    pub entity_count: usize,
+    pub edge_count: usize,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScheduleKindRequest {
     ScheduleC,
@@ -412,6 +425,19 @@ impl TurboLedgerService {
         request: OntologyQueryPathRequest,
     ) -> Result<OntologyQueryPathResponse, ToolError> {
         self.ontology_query_path(request)
+    }
+
+    pub fn ontology_export_snapshot(
+        &self,
+        request: OntologyExportSnapshotRequest,
+    ) -> Result<OntologyExportSnapshotResponse, ToolError> {
+        let store = OntologyStore::load(&request.ontology_path)?;
+        Ok(OntologyExportSnapshotResponse {
+            entity_count: store.entities.len(),
+            edge_count: store.edges.len(),
+            entities: store.entities,
+            edges: store.edges,
+        })
     }
 
     pub fn validate_reconciliation_stage_tool(

--- a/crates/ledgerr-mcp/src/mcp_adapter.rs
+++ b/crates/ledgerr-mcp/src/mcp_adapter.rs
@@ -8,11 +8,12 @@ use crate::{
     ClassifyIngestedRequest, ClassifyTransactionRequest, EventHistoryFilter,
     ExportCpaWorkbookRequest, FlagStatusRequest, GetRawContextRequest, GetScheduleSummaryRequest,
     HsmResumeRequest, HsmStatusRequest, HsmTransitionRequest, IngestPdfRequest,
-    IngestStatementRowsRequest, ListAccountsRequest, OntologyQueryPathRequest, OntologyStore,
-    OntologyUpsertEdgesRequest, OntologyUpsertEntitiesRequest, QueryAuditLogRequest,
-    QueryFlagsRequest, ReconcileExcelClassificationRequest, ReconciliationStageRequest,
-    ReplayLifecycleRequest, ScheduleKindRequest, TaxAmbiguityReviewRequest, TaxAssistRequest,
-    TaxEvidenceChainRequest, ToolError, TurboLedgerService, TurboLedgerTools,
+    IngestStatementRowsRequest, ListAccountsRequest, OntologyExportSnapshotRequest,
+    OntologyQueryPathRequest, OntologyUpsertEdgesRequest, OntologyUpsertEntitiesRequest,
+    QueryAuditLogRequest, QueryFlagsRequest, ReconcileExcelClassificationRequest,
+    ReconciliationStageRequest, ReplayLifecycleRequest, ScheduleKindRequest,
+    TaxAmbiguityReviewRequest, TaxAssistRequest, TaxEvidenceChainRequest, ToolError,
+    TurboLedgerService, TurboLedgerTools,
 };
 
 pub const LIST_ACCOUNTS_TOOL: &str = "l3dg3rr_list_accounts";
@@ -75,7 +76,7 @@ pub const TOOL_GROUP_AUDIT: &[&str] = &[QUERY_AUDIT_LOG_TOOL];
 pub const TOOL_GROUP_ONTOLOGY_WRITE: &[&str] =
     &[ONTOLOGY_UPSERT_ENTITIES_TOOL, ONTOLOGY_UPSERT_EDGES_TOOL];
 
-pub fn tool_catalog() -> Vec<String> {
+pub fn tool_names() -> Vec<String> {
     let mut features = Vec::new();
 
     #[cfg(feature = "core")]
@@ -99,10 +100,10 @@ pub fn tool_catalog() -> Vec<String> {
         features.push("core");
     }
 
-    tool_catalog_with_features(&features)
+    tool_names_for(&features)
 }
 
-pub fn tool_catalog_with_features(features: &[&str]) -> Vec<String> {
+pub fn tool_names_for(features: &[&str]) -> Vec<String> {
     let mut tools = Vec::new();
 
     if features.iter().any(|f| *f == "core") {
@@ -137,9 +138,9 @@ pub fn tool_catalog_with_features(features: &[&str]) -> Vec<String> {
 }
 
 /// Return the full MCP-spec tool objects (name + inputSchema) for all enabled tools.
-/// Use this in tools/list responses — do NOT use tool_catalog() directly for that.
-pub fn tool_list_entries() -> Vec<Value> {
-    tool_catalog()
+/// Use this in tools/list responses — do NOT use tool_names() directly for that.
+pub fn tool_descriptors() -> Vec<Value> {
+    tool_names()
         .into_iter()
         .map(|name| {
             let schema = tool_input_schema(&name);
@@ -154,9 +155,17 @@ pub fn tool_input_schema(name: &str) -> Value {
         // ── no-argument tools ──────────────────────────────────────────────
         LIST_ACCOUNTS_TOOL
         | "l3dg3rr_get_pipeline_status"
-        | ONTOLOGY_EXPORT_SNAPSHOT_TOOL
         | HSM_STATUS_TOOL
         | QUERY_AUDIT_LOG_TOOL => json!({ "type": "object", "properties": {} }),
+
+        // ── ontology_export_snapshot ───────────────────────────────────────
+        ONTOLOGY_EXPORT_SNAPSHOT_TOOL => json!({
+            "type": "object",
+            "required": ["ontology_path"],
+            "properties": {
+                "ontology_path": { "type": "string", "description": "Path to the ontology file" }
+            }
+        }),
 
         // ── get_raw_context ───────────────────────────────────────────────
         GET_RAW_CONTEXT_TOOL => json!({
@@ -170,16 +179,18 @@ pub fn tool_input_schema(name: &str) -> Value {
         // ── proxy_docling_ingest_pdf ───────────────────────────────────────
         "proxy_docling_ingest_pdf" => json!({
             "type": "object",
-            "required": ["source_ref"],
+            "required": ["pdf_path", "journal_path", "workbook_path"],
             "properties": {
-                "source_ref": { "type": "string", "description": "VENDOR--ACCOUNT--YYYY-MM--DOCTYPE source filename" },
+                "pdf_path": { "type": "string", "description": "Path to the PDF file (VENDOR--ACCOUNT--YYYY-MM--DOCTYPE naming required)" },
+                "journal_path": { "type": "string", "description": "Path to the journal file" },
+                "workbook_path": { "type": "string", "description": "Path to the Excel workbook" },
                 "raw_context_bytes": {
                     "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 255 },
-                    "description": "Raw PDF bytes as a byte array (optional if source_ref already exists)"
+                    "description": "Raw PDF bytes as a byte array (required when source file does not yet exist on disk)"
                 },
                 "extracted_rows": {
                     "type": "array", "items": { "type": "object" },
-                    "description": "Pre-extracted transaction rows from Docling (optional)"
+                    "description": "Pre-extracted transaction rows from Docling (optional; omit or pass [] to ingest without rows)"
                 }
             }
         }),
@@ -402,7 +413,7 @@ pub fn tool_input_schema(name: &str) -> Value {
     }
 }
 
-pub fn list_accounts_tool_result(service: &TurboLedgerService) -> Value {
+pub fn handle_list_accounts(service: &TurboLedgerService) -> Value {
     match service.list_accounts_tool(ListAccountsRequest) {
         Ok(response) => {
             let accounts = response
@@ -418,28 +429,14 @@ pub fn list_accounts_tool_result(service: &TurboLedgerService) -> Value {
                 "isError": false
             })
         }
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn get_raw_context_tool_result(service: &TurboLedgerService, arguments: &Value) -> Value {
+pub fn handle_get_raw_context(service: &TurboLedgerService, arguments: &Value) -> Value {
     let request = match parse_get_raw_context_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.get_raw_context(request) {
@@ -450,13 +447,7 @@ pub fn get_raw_context_tool_result(service: &TurboLedgerService, arguments: &Val
             }],
             "isError": false
         }),
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
@@ -500,7 +491,7 @@ pub fn get_pipeline_status(
     }
 }
 
-pub fn normalize_rows_with_provenance(
+pub fn rows_to_json_with_provenance(
     provider: &str,
     backend_tool: &str,
     backend_version: Option<&str>,
@@ -527,7 +518,14 @@ pub fn normalize_rows_with_provenance(
         .collect()
 }
 
-pub fn map_tool_error(error: &ToolError) -> Value {
+fn error_envelope(err: &ToolError) -> Value {
+    json!({
+        "content": [{ "type": "json", "json": error_payload(err) }],
+        "isError": true
+    })
+}
+
+pub fn error_payload(error: &ToolError) -> Value {
     match error {
         ToolError::InvalidInput(message) => json!({
             "isError": true,
@@ -567,12 +565,15 @@ pub fn protocol_method_not_found(id: Value, method: &str) -> Value {
     })
 }
 
-pub fn parse_ingest_pdf_request(arguments: &Value) -> Result<IngestPdfRequest, ToolError> {
+fn parse_ingest_pdf_request(arguments: &Value) -> Result<IngestPdfRequest, ToolError> {
     let pdf_path = required_str(arguments, "pdf_path")?.to_string();
     let journal_path = PathBuf::from(required_str(arguments, "journal_path")?);
     let workbook_path = PathBuf::from(required_str(arguments, "workbook_path")?);
     let raw_context_bytes = parse_optional_bytes(arguments.get("raw_context_bytes"))?;
-    let extracted_rows = parse_rows(arguments.get("extracted_rows"), "extracted_rows")?;
+    let extracted_rows = match arguments.get("extracted_rows") {
+        None | Some(Value::Null) => Vec::new(),
+        some => parse_rows(some, "extracted_rows")?,
+    };
 
     Ok(IngestPdfRequest {
         pdf_path,
@@ -583,7 +584,7 @@ pub fn parse_ingest_pdf_request(arguments: &Value) -> Result<IngestPdfRequest, T
     })
 }
 
-pub fn parse_ingest_statement_rows_request(
+fn parse_ingest_statement_rows_request(
     arguments: &Value,
 ) -> Result<IngestStatementRowsRequest, ToolError> {
     let journal_path = PathBuf::from(required_str(arguments, "journal_path")?);
@@ -597,25 +598,17 @@ pub fn parse_ingest_statement_rows_request(
     })
 }
 
-pub fn ingest_pdf_tool_result<T: TurboLedgerTools>(
+pub fn handle_ingest_pdf<T: TurboLedgerTools>(
     service: &T,
     arguments: &Value,
     backend_call_id: Option<String>,
 ) -> Value {
     let request = match parse_ingest_pdf_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
-    let canonical_rows = normalize_rows_with_provenance(
+    let canonical_rows = rows_to_json_with_provenance(
         "docling",
         "ingest_pdf",
         Some(env!("CARGO_PKG_VERSION")),
@@ -646,35 +639,21 @@ pub fn ingest_pdf_tool_result<T: TurboLedgerTools>(
                 "isError": false
             })
         }
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn ingest_statement_rows_tool_result<T: TurboLedgerTools>(
+pub fn handle_ingest_statement_rows<T: TurboLedgerTools>(
     service: &T,
     arguments: &Value,
     backend_call_id: Option<String>,
 ) -> Value {
     let request = match parse_ingest_statement_rows_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
-    let canonical_rows = normalize_rows_with_provenance(
+    let canonical_rows = rows_to_json_with_provenance(
         "rustledger",
         "ingest_statement_rows",
         Some(env!("CARGO_PKG_VERSION")),
@@ -707,28 +686,14 @@ pub fn ingest_statement_rows_tool_result<T: TurboLedgerTools>(
                 "isError": false
             })
         }
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn ontology_query_path_tool_result(service: &TurboLedgerService, arguments: &Value) -> Value {
+pub fn handle_ontology_query_path(service: &TurboLedgerService, arguments: &Value) -> Value {
     let request = match parse_ontology_query_path_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.ontology_query_path_tool(request) {
@@ -742,71 +707,43 @@ pub fn ontology_query_path_tool_result(service: &TurboLedgerService, arguments: 
             }],
             "isError": false
         }),
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn ontology_export_snapshot_tool_result(arguments: &Value) -> Value {
+pub fn handle_ontology_export_snapshot(service: &TurboLedgerService, arguments: &Value) -> Value {
     let ontology_path = match parse_ontology_path(arguments) {
         Ok(path) => path,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
-    match OntologyStore::load(&ontology_path) {
-        Ok(store) => json!({
+    match service.ontology_export_snapshot(OntologyExportSnapshotRequest { ontology_path }) {
+        Ok(response) => json!({
             "content": [{
                 "type": "json",
                 "json": {
-                    "entities": store.entities,
-                    "edges": store.edges,
+                    "entities": response.entities,
+                    "edges": response.edges,
                     "snapshot": {
-                        "entity_count": store.entities.len(),
-                        "edge_count": store.edges.len(),
+                        "entity_count": response.entity_count,
+                        "edge_count": response.edge_count,
                     }
                 }
             }],
             "isError": false
         }),
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn reconciliation_tool_result(
+pub fn dispatch_reconciliation(
     service: &TurboLedgerService,
     tool_name: &str,
     arguments: &Value,
 ) -> Value {
     let request = match parse_reconciliation_stage_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     let response = match tool_name {
@@ -860,30 +797,16 @@ pub fn reconciliation_tool_result(
                 "isError": blocked
             })
         }
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn hsm_tool_result(service: &TurboLedgerService, tool_name: &str, arguments: &Value) -> Value {
+pub fn dispatch_hsm(service: &TurboLedgerService, tool_name: &str, arguments: &Value) -> Value {
     match tool_name {
         HSM_TRANSITION_TOOL => {
             let request = match parse_hsm_transition_request(arguments) {
                 Ok(request) => request,
-                Err(err) => {
-                    return json!({
-                        "content": [{
-                            "type": "json",
-                            "json": map_tool_error(&err)
-                        }],
-                        "isError": true
-                    });
-                }
+                Err(err) => return error_envelope(&err),
             };
 
             match service.hsm_transition_tool(request) {
@@ -919,13 +842,7 @@ pub fn hsm_tool_result(service: &TurboLedgerService, tool_name: &str, arguments:
                         "isError": blocked
                     })
                 }
-                Err(err) => json!({
-                    "content": [{
-                        "type": "json",
-                        "json": map_tool_error(&err)
-                    }],
-                    "isError": true
-                }),
+                Err(err) => error_envelope(&err),
             }
         }
         HSM_STATUS_TOOL => match service.hsm_status_tool(HsmStatusRequest) {
@@ -943,26 +860,12 @@ pub fn hsm_tool_result(service: &TurboLedgerService, tool_name: &str, arguments:
                 }],
                 "isError": false
             }),
-            Err(err) => json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            }),
+            Err(err) => error_envelope(&err),
         },
         HSM_RESUME_TOOL => {
             let request = match parse_hsm_resume_request(arguments) {
                 Ok(request) => request,
-                Err(err) => {
-                    return json!({
-                        "content": [{
-                            "type": "json",
-                            "json": map_tool_error(&err)
-                        }],
-                        "isError": true
-                    });
-                }
+                Err(err) => return error_envelope(&err),
             };
 
             match service.hsm_resume_tool(request) {
@@ -994,31 +897,17 @@ pub fn hsm_tool_result(service: &TurboLedgerService, tool_name: &str, arguments:
                         "isError": blocked
                     })
                 }
-                Err(err) => json!({
-                    "content": [{
-                        "type": "json",
-                        "json": map_tool_error(&err)
-                    }],
-                    "isError": true
-                }),
+                Err(err) => error_envelope(&err),
             }
         }
         _ => unknown_tool_result(tool_name),
     }
 }
 
-pub fn event_history_tool_result(service: &TurboLedgerService, arguments: &Value) -> Value {
+pub fn handle_event_history(service: &TurboLedgerService, arguments: &Value) -> Value {
     let filter = match parse_event_history_filter(arguments) {
         Ok(filter) => filter,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.event_history(filter.clone()) {
@@ -1072,28 +961,14 @@ pub fn event_history_tool_result(service: &TurboLedgerService, arguments: &Value
                 "isError": true
             })
         }
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn event_replay_tool_result(service: &TurboLedgerService, arguments: &Value) -> Value {
+pub fn handle_event_replay(service: &TurboLedgerService, arguments: &Value) -> Value {
     let request = match parse_replay_lifecycle_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.replay_lifecycle(request) {
@@ -1114,28 +989,14 @@ pub fn event_replay_tool_result(service: &TurboLedgerService, arguments: &Value)
             }],
             "isError": false
         }),
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn tax_assist_tool_result(service: &TurboLedgerService, arguments: &Value) -> Value {
+pub fn handle_tax_assist(service: &TurboLedgerService, arguments: &Value) -> Value {
     let request = match parse_tax_assist_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.tax_assist_tool(request) {
@@ -1173,28 +1034,14 @@ pub fn tax_assist_tool_result(service: &TurboLedgerService, arguments: &Value) -
                 "isError": blocked
             })
         }
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn tax_evidence_chain_tool_result(service: &TurboLedgerService, arguments: &Value) -> Value {
+pub fn handle_tax_evidence_chain(service: &TurboLedgerService, arguments: &Value) -> Value {
     let request = match parse_tax_evidence_chain_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.tax_evidence_chain_tool(request) {
@@ -1210,28 +1057,14 @@ pub fn tax_evidence_chain_tool_result(service: &TurboLedgerService, arguments: &
             }],
             "isError": false
         }),
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn tax_ambiguity_review_tool_result(service: &TurboLedgerService, arguments: &Value) -> Value {
+pub fn handle_tax_ambiguity_review(service: &TurboLedgerService, arguments: &Value) -> Value {
     let request = match parse_tax_ambiguity_review_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.tax_ambiguity_review_tool(request) {
@@ -1263,28 +1096,14 @@ pub fn tax_ambiguity_review_tool_result(service: &TurboLedgerService, arguments:
                 "isError": blocked
             })
         }
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn classify_ingested_tool_result(service: &TurboLedgerService, arguments: &Value) -> Value {
+pub fn handle_classify_ingested(service: &TurboLedgerService, arguments: &Value) -> Value {
     let request = match parse_classify_ingested_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.classify_ingested(request) {
@@ -1310,28 +1129,14 @@ pub fn classify_ingested_tool_result(service: &TurboLedgerService, arguments: &V
                 "isError": false
             })
         }
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn query_flags_tool_result(service: &TurboLedgerService, arguments: &Value) -> Value {
+pub fn handle_query_flags(service: &TurboLedgerService, arguments: &Value) -> Value {
     let request = match parse_query_flags_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.query_flags(request) {
@@ -1361,28 +1166,14 @@ pub fn query_flags_tool_result(service: &TurboLedgerService, arguments: &Value) 
                 "isError": false
             })
         }
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn query_audit_log_tool_result(service: &TurboLedgerService, arguments: &Value) -> Value {
+pub fn handle_query_audit_log(service: &TurboLedgerService, arguments: &Value) -> Value {
     let _request = match parse_query_audit_log_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.query_audit_log(QueryAuditLogRequest) {
@@ -1410,28 +1201,14 @@ pub fn query_audit_log_tool_result(service: &TurboLedgerService, arguments: &Val
                 "isError": false
             })
         }
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn classify_transaction_tool_result(service: &TurboLedgerService, arguments: &Value) -> Value {
+pub fn handle_classify_transaction(service: &TurboLedgerService, arguments: &Value) -> Value {
     let request = match parse_classify_transaction_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.classify_transaction(request) {
@@ -1464,31 +1241,17 @@ pub fn classify_transaction_tool_result(service: &TurboLedgerService, arguments:
                 "isError": false
             })
         }
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn reconcile_excel_classification_tool_result(
+pub fn handle_reconcile_excel_classification(
     service: &TurboLedgerService,
     arguments: &Value,
 ) -> Value {
     let request = match parse_reconcile_excel_classification_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.reconcile_excel_classification(request) {
@@ -1521,28 +1284,14 @@ pub fn reconcile_excel_classification_tool_result(
                 "isError": false
             })
         }
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn get_schedule_summary_tool_result(service: &TurboLedgerService, arguments: &Value) -> Value {
+pub fn handle_get_schedule_summary(service: &TurboLedgerService, arguments: &Value) -> Value {
     let request = match parse_get_schedule_summary_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.get_schedule_summary(request) {
@@ -1576,28 +1325,14 @@ pub fn get_schedule_summary_tool_result(service: &TurboLedgerService, arguments:
                 "isError": false
             })
         }
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn export_cpa_workbook_tool_result(service: &TurboLedgerService, arguments: &Value) -> Value {
+pub fn handle_export_cpa_workbook(service: &TurboLedgerService, arguments: &Value) -> Value {
     let request = match parse_export_cpa_workbook_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.export_cpa_workbook(request) {
@@ -1608,31 +1343,17 @@ pub fn export_cpa_workbook_tool_result(service: &TurboLedgerService, arguments: 
             }],
             "isError": false
         }),
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn ontology_upsert_entities_tool_result(
+pub fn handle_ontology_upsert_entities(
     service: &TurboLedgerService,
     arguments: &Value,
 ) -> Value {
     let request = match parse_ontology_upsert_entities_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.ontology_upsert_entities_tool(request) {
@@ -1643,28 +1364,14 @@ pub fn ontology_upsert_entities_tool_result(
             }],
             "isError": false
         }),
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
+        Err(err) => error_envelope(&err),
     }
 }
 
-pub fn ontology_upsert_edges_tool_result(service: &TurboLedgerService, arguments: &Value) -> Value {
+pub fn handle_ontology_upsert_edges(service: &TurboLedgerService, arguments: &Value) -> Value {
     let request = match parse_ontology_upsert_edges_request(arguments) {
         Ok(request) => request,
-        Err(err) => {
-            return json!({
-                "content": [{
-                    "type": "json",
-                    "json": map_tool_error(&err)
-                }],
-                "isError": true
-            });
-        }
+        Err(err) => return error_envelope(&err),
     };
 
     match service.ontology_upsert_edges_tool(request) {
@@ -1675,34 +1382,7 @@ pub fn ontology_upsert_edges_tool_result(service: &TurboLedgerService, arguments
             }],
             "isError": false
         }),
-        Err(err) => json!({
-            "content": [{
-                "type": "json",
-                "json": map_tool_error(&err)
-            }],
-            "isError": true
-        }),
-    }
-}
-
-pub struct McpAdapter<'a, T: TurboLedgerTools> {
-    service: &'a T,
-}
-
-impl<'a, T: TurboLedgerTools> McpAdapter<'a, T> {
-    pub fn new(service: &'a T) -> Self {
-        Self { service }
-    }
-
-    pub fn provider_passthrough_ping(&self) -> Value {
-        let _ = &self.service;
-        json!({
-            "provider": "rustledger",
-            "backend_tool": "list_accounts",
-            "backend_version": serde_json::Value::Null,
-            "backend_call_id": serde_json::Value::Null,
-            "status": "ok",
-        })
+        Err(err) => error_envelope(&err),
     }
 }
 

--- a/crates/ledgerr-mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ledgerr-mcp/tests/mcp_adapter_contract.rs
@@ -3,7 +3,7 @@ use ledger_core::ingest::TransactionInput;
 // DOC-01 (D-01, D-03): MCP transport boundary must expose proxy/passthrough tools.
 #[test]
 fn doc_01_mcp_boundary_tool_catalog_exposes_passthrough_proxy_surface() {
-    let tools = ledgerr_mcp::mcp_adapter::tool_catalog();
+    let tools = ledgerr_mcp::mcp_adapter::tool_names();
 
     assert!(tools.contains(&"proxy_rustledger_ingest_statement_rows".to_string()));
     assert!(tools.contains(&"proxy_docling_ingest_pdf".to_string()));
@@ -27,7 +27,7 @@ fn doc_02_normalized_rows_include_canonical_and_provenance_fields() {
         source_ref: "2023-taxes/WF--BH-CHK--2023-01--statement.rkyv".to_string(),
     }];
 
-    let normalized = ledgerr_mcp::mcp_adapter::normalize_rows_with_provenance(
+    let normalized = ledgerr_mcp::mcp_adapter::rows_to_json_with_provenance(
         "rustledger",
         "ingest_statement_rows",
         Some("1.0.0"),
@@ -68,7 +68,7 @@ fn doc_02_pipeline_status_shape_is_deterministic_and_concise() {
 // DOC-01 (D-03): Rustledger proxy surface must remain explicitly advertised in catalog.
 #[test]
 fn doc_01_rustledger_proxy_tool_name_is_exact_and_callable_target() {
-    let tools = ledgerr_mcp::mcp_adapter::tool_catalog();
+    let tools = ledgerr_mcp::mcp_adapter::tool_names();
     assert!(tools
         .iter()
         .any(|name| name == "proxy_rustledger_ingest_statement_rows"));

--- a/crates/ledgerr-mcp/tests/ontology_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/ontology_mcp_e2e.rs
@@ -2,7 +2,10 @@ use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 
-use ledgerr_mcp::{OntologyEdgeInput, OntologyEntityInput, OntologyEntityKind, OntologyStore};
+use ledgerr_mcp::{
+    mcp_adapter, OntologyEdgeInput, OntologyEntityInput, OntologyEntityKind,
+    OntologyExportSnapshotRequest, OntologyStore, TurboLedgerService,
+};
 use serde_json::{json, Value};
 
 const ONTOLOGY_QUERY_TOOL: &str = "l3dg3rr_ontology_query_path";
@@ -301,4 +304,45 @@ fn onto_03_export_snapshot_stable_json_serialization_over_transport() {
         .expect("serialize second payload");
 
     assert_eq!(first_payload, second_payload);
+}
+
+// ONTO-03 (D-03): ontology_export_snapshot routes through TurboLedgerService, not OntologyStore directly.
+#[test]
+fn onto_03_export_snapshot_routes_through_service() {
+    const TEST_MANIFEST: &str = "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n\n[accounts]\nWF-BH-CHK = { institution = \"Wells Fargo\", type = \"checking\", currency = \"USD\" }\n";
+
+    let service =
+        TurboLedgerService::from_manifest_str(TEST_MANIFEST).expect("manifest must parse");
+
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let ontology_path = tempdir.path().join("ontology.json");
+    let _ = seed_ontology(&ontology_path);
+
+    // Call via service method directly and verify response struct fields.
+    let response = service
+        .ontology_export_snapshot(OntologyExportSnapshotRequest {
+            ontology_path: ontology_path.clone(),
+        })
+        .expect("ontology_export_snapshot must succeed");
+
+    assert_eq!(response.entity_count, response.entities.len());
+    assert_eq!(response.edge_count, response.edges.len());
+    assert_eq!(response.entity_count, 4, "seed produces 4 entities");
+    assert_eq!(response.edge_count, 3, "seed produces 3 edges");
+    assert!(!response.entities.is_empty());
+    assert!(!response.edges.is_empty());
+
+    // Call via JSON handler and check the isError: false shape.
+    let args = json!({ "ontology_path": ontology_path.display().to_string() });
+    let result = mcp_adapter::handle_ontology_export_snapshot(&service, &args);
+
+    assert_eq!(result["isError"], Value::Bool(false));
+    let json_payload = &result["content"][0]["json"];
+    assert!(json_payload["entities"].is_array());
+    assert!(json_payload["edges"].is_array());
+    assert_eq!(
+        json_payload["snapshot"]["entity_count"].as_u64().unwrap(),
+        4
+    );
+    assert_eq!(json_payload["snapshot"]["edge_count"].as_u64().unwrap(), 3);
 }

--- a/docs/bugs/SUMMARY.md
+++ b/docs/bugs/SUMMARY.md
@@ -1,0 +1,54 @@
+# l3dg3rr MCP Server — Interface Test Summary
+
+**Date**: 2026-04-16
+**Binary**: `target/debug/ledgerr-mcp-server`
+**Protocol**: MCP 2025-11-25
+**Commit**: `faba56d`
+**Tools advertised**: 28 | **Tools probed**: 27
+
+## Bug Registry
+
+| ID | Severity | Tool | Issue | Status |
+|----|----------|------|-------|--------|
+| BUG-001 | P1 | `proxy_docling_ingest_pdf` | Schema required `source_ref`; impl required `pdf_path`+`journal_path`+`workbook_path` | ✅ Fixed — schema updated to match impl; `extracted_rows` made truly optional |
+| BUG-002 | P1 | `l3dg3rr_ontology_export_snapshot` | Schema advertised no params; impl required `ontology_path` | ✅ Fixed — schema updated; handler routed through `TurboLedgerService` |
+
+## Pass Results by Tool Group
+
+| Group | Tools | Result |
+|-------|-------|--------|
+| Core | `list_accounts`, `get_pipeline_status`, `hsm_status`, `query_audit_log`, `proxy_rustledger_ingest_statement_rows` | ✅ All pass |
+| Reconciliation | `validate_reconciliation`, `reconcile_postings`, `commit_guarded` | ✅ All pass (balanced/unbalanced/edge cases) |
+| HSM | `hsm_transition`, `hsm_resume`, `hsm_status` | ✅ Respond correctly (blocked transitions expected by lifecycle guard) |
+| Events | `event_history`, `event_replay` | ✅ All pass |
+| Classification | `classify_ingested`, `classify_transaction`, `reconcile_excel_classification`, `query_flags` | ✅ All pass |
+| Tax | `tax_assist`, `tax_evidence_chain`, `tax_ambiguity_review`, `get_schedule_summary`, `export_cpa_workbook` | ✅ All pass |
+| Ontology (read) | `ontology_query_path`, `ontology_upsert_entities`, `ontology_upsert_edges` | ✅ Pass |
+| Ontology (export) | `ontology_export_snapshot` | ✅ Pass (BUG-002 fixed) |
+| Docling proxy | `proxy_docling_ingest_pdf` | ✅ Pass (BUG-001 fixed) |
+
+## Protocol Compliance
+
+- Initialize/initialized handshake: ✅
+- `tools/list` returns complete schema: ✅
+- JSON-RPC error codes: ✅ (`-32601` for unknown method)
+- Response envelope (`result.content[].type`, `isError`): ✅
+
+## Input Validation Coverage
+
+| Input class | Behavior |
+|-------------|----------|
+| Valid decimal string `"-42.11"` | ✅ Accepted |
+| Non-numeric decimal | ✅ Rejected with `InvalidInput` |
+| ISO 8601 date `"2024-01-15"` | ✅ Accepted |
+| Slash-delimited date `"2024/01/15"` | ✅ Rejected |
+| Valid schedule enum | ✅ Accepted |
+| Invalid enum value | ✅ Rejected with descriptive message |
+| Missing required field | ✅ Rejected with `"missing or invalid \`fieldname\`"` |
+| Unknown tool name | ✅ Returns `unknown tool: <name>` with `isError:true` |
+
+## Recommendations
+
+1. **Systematic schema audit**: BUG-001 and BUG-002 reveal a pattern — schemas may have been written against an earlier or future API shape. Audit all 28 tool schemas against their `parse_*` functions.
+2. **Schema generation**: Derive `inputSchema` from the same struct that drives parsing (e.g., `schemars`) to prevent drift.
+3. **CI gate**: Add a test that calls every tool with schema-compliant minimal args and asserts `isError:false` (or an expected domain error, not a parse error).


### PR DESCRIPTION
## Summary

Eight improvements to `crates/ledgerr-mcp/src/mcp_adapter.rs` identified during a systematic readability review:

- **`error_envelope` helper extracted** — the identical parse-error/service-error JSON block appeared ~29 times. Now a single private function; every handler is 8–12 lines shorter.
- **23 handler functions renamed** — `*_tool_result` suffix dropped in favour of `handle_*`; multi-tool dispatchers renamed to `dispatch_reconciliation` / `dispatch_hsm` to make the fan-out explicit.
- **`map_tool_error` → `error_payload`** — the old name implied an error-to-error transform; the function renders a JSON payload.
- **`normalize_rows_with_provenance` → `rows_to_json_with_provenance`** — rows are already normalized `TransactionInput` values; the function converts them to JSON and annotates with provenance metadata.
- **`tool_catalog` / `tool_list_entries` → `tool_names` / `tool_descriptors`** — the old names were indistinguishable; new names signal whether the return is names-only (`Vec<String>`) or names+schemas (`Vec<Value>`). `tool_catalog_with_features` → `tool_names_for`.
- **Two `pub` parse functions made private** — `parse_ingest_pdf_request` and `parse_ingest_statement_rows_request` had zero external callers.
- **`handle_ontology_export_snapshot` routed through `TurboLedgerService`** — was the only handler calling `OntologyStore::load` directly, bypassing the service abstraction every other handler respects. Added `OntologyExportSnapshotRequest` / `OntologyExportSnapshotResponse` types, a service method, and a covering test.
- **Vestigial `McpAdapter` struct removed** — its sole method (`provider_passthrough_ping`) immediately discarded its service reference with `let _ = &self.service`; zero call sites existed in the crate.

## Test plan

- [x] `cargo test -p ledgerr-mcp` — 86 tests, 0 failures
- [x] All existing tests updated for renamed call sites (`mcp_adapter_contract.rs`, `ontology_mcp_e2e.rs`, `ledgerr-mcp-server.rs`)
- [x] New test added: `onto_03_export_snapshot_routes_through_service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)