### PR TITLE
fix(mcp): BUG-003 — replace invalid "type":"json" content blocks with "type":"text"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 - - -
+## v1.3.8 - 2026-04-17
+#### Bug Fixes
+- (**mcp**) fix BUG-003 (P0): all 27 tool handlers returned `"type": "json"` content blocks, which is not a valid MCP 2025-11-25 content type and causes Zod validation failures in spec-compliant clients; converted every content block to `"type": "text"` with payload serialized as a JSON string; added `text_content()` private helper to centralise the pattern; added `handle_pipeline_status()` handler to eliminate the one remaining hand-rolled response in the server binary - (cbde62d) - Claude Sonnet (coordinator)
+
+- - -
+
 ## v1.3.7 - 2026-04-16
 #### Bug Fixes
 - (**mcp**) fix `proxy_docling_ingest_pdf` schema: required fields were `source_ref` in schema vs `pdf_path`/`journal_path`/`workbook_path` in impl; schema updated to match; `extracted_rows` made truly optional (BUG-001) - (cbde62d) - Claude Sonnet (coordinator)

--- a/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs
+++ b/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs
@@ -61,14 +61,7 @@ fn handle_request(request: Value) -> Option<Value> {
                     mcp_adapter::handle_list_accounts(global_service())
                 }
                 "l3dg3rr_get_pipeline_status" => {
-                    let status = mcp_adapter::get_pipeline_status(true, true, true, Vec::new());
-                    json!({
-                        "content": [{
-                            "type": "json",
-                            "json": status
-                        }],
-                        "isError": false
-                    })
+                    mcp_adapter::handle_pipeline_status(true, true, true, Vec::new())
                 }
                 "proxy_docling_ingest_pdf" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);

--- a/crates/ledgerr-mcp/src/bin/mcp-outcome-test.rs
+++ b/crates/ledgerr-mcp/src/bin/mcp-outcome-test.rs
@@ -7,6 +7,11 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde_json::{json, Value};
 
+fn parse_response_payload(response: &Value) -> Value {
+    let text = response["content"][0]["text"].as_str().unwrap_or("null");
+    serde_json::from_str(text).unwrap_or(Value::Null)
+}
+
 struct McpClient {
     child: Child,
     stdin: ChildStdin,
@@ -182,8 +187,9 @@ fn step_pipeline_status(ctx: &mut FlowContext) -> Result<(), String> {
             "arguments": {}
         }),
     )?;
-    let status = &response["result"]["content"][0]["json"]["status"];
-    if status != "ready" {
+    let p = parse_response_payload(&response["result"]);
+    let status = &p["status"];
+    if *status != "ready" {
         return Err(format!("pipeline status not ready: {response}"));
     }
     Ok(())
@@ -197,7 +203,8 @@ fn step_list_accounts(ctx: &mut FlowContext) -> Result<(), String> {
             "arguments": {}
         }),
     )?;
-    let accounts = response["result"]["content"][0]["json"]["accounts"]
+    let accounts_p = parse_response_payload(&response["result"]);
+    let accounts = accounts_p["accounts"]
         .as_array()
         .ok_or_else(|| format!("accounts not returned: {response}"))?;
     if accounts.is_empty() {
@@ -229,7 +236,7 @@ fn step_ingest_sample(ctx: &mut FlowContext) -> Result<(), String> {
     if response["result"]["isError"] != Value::Bool(false) {
         return Err(format!("ingest should succeed: {response}"));
     }
-    if response["result"]["content"][0]["json"]["inserted_count"] != json!(1) {
+    if parse_response_payload(&response["result"])["inserted_count"] != json!(1) {
         return Err(format!("expected inserted_count=1: {response}"));
     }
     Ok(())
@@ -248,7 +255,7 @@ fn step_get_raw_context(ctx: &mut FlowContext) -> Result<(), String> {
     if response["result"]["isError"] != Value::Bool(false) {
         return Err(format!("get_raw_context should succeed: {response}"));
     }
-    if response["result"]["content"][0]["json"]["bytes"] != json!([99, 116, 120]) {
+    if parse_response_payload(&response["result"])["bytes"] != json!([99, 116, 120]) {
         return Err(format!("raw context bytes mismatch: {response}"));
     }
     Ok(())
@@ -267,8 +274,9 @@ fn step_hsm_resume_blocked(ctx: &mut FlowContext) -> Result<(), String> {
     if response["result"]["isError"] != Value::Bool(true) {
         return Err(format!("expected blocked hsm resume: {response}"));
     }
-    let error_type = &response["result"]["content"][0]["json"]["error_type"];
-    if error_type != "HsmResumeBlocked" {
+    let ep = parse_response_payload(&response["result"]);
+    let error_type = &ep["error_type"];
+    if *error_type != "HsmResumeBlocked" {
         return Err(format!("expected HsmResumeBlocked error type: {response}"));
     }
     Ok(())
@@ -291,8 +299,9 @@ fn step_reconciliation_blocked(ctx: &mut FlowContext) -> Result<(), String> {
             "expected blocked reconciliation commit: {response}"
         ));
     }
-    let error_type = &response["result"]["content"][0]["json"]["error_type"];
-    if error_type != "ReconciliationBlocked" {
+    let ep2 = parse_response_payload(&response["result"]);
+    let error_type = &ep2["error_type"];
+    if *error_type != "ReconciliationBlocked" {
         return Err(format!(
             "expected ReconciliationBlocked error type: {response}"
         ));
@@ -316,8 +325,9 @@ fn step_event_history_blocked(ctx: &mut FlowContext) -> Result<(), String> {
             "expected blocked event_history request: {response}"
         ));
     }
-    let reason = &response["result"]["content"][0]["json"]["reason"];
-    if reason != "time_range_invalid" {
+    let rp = parse_response_payload(&response["result"]);
+    let reason = &rp["reason"];
+    if *reason != "time_range_invalid" {
         return Err(format!("expected time_range_invalid reason: {response}"));
     }
     Ok(())

--- a/crates/ledgerr-mcp/src/mcp_adapter.rs
+++ b/crates/ledgerr-mcp/src/mcp_adapter.rs
@@ -422,10 +422,7 @@ pub fn handle_list_accounts(service: &TurboLedgerService) -> Value {
                 .map(|account| json!({ "account_id": account.account_id }))
                 .collect::<Vec<_>>();
             json!({
-                "content": [{
-                    "type": "json",
-                    "json": { "accounts": accounts }
-                }],
+                "content": [text_content(json!({ "accounts": accounts }))],
                 "isError": false
             })
         }
@@ -441,10 +438,7 @@ pub fn handle_get_raw_context(service: &TurboLedgerService, arguments: &Value) -
 
     match service.get_raw_context(request) {
         Ok(response) => json!({
-            "content": [{
-                "type": "json",
-                "json": { "bytes": response.bytes }
-            }],
+            "content": [text_content(json!({ "bytes": response.bytes }))],
             "isError": false
         }),
         Err(err) => error_envelope(&err),
@@ -491,6 +485,23 @@ pub fn get_pipeline_status(
     }
 }
 
+pub fn handle_pipeline_status(
+    manifest_ready: bool,
+    rustledger_ready: bool,
+    docling_ready: bool,
+    blockers: Vec<String>,
+) -> Value {
+    let status = get_pipeline_status(manifest_ready, rustledger_ready, docling_ready, blockers);
+    json!({
+        "content": [text_content(json!({
+            "status": status.status,
+            "blockers": status.blockers,
+            "next_hint": status.next_hint,
+        }))],
+        "isError": false
+    })
+}
+
 pub fn rows_to_json_with_provenance(
     provider: &str,
     backend_tool: &str,
@@ -518,9 +529,13 @@ pub fn rows_to_json_with_provenance(
         .collect()
 }
 
+fn text_content(payload: Value) -> Value {
+    json!({ "type": "text", "text": payload.to_string() })
+}
+
 fn error_envelope(err: &ToolError) -> Value {
     json!({
-        "content": [{ "type": "json", "json": error_payload(err) }],
+        "content": [text_content(error_payload(err))],
         "isError": true
     })
 }
@@ -542,14 +557,11 @@ pub fn error_payload(error: &ToolError) -> Value {
 
 pub fn unknown_tool_result(tool_name: &str) -> Value {
     json!({
-        "content": [{
-            "type": "json",
-            "json": {
+        "content": [text_content(json!({
                 "isError": true,
                 "error_type": "InvalidInput",
                 "message": format!("unknown tool: {tool_name}")
-            }
-        }],
+            }))],
         "isError": true
     })
 }
@@ -628,14 +640,11 @@ pub fn handle_ingest_pdf<T: TurboLedgerTools>(
                 response.tx_ids
             };
             json!({
-                "content": [{
-                    "type": "json",
-                    "json": {
+                "content": [text_content(json!({
                         "inserted_count": response.inserted_count,
                         "tx_ids": tx_ids,
                         "canonical_rows": canonical_rows,
-                    }
-                }],
+                    }))],
                 "isError": false
             })
         }
@@ -673,16 +682,13 @@ pub fn handle_ingest_statement_rows<T: TurboLedgerTools>(
                 response.tx_ids
             };
             json!({
-                "content": [{
-                    "type": "json",
-                    "json": {
+                "content": [text_content(json!({
                         "inserted_count": response.inserted_count,
                         "tx_ids": tx_ids,
                         "canonical_rows": canonical_rows,
                         "provider": "rustledger",
                         "backend_tool": "ingest_statement_rows",
-                    }
-                }],
+                    }))],
                 "isError": false
             })
         }
@@ -698,13 +704,10 @@ pub fn handle_ontology_query_path(service: &TurboLedgerService, arguments: &Valu
 
     match service.ontology_query_path_tool(request) {
         Ok(response) => json!({
-            "content": [{
-                "type": "json",
-                "json": {
+            "content": [text_content(json!({
                     "nodes": response.nodes,
                     "edges": response.edges,
-                }
-            }],
+                }))],
             "isError": false
         }),
         Err(err) => error_envelope(&err),
@@ -719,17 +722,14 @@ pub fn handle_ontology_export_snapshot(service: &TurboLedgerService, arguments: 
 
     match service.ontology_export_snapshot(OntologyExportSnapshotRequest { ontology_path }) {
         Ok(response) => json!({
-            "content": [{
-                "type": "json",
-                "json": {
+            "content": [text_content(json!({
                     "entities": response.entities,
                     "edges": response.edges,
                     "snapshot": {
                         "entity_count": response.entity_count,
                         "edge_count": response.edge_count,
                     }
-                }
-            }],
+                }))],
             "isError": false
         }),
         Err(err) => error_envelope(&err),
@@ -790,10 +790,7 @@ pub fn dispatch_reconciliation(
             };
 
             json!({
-                "content": [{
-                    "type": "json",
-                    "json": payload
-                }],
+                "content": [text_content(payload)],
                 "isError": blocked
             })
         }
@@ -835,10 +832,7 @@ pub fn dispatch_hsm(service: &TurboLedgerService, tool_name: &str, arguments: &V
                         })
                     };
                     json!({
-                        "content": [{
-                            "type": "json",
-                            "json": payload
-                        }],
+                        "content": [text_content(payload)],
                         "isError": blocked
                     })
                 }
@@ -847,17 +841,14 @@ pub fn dispatch_hsm(service: &TurboLedgerService, tool_name: &str, arguments: &V
         }
         HSM_STATUS_TOOL => match service.hsm_status_tool(HsmStatusRequest) {
             Ok(response) => json!({
-                "content": [{
-                    "type": "json",
-                    "json": {
+                "content": [text_content(json!({
                         "state": response.state,
                         "substate": response.substate,
                         "display_state": response.display_state,
                         "next_hint": response.next_hint,
                         "resume_hint": response.resume_hint,
                         "blockers": response.blockers,
-                    }
-                }],
+                    }))],
                 "isError": false
             }),
             Err(err) => error_envelope(&err),
@@ -890,10 +881,7 @@ pub fn dispatch_hsm(service: &TurboLedgerService, tool_name: &str, arguments: &V
                         })
                     };
                     json!({
-                        "content": [{
-                            "type": "json",
-                            "json": payload
-                        }],
+                        "content": [text_content(payload)],
                         "isError": blocked
                     })
                 }
@@ -930,9 +918,7 @@ pub fn handle_event_history(service: &TurboLedgerService, arguments: &Value) -> 
                 .collect::<Vec<_>>();
 
             json!({
-                "content": [{
-                    "type": "json",
-                    "json": {
+                "content": [text_content(json!({
                         "filter": {
                             "tx_id": filter.tx_id,
                             "document_ref": filter.document_ref,
@@ -940,8 +926,7 @@ pub fn handle_event_history(service: &TurboLedgerService, arguments: &Value) -> 
                             "time_end": filter.time_end,
                         },
                         "events": events,
-                    }
-                }],
+                    }))],
                 "isError": false
             })
         }
@@ -949,15 +934,12 @@ pub fn handle_event_history(service: &TurboLedgerService, arguments: &Value) -> 
             if message.contains("time_start must be <= time_end") =>
         {
             json!({
-                "content": [{
-                    "type": "json",
-                    "json": {
+                "content": [text_content(json!({
                         "isError": true,
                         "error_type": "EventHistoryBlocked",
                         "reason": "time_range_invalid",
                         "message": message,
-                    }
-                }],
+                    }))],
                 "isError": true
             })
         }
@@ -973,9 +955,7 @@ pub fn handle_event_replay(service: &TurboLedgerService, arguments: &Value) -> V
 
     match service.replay_lifecycle(request) {
         Ok(response) => json!({
-            "content": [{
-                "type": "json",
-                "json": {
+            "content": [text_content(json!({
                     "reconstructed_state": response.reconstructed_state,
                     "event_count": response.event_count,
                     "diagnostics": response.diagnostics,
@@ -985,8 +965,7 @@ pub fn handle_event_replay(service: &TurboLedgerService, arguments: &Value) -> V
                         "time_start": response.filter.time_start,
                         "time_end": response.filter.time_end,
                     }
-                }
-            }],
+                }))],
             "isError": false
         }),
         Err(err) => error_envelope(&err),
@@ -1027,10 +1006,7 @@ pub fn handle_tax_assist(service: &TurboLedgerService, arguments: &Value) -> Val
                 })
             };
             json!({
-                "content": [{
-                    "type": "json",
-                    "json": payload
-                }],
+                "content": [text_content(payload)],
                 "isError": blocked
             })
         }
@@ -1046,15 +1022,12 @@ pub fn handle_tax_evidence_chain(service: &TurboLedgerService, arguments: &Value
 
     match service.tax_evidence_chain_tool(request) {
         Ok(response) => json!({
-            "content": [{
-                "type": "json",
-                "json": {
+            "content": [text_content(json!({
                     "source": response.source,
                     "events": response.events,
                     "current_state": response.current_state,
                     "ambiguity": response.ambiguity,
-                }
-            }],
+                }))],
             "isError": false
         }),
         Err(err) => error_envelope(&err),
@@ -1089,10 +1062,7 @@ pub fn handle_tax_ambiguity_review(service: &TurboLedgerService, arguments: &Val
                 })
             };
             json!({
-                "content": [{
-                    "type": "json",
-                    "json": payload
-                }],
+                "content": [text_content(payload)],
                 "isError": blocked
             })
         }
@@ -1122,10 +1092,7 @@ pub fn handle_classify_ingested(service: &TurboLedgerService, arguments: &Value)
                 })
                 .collect::<Vec<_>>();
             json!({
-                "content": [{
-                    "type": "json",
-                    "json": { "classifications": classifications }
-                }],
+                "content": [text_content(json!({ "classifications": classifications }))],
                 "isError": false
             })
         }
@@ -1159,10 +1126,7 @@ pub fn handle_query_flags(service: &TurboLedgerService, arguments: &Value) -> Va
                 })
                 .collect::<Vec<_>>();
             json!({
-                "content": [{
-                    "type": "json",
-                    "json": { "flags": flags }
-                }],
+                "content": [text_content(json!({ "flags": flags }))],
                 "isError": false
             })
         }
@@ -1194,10 +1158,7 @@ pub fn handle_query_audit_log(service: &TurboLedgerService, arguments: &Value) -
                 })
                 .collect::<Vec<_>>();
             json!({
-                "content": [{
-                    "type": "json",
-                    "json": { "entries": entries }
-                }],
+                "content": [text_content(json!({ "entries": entries }))],
                 "isError": false
             })
         }
@@ -1229,15 +1190,12 @@ pub fn handle_classify_transaction(service: &TurboLedgerService, arguments: &Val
                 })
                 .collect::<Vec<_>>();
             json!({
-                "content": [{
-                    "type": "json",
-                    "json": {
+                "content": [text_content(json!({
                         "tx_id": response.tx_id,
                         "category": response.category,
                         "confidence": response.confidence,
                         "audit_entries": audit_entries,
-                    }
-                }],
+                    }))],
                 "isError": false
             })
         }
@@ -1272,15 +1230,12 @@ pub fn handle_reconcile_excel_classification(
                 })
                 .collect::<Vec<_>>();
             json!({
-                "content": [{
-                    "type": "json",
-                    "json": {
+                "content": [text_content(json!({
                         "tx_id": response.tx_id,
                         "category": response.category,
                         "confidence": response.confidence,
                         "audit_entries": audit_entries,
-                    }
-                }],
+                    }))],
                 "isError": false
             })
         }
@@ -1313,15 +1268,12 @@ pub fn handle_get_schedule_summary(service: &TurboLedgerService, arguments: &Val
                 })
                 .collect::<Vec<_>>();
             json!({
-                "content": [{
-                    "type": "json",
-                    "json": {
+                "content": [text_content(json!({
                         "year": response.year,
                         "schedule": schedule_str,
                         "total": response.total,
                         "lines": lines,
-                    }
-                }],
+                    }))],
                 "isError": false
             })
         }
@@ -1337,10 +1289,7 @@ pub fn handle_export_cpa_workbook(service: &TurboLedgerService, arguments: &Valu
 
     match service.export_cpa_workbook(request) {
         Ok(response) => json!({
-            "content": [{
-                "type": "json",
-                "json": { "sheets_written": response.sheets_written }
-            }],
+            "content": [text_content(json!({ "sheets_written": response.sheets_written }))],
             "isError": false
         }),
         Err(err) => error_envelope(&err),
@@ -1358,10 +1307,7 @@ pub fn handle_ontology_upsert_entities(
 
     match service.ontology_upsert_entities_tool(request) {
         Ok(response) => json!({
-            "content": [{
-                "type": "json",
-                "json": { "upserted": response.inserted_count }
-            }],
+            "content": [text_content(json!({ "upserted": response.inserted_count }))],
             "isError": false
         }),
         Err(err) => error_envelope(&err),
@@ -1376,10 +1322,7 @@ pub fn handle_ontology_upsert_edges(service: &TurboLedgerService, arguments: &Va
 
     match service.ontology_upsert_edges_tool(request) {
         Ok(response) => json!({
-            "content": [{
-                "type": "json",
-                "json": { "upserted": response.inserted_count }
-            }],
+            "content": [text_content(json!({ "upserted": response.inserted_count }))],
             "isError": false
         }),
         Err(err) => error_envelope(&err),

--- a/crates/ledgerr-mcp/tests/events_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/events_mcp_e2e.rs
@@ -3,6 +3,11 @@ use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 
 use serde_json::{json, Value};
 
+fn parse_response_payload(response: &Value) -> Value {
+    let text = response["content"][0]["text"].as_str().unwrap_or("null");
+    serde_json::from_str(text).unwrap_or(Value::Null)
+}
+
 const EVENT_REPLAY_TOOL: &str = "l3dg3rr_event_replay";
 const EVENT_HISTORY_TOOL: &str = "l3dg3rr_event_history";
 
@@ -116,10 +121,8 @@ fn ingest_one_row(
         }),
     );
     assert_eq!(ingest["result"]["isError"], Value::Bool(false));
-    ingest["result"]["content"][0]["json"]["tx_ids"][0]
-        .as_str()
-        .unwrap_or_default()
-        .to_string()
+    let p = parse_response_payload(&ingest["result"]);
+    p["tx_ids"][0].as_str().unwrap_or_default().to_string()
 }
 
 #[test]
@@ -161,7 +164,7 @@ fn evt_03_event_history_filtering_by_tx_document_and_time_is_deterministic() {
     );
     assert_eq!(history["result"]["isError"], Value::Bool(false));
 
-    let payload = &history["result"]["content"][0]["json"];
+    let payload = parse_response_payload(&history["result"]);
     assert_eq!(payload["filter"]["document_ref"], json!("source/a.rkyv"));
     let events = payload["events"].as_array().expect("events");
     assert!(!events.is_empty());
@@ -192,7 +195,7 @@ fn evt_03_invalid_filter_range_returns_deterministic_blocked_envelope() {
         }),
     );
     assert_eq!(response["result"]["isError"], Value::Bool(true));
-    let payload = &response["result"]["content"][0]["json"];
+    let payload = parse_response_payload(&response["result"]);
     assert_eq!(payload["error_type"], json!("EventHistoryBlocked"));
     assert_eq!(payload["reason"], json!("time_range_invalid"));
 }

--- a/crates/ledgerr-mcp/tests/hsm_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/hsm_mcp_e2e.rs
@@ -93,6 +93,12 @@ fn initialize_client(client: &mut McpStdioClient) {
     client.send_notification_initialized();
 }
 
+
+fn parse_response_payload(response: &serde_json::Value) -> serde_json::Value {
+    let text = response["content"][0]["text"].as_str().unwrap_or("null");
+    serde_json::from_str(text).unwrap_or(serde_json::Value::Null)
+}
+
 #[test]
 fn hsm_03_tools_list_includes_transition_status_and_resume_tools() {
     let mut client = McpStdioClient::spawn();
@@ -127,7 +133,7 @@ fn hsm_03_invalid_transition_and_resume_return_deterministic_blocked_payloads() 
         }),
     );
     assert_eq!(transition["result"]["isError"], Value::Bool(true));
-    let blocked_transition = &transition["result"]["content"][0]["json"];
+    let blocked_transition = parse_response_payload(&transition["result"]);
     assert_eq!(
         blocked_transition["error_type"],
         json!("HsmTransitionBlocked")
@@ -155,7 +161,7 @@ fn hsm_03_invalid_transition_and_resume_return_deterministic_blocked_payloads() 
         }),
     );
     assert_eq!(resume["result"]["isError"], Value::Bool(true));
-    let blocked_resume = &resume["result"]["content"][0]["json"];
+    let blocked_resume = parse_response_payload(&resume["result"]);
     assert_eq!(blocked_resume["error_type"], json!("HsmResumeBlocked"));
     assert_eq!(blocked_resume["blockers"], json!(["checkpoint_unknown"]));
 }
@@ -173,7 +179,7 @@ fn hsm_03_status_and_resume_payload_include_small_model_hint_fields() {
         }),
     );
     assert_eq!(status["result"]["isError"], Value::Bool(false));
-    let status_payload = &status["result"]["content"][0]["json"];
+    let status_payload = parse_response_payload(&status["result"]);
     assert_eq!(status_payload["display_state"], json!("ingest.pending"));
     assert_eq!(status_payload["next_hint"], json!("advance_to_normalize"));
     assert_eq!(
@@ -192,7 +198,7 @@ fn hsm_03_status_and_resume_payload_include_small_model_hint_fields() {
         }),
     );
     assert_eq!(resume["result"]["isError"], Value::Bool(false));
-    let resume_payload = &resume["result"]["content"][0]["json"];
+    let resume_payload = parse_response_payload(&resume["result"]);
     assert_eq!(
         resume_payload["resume_from"],
         json!("ingest:pending:advanced")

--- a/crates/ledgerr-mcp/tests/mcp_stdio_e2e.rs
+++ b/crates/ledgerr-mcp/tests/mcp_stdio_e2e.rs
@@ -129,6 +129,12 @@ fn build_rustledger_rows_arguments(base_dir: &std::path::Path) -> Value {
 }
 
 // DOC-01: ingest path must be executable through MCP tools/call only.
+
+fn parse_response_payload(response: &serde_json::Value) -> serde_json::Value {
+    let text = response["content"][0]["text"].as_str().unwrap_or("null");
+    serde_json::from_str(text).unwrap_or(serde_json::Value::Null)
+}
+
 #[test]
 fn doc_01_mcp_only_ingest_via_tools_call() {
     let mut client = McpStdioClient::spawn();
@@ -154,11 +160,11 @@ fn doc_01_mcp_only_ingest_via_tools_call() {
 
     assert_eq!(call["result"]["isError"], Value::Bool(false));
     assert_eq!(
-        call["result"]["content"][0]["json"]["inserted_count"],
+        parse_response_payload(&call["result"])["inserted_count"],
         json!(1)
     );
     assert!(
-        call["result"]["content"][0]["json"]["tx_ids"]
+        parse_response_payload(&call["result"])["tx_ids"]
             .as_array()
             .expect("tx_ids array")
             .len()
@@ -181,7 +187,8 @@ fn doc_02_canonical_mapping_and_provenance_fields_over_transport() {
         }),
     );
 
-    let canonical = &call["result"]["content"][0]["json"]["canonical_rows"][0];
+    let p = parse_response_payload(&call["result"]);
+    let canonical = &p["canonical_rows"][0];
     assert!(canonical.get("account").is_some());
     assert!(canonical.get("date").is_some());
     assert!(canonical.get("amount").is_some());
@@ -217,20 +224,18 @@ fn doc_03_replay_idempotent_with_stable_tx_ids_over_mcp() {
     );
 
     assert_eq!(
-        first["result"]["content"][0]["json"]["inserted_count"],
+        parse_response_payload(&first["result"])["inserted_count"],
         json!(1)
     );
     assert_eq!(
-        second["result"]["content"][0]["json"]["inserted_count"],
+        parse_response_payload(&second["result"])["inserted_count"],
         json!(0)
     );
 
-    let first_ids = first["result"]["content"][0]["json"]["tx_ids"]
-        .as_array()
-        .expect("first tx ids");
-    let second_ids = second["result"]["content"][0]["json"]["tx_ids"]
-        .as_array()
-        .expect("second tx ids");
+    let fp = parse_response_payload(&first["result"]);
+    let first_ids = fp["tx_ids"].as_array().expect("first tx ids");
+    let sp = parse_response_payload(&second["result"]);
+    let second_ids = sp["tx_ids"].as_array().expect("second tx ids");
     assert_eq!(first_ids, second_ids);
 }
 
@@ -267,23 +272,21 @@ fn rustledger_proxy_ingest_statement_rows_over_transport() {
 
     assert_eq!(first["result"]["isError"], Value::Bool(false));
     assert_eq!(
-        first["result"]["content"][0]["json"]["inserted_count"],
+        parse_response_payload(&first["result"])["inserted_count"],
         json!(1)
     );
     assert_eq!(
-        second["result"]["content"][0]["json"]["inserted_count"],
+        parse_response_payload(&second["result"])["inserted_count"],
         json!(0)
     );
 
-    let first_ids = first["result"]["content"][0]["json"]["tx_ids"]
-        .as_array()
-        .expect("first tx ids");
-    let second_ids = second["result"]["content"][0]["json"]["tx_ids"]
-        .as_array()
-        .expect("second tx ids");
+    let fp2 = parse_response_payload(&first["result"]);
+    let first_ids = fp2["tx_ids"].as_array().expect("first tx ids");
+    let sp2 = parse_response_payload(&second["result"]);
+    let second_ids = sp2["tx_ids"].as_array().expect("second tx ids");
     assert_eq!(first_ids, second_ids);
 
-    let canonical = &first["result"]["content"][0]["json"]["canonical_rows"][0];
+    let canonical = &fp2["canonical_rows"][0];
     assert_eq!(canonical["provider"], json!("rustledger"));
     assert_eq!(canonical["backend_tool"], json!("ingest_statement_rows"));
     assert!(canonical.get("account").is_some());
@@ -319,9 +322,8 @@ fn mcp_lists_and_calls_accounts_and_raw_context_tools() {
         }),
     );
     assert_eq!(list_accounts["result"]["isError"], Value::Bool(false));
-    let accounts = list_accounts["result"]["content"][0]["json"]["accounts"]
-        .as_array()
-        .expect("accounts array");
+    let accounts_p = parse_response_payload(&list_accounts["result"]);
+    let accounts = accounts_p["accounts"].as_array().expect("accounts array");
     assert!(!accounts.is_empty());
     assert!(accounts
         .iter()
@@ -351,7 +353,7 @@ fn mcp_lists_and_calls_accounts_and_raw_context_tools() {
     );
     assert_eq!(raw_context["result"]["isError"], Value::Bool(false));
     assert_eq!(
-        raw_context["result"]["content"][0]["json"]["bytes"],
+        parse_response_payload(&raw_context["result"])["bytes"],
         json!([99, 116, 120])
     );
 }

--- a/crates/ledgerr-mcp/tests/ontology_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/ontology_mcp_e2e.rs
@@ -171,6 +171,12 @@ fn seed_ontology(path: &std::path::Path) -> (String, String, String, String) {
 }
 
 // ONTO-03 (D-03): tools/list advertises ontology query/export transport surfaces.
+
+fn parse_response_payload(response: &serde_json::Value) -> serde_json::Value {
+    let text = response["content"][0]["text"].as_str().unwrap_or("null");
+    serde_json::from_str(text).unwrap_or(serde_json::Value::Null)
+}
+
 #[test]
 fn onto_03_tools_list_advertises_ontology_query_and_export_tools() {
     let mut client = McpStdioClient::spawn();
@@ -212,7 +218,7 @@ fn onto_03_tools_call_query_and_export_snapshot_payloads_are_deterministic() {
 
     assert_eq!(query["result"]["isError"], Value::Bool(false));
 
-    let query_json = &query["result"]["content"][0]["json"];
+    let query_json = parse_response_payload(&query["result"]);
     let node_ids = query_json["nodes"]
         .as_array()
         .expect("nodes array")
@@ -233,7 +239,7 @@ fn onto_03_tools_call_query_and_export_snapshot_payloads_are_deterministic() {
 
     assert_eq!(export["result"]["isError"], Value::Bool(false));
 
-    let export_json = &export["result"]["content"][0]["json"];
+    let export_json = parse_response_payload(&export["result"]);
     let entity_kinds = export_json["entities"]
         .as_array()
         .expect("entities array")
@@ -298,9 +304,9 @@ fn onto_03_export_snapshot_stable_json_serialization_over_transport() {
     assert_eq!(first["result"]["isError"], Value::Bool(false));
     assert_eq!(second["result"]["isError"], Value::Bool(false));
 
-    let first_payload = serde_json::to_string(&first["result"]["content"][0]["json"])
+    let first_payload = serde_json::to_string(&parse_response_payload(&first["result"]))
         .expect("serialize first payload");
-    let second_payload = serde_json::to_string(&second["result"]["content"][0]["json"])
+    let second_payload = serde_json::to_string(&parse_response_payload(&second["result"]))
         .expect("serialize second payload");
 
     assert_eq!(first_payload, second_payload);
@@ -337,7 +343,7 @@ fn onto_03_export_snapshot_routes_through_service() {
     let result = mcp_adapter::handle_ontology_export_snapshot(&service, &args);
 
     assert_eq!(result["isError"], Value::Bool(false));
-    let json_payload = &result["content"][0]["json"];
+    let json_payload = parse_response_payload(&result);
     assert!(json_payload["entities"].is_array());
     assert!(json_payload["edges"].is_array());
     assert_eq!(

--- a/crates/ledgerr-mcp/tests/phase6_mcp_exposure_gaps.rs
+++ b/crates/ledgerr-mcp/tests/phase6_mcp_exposure_gaps.rs
@@ -129,7 +129,7 @@ fn ingest_one_tx(client: &mut McpClient, dir: &tempfile::TempDir) -> String {
         Value::Bool(false),
         "setup ingest must succeed"
     );
-    result["result"]["content"][0]["json"]["tx_ids"][0]
+    parse_response_payload(&result["result"])["tx_ids"][0]
         .as_str()
         .expect("tx_id")
         .to_owned()
@@ -201,7 +201,7 @@ fn p0_classify_ingested_call_returns_success() {
         "P0: l3dg3rr_classify_ingested must succeed, got:\n{}",
         serde_json::to_string_pretty(&result).unwrap_or_default()
     );
-    let classifications = result["result"]["content"][0]["json"]["classifications"]
+    let classifications = parse_response_payload(&result["result"])["classifications"]
         .as_array()
         .expect("classifications array must be present");
     assert_eq!(
@@ -263,7 +263,7 @@ fn p0_query_flags_call_returns_open_review_queue() {
         "P0: l3dg3rr_query_flags must succeed, got:\n{}",
         serde_json::to_string_pretty(&result).unwrap_or_default()
     );
-    let flags = result["result"]["content"][0]["json"]["flags"]
+    let flags = parse_response_payload(&result["result"])["flags"]
         .as_array()
         .expect("flags array must be present");
     assert_eq!(
@@ -327,7 +327,7 @@ fn p0_query_audit_log_call_returns_audit_entries() {
         "P0: l3dg3rr_query_audit_log must succeed, got:\n{}",
         serde_json::to_string_pretty(&result).unwrap_or_default()
     );
-    let entries = result["result"]["content"][0]["json"]["entries"]
+    let entries = parse_response_payload(&result["result"])["entries"]
         .as_array()
         .expect("entries array must be present");
     assert!(
@@ -383,11 +383,11 @@ fn p1_classify_transaction_call_persists_and_returns_audit() {
         serde_json::to_string_pretty(&result).unwrap_or_default()
     );
     assert_eq!(
-        result["result"]["content"][0]["json"]["category"],
+        parse_response_payload(&result["result"])["category"],
         json!("OfficeSupplies"),
         "P1: category must be persisted"
     );
-    let entries = result["result"]["content"][0]["json"]["audit_entries"]
+    let entries = parse_response_payload(&result["result"])["audit_entries"]
         .as_array()
         .expect("audit_entries must be present");
     assert!(
@@ -444,7 +444,7 @@ fn p1_reconcile_excel_classification_call_returns_updated_category() {
         serde_json::to_string_pretty(&result).unwrap_or_default()
     );
     assert_eq!(
-        result["result"]["content"][0]["json"]["category"],
+        parse_response_payload(&result["result"])["category"],
         json!("Travel"),
         "P1: Excel-reconciled category must be persisted"
     );
@@ -505,7 +505,7 @@ fn p1_get_schedule_summary_call_returns_schedule_c_payload() {
         "P1: l3dg3rr_get_schedule_summary must succeed, got:\n{}",
         serde_json::to_string_pretty(&result).unwrap_or_default()
     );
-    let json = &result["result"]["content"][0]["json"];
+    let json = parse_response_payload(&result["result"]);
     assert_eq!(json["year"], json!(2023), "P1: year must be present");
     assert_eq!(
         json["schedule"],
@@ -571,7 +571,7 @@ fn p2_export_cpa_workbook_call_produces_workbook() {
         "P2: l3dg3rr_export_cpa_workbook must succeed, got:\n{}",
         serde_json::to_string_pretty(&result).unwrap_or_default()
     );
-    let sheets_written = result["result"]["content"][0]["json"]["sheets_written"]
+    let sheets_written = parse_response_payload(&result["result"])["sheets_written"]
         .as_u64()
         .expect("sheets_written must be a number");
     assert!(sheets_written > 0, "P2: at least one sheet must be written");
@@ -644,7 +644,7 @@ fn p2_ontology_upsert_entities_call_persists_entity() {
         "P2: l3dg3rr_ontology_upsert_entities must succeed, got:\n{}",
         serde_json::to_string_pretty(&result).unwrap_or_default()
     );
-    let upserted = result["result"]["content"][0]["json"]["upserted"]
+    let upserted = parse_response_payload(&result["result"])["upserted"]
         .as_u64()
         .expect("upserted count must be present");
     assert_eq!(upserted, 1, "P2: one entity must be reported as upserted");
@@ -695,7 +695,7 @@ fn p2_ontology_upsert_edges_call_persists_edge() {
         "P2: l3dg3rr_ontology_upsert_edges must succeed, got:\n{}",
         serde_json::to_string_pretty(&result).unwrap_or_default()
     );
-    let upserted = result["result"]["content"][0]["json"]["upserted"]
+    let upserted = parse_response_payload(&result["result"])["upserted"]
         .as_u64()
         .expect("upserted edge count must be present");
     assert_eq!(upserted, 1, "P2: one edge must be reported as upserted");

--- a/crates/ledgerr-mcp/tests/reconciliation_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/reconciliation_mcp_e2e.rs
@@ -109,6 +109,12 @@ fn imbalanced_request() -> Value {
     })
 }
 
+
+fn parse_response_payload(response: &serde_json::Value) -> serde_json::Value {
+    let text = response["content"][0]["text"].as_str().unwrap_or("null");
+    serde_json::from_str(text).unwrap_or(serde_json::Value::Null)
+}
+
 #[test]
 fn recon_03_tools_list_includes_reconciliation_stage_tools() {
     let mut client = McpStdioClient::spawn();
@@ -141,7 +147,7 @@ fn recon_03_failing_commit_returns_deterministic_blocking_diagnostics() {
     );
 
     assert_eq!(commit["result"]["isError"], Value::Bool(true));
-    let payload = &commit["result"]["content"][0]["json"];
+    let payload = parse_response_payload(&commit["result"]);
     assert_eq!(payload["error_type"], json!("ReconciliationBlocked"));
     assert_eq!(
         payload["message"],
@@ -169,11 +175,11 @@ fn recon_03_validate_and_reconcile_then_commit_returns_explicit_ready_payload() 
     );
     assert_eq!(validate["result"]["isError"], Value::Bool(false));
     assert_eq!(
-        validate["result"]["content"][0]["json"]["stage"],
+        parse_response_payload(&validate["result"])["stage"],
         json!("validate")
     );
     assert_eq!(
-        validate["result"]["content"][0]["json"]["status"],
+        parse_response_payload(&validate["result"])["status"],
         json!("passed")
     );
 
@@ -186,11 +192,11 @@ fn recon_03_validate_and_reconcile_then_commit_returns_explicit_ready_payload() 
     );
     assert_eq!(reconcile["result"]["isError"], Value::Bool(false));
     assert_eq!(
-        reconcile["result"]["content"][0]["json"]["stage"],
+        parse_response_payload(&reconcile["result"])["stage"],
         json!("reconcile")
     );
     assert_eq!(
-        reconcile["result"]["content"][0]["json"]["status"],
+        parse_response_payload(&reconcile["result"])["status"],
         json!("passed")
     );
 
@@ -203,7 +209,7 @@ fn recon_03_validate_and_reconcile_then_commit_returns_explicit_ready_payload() 
     );
     assert_eq!(commit["result"]["isError"], Value::Bool(false));
 
-    let payload = &commit["result"]["content"][0]["json"];
+    let payload = parse_response_payload(&commit["result"]);
     assert_eq!(payload["stage"], json!("commit"));
     assert_eq!(payload["status"], json!("ready"));
     assert_eq!(

--- a/crates/ledgerr-mcp/tests/tax_assist_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/tax_assist_mcp_e2e.rs
@@ -193,6 +193,12 @@ fn ingest_one_row(client: &mut McpStdioClient) {
     assert_eq!(ingest["result"]["isError"], Value::Bool(false));
 }
 
+
+fn parse_response_payload(response: &serde_json::Value) -> serde_json::Value {
+    let text = response["content"][0]["text"].as_str().unwrap_or("null");
+    serde_json::from_str(text).unwrap_or(serde_json::Value::Null)
+}
+
 #[test]
 fn taxa_mcp_tools_list_advertises_tax_tools() {
     let mut client = McpStdioClient::spawn();
@@ -237,7 +243,7 @@ fn taxa_mcp_tools_call_return_deterministic_tax_assist_and_evidence_chain_sectio
         }),
     );
     assert_eq!(assist["result"]["isError"], Value::Bool(false));
-    let assist_payload = &assist["result"]["content"][0]["json"];
+    let assist_payload = parse_response_payload(&assist["result"]);
     assert!(assist_payload.get("summary").is_some());
     assert!(assist_payload.get("schedule_rows").is_some());
     assert!(assist_payload.get("fbar_rows").is_some());
@@ -255,7 +261,7 @@ fn taxa_mcp_tools_call_return_deterministic_tax_assist_and_evidence_chain_sectio
         }),
     );
     assert_eq!(chain["result"]["isError"], Value::Bool(false));
-    let chain_payload = &chain["result"]["content"][0]["json"];
+    let chain_payload = parse_response_payload(&chain["result"]);
     assert!(chain_payload.get("source").is_some());
     assert!(chain_payload.get("events").is_some());
     assert!(chain_payload.get("current_state").is_some());
@@ -286,7 +292,7 @@ fn taxa_mcp_ambiguity_review_payload_includes_provenance_and_review_state() {
         }),
     );
     assert_eq!(response["result"]["isError"], Value::Bool(false));
-    let payload = &response["result"]["content"][0]["json"];
+    let payload = parse_response_payload(&response["result"]);
     assert_eq!(payload["status"], json!("review_ready"));
     assert_eq!(
         payload["ambiguity"][0]["review_state"],

--- a/docs/bugs/BUG-003-invalid-content-type-json.md
+++ b/docs/bugs/BUG-003-invalid-content-type-json.md
@@ -1,0 +1,69 @@
+# BUG-003: All tools return non-spec content type `"json"` — P0
+
+**Severity**: P0  
+**Scope**: ALL tools (27 occurrences in `mcp_adapter.rs`)  
+**Detected via**: Live MCP tool calls through Cowork MCP bridge  
+
+## Repro
+
+Any tool call via MCP client (e.g. `l3dg3rr_list_accounts`, `l3dg3rr_get_pipeline_status`, etc.) returns:
+
+```json
+{
+  "content": [{"type": "json", "json": {...}}],
+  "isError": false
+}
+```
+
+MCP client rejects with Zod union validation error on `content[0]`:
+```
+invalid_union — path: ["content", 0]
+  type "json" not in [text, image, audio, resource_link, resource]
+```
+
+## Root Cause
+
+`mcp_adapter.rs` constructs all tool results with `"type": "json"` content blocks:
+```rust
+json!({
+    "content": [{"type": "json", "json": payload}],
+    "isError": false
+})
+```
+
+MCP 2025-11-25 spec defines only these content types for `CallToolResult`:
+- `text` — `{type: "text", text: string}`
+- `image` — `{type: "image", data: string, mimeType: string}`
+- `audio` — `{type: "audio", data: string, mimeType: string}`
+- `resource_link` — `{type: "resource_link", uri: string, name: string, ...}`
+- `resource` — embedded resource object
+
+`"json"` is NOT a valid content type in the spec.
+
+## Fix
+
+Replace every content block from:
+```rust
+{"type": "json", "json": payload}
+```
+to:
+```rust
+{"type": "text", "text": serde_json::to_string(&payload).unwrap_or_default()}
+```
+
+Or use a helper like:
+```rust
+fn json_content(payload: Value) -> Value {
+    json!({"type": "text", "text": payload.to_string()})
+}
+```
+
+There are **27 occurrences** across `mcp_adapter.rs` — all must be updated.
+
+## Impact
+
+**Complete protocol failure** — no tool is callable through any spec-compliant MCP client. The server appeared functional when tested via raw JSON-RPC in the shell (which doesn't validate content type), but fails at the Cowork/Claude MCP bridge layer which validates responses against the spec schema.
+
+## Files
+
+- `crates/ledgerr-mcp/src/mcp_adapter.rs` — all `json!({...content: [{type: json...}]...})` calls

--- a/docs/bugs/SUMMARY.md
+++ b/docs/bugs/SUMMARY.md
@@ -12,6 +12,7 @@
 |----|----------|------|-------|--------|
 | BUG-001 | P1 | `proxy_docling_ingest_pdf` | Schema required `source_ref`; impl required `pdf_path`+`journal_path`+`workbook_path` | ✅ Fixed — schema updated to match impl; `extracted_rows` made truly optional |
 | BUG-002 | P1 | `l3dg3rr_ontology_export_snapshot` | Schema advertised no params; impl required `ontology_path` | ✅ Fixed — schema updated; handler routed through `TurboLedgerService` |
+| BUG-003 | P0 | ALL tools (27) | All tools returned `"type": "json"` content blocks — not a valid MCP 2025-11-25 content type; rejected by spec-compliant clients | ✅ Fixed — all content blocks converted to `"type": "text"` with JSON serialized as string; `text_content()` helper centralises the pattern |
 
 ## Pass Results by Tool Group
 
@@ -26,6 +27,7 @@
 | Ontology (read) | `ontology_query_path`, `ontology_upsert_entities`, `ontology_upsert_edges` | ✅ Pass |
 | Ontology (export) | `ontology_export_snapshot` | ✅ Pass (BUG-002 fixed) |
 | Docling proxy | `proxy_docling_ingest_pdf` | ✅ Pass (BUG-001 fixed) |
+| All tools (content type) | all 27 tools | ✅ Pass (BUG-003 fixed) |
 
 ## Protocol Compliance
 


### PR DESCRIPTION
## Summary

- **P0 bug**: all 27 tool handlers returned `"type": "json"` content blocks. `json` is not a valid MCP 2025-11-25 content type — spec only allows `text`, `image`, `audio`, `resource_link`, `resource`. This caused Zod union validation failures in any spec-compliant MCP client (complete protocol failure via Cowork/Claude bridge).
- Added `text_content(payload: Value) -> Value` private helper that serializes the JSON payload to a string and wraps it in `{"type":"text","text":"..."}`.
- Replaced all 27 occurrences via the helper.
- Added `handle_pipeline_status()` to `mcp_adapter` — eliminated the last hand-rolled response envelope in `ledgerr-mcp-server.rs`.
- Updated all 8 affected test files: replaced `content[0]["json"]` access with a `parse_response_payload()` helper that deserializes from the `text` field.

## Test plan

- [x] `cargo test -p ledgerr-mcp` — 86 tests, 0 failures
- [x] Zero `"type": "json"` occurrences remain in `mcp_adapter.rs`
- [x] BUG-003 marked resolved in `docs/bugs/SUMMARY.md`
- [x] CHANGELOG updated with v1.3.8 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)