### PR TITLE
feat(plugin-info): add l3dg3rr_plugin_info MCP tool with Windows self-update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -91,7 +91,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -131,10 +131,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -399,6 +411,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,7 +547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -568,10 +586,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -590,8 +666,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -667,10 +745,211 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -691,6 +970,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -721,6 +1016,8 @@ version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -752,12 +1049,16 @@ dependencies = [
  "blake3",
  "calamine",
  "ledger-core",
+ "reqwest",
  "rust_decimal",
  "rust_xlsxwriter",
+ "semver",
  "serde",
  "serde_json",
+ "sysinfo",
  "tempfile",
  "thiserror",
+ "winreg",
 ]
 
 [[package]]
@@ -773,10 +1074,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rs"
@@ -813,6 +1126,26 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -856,6 +1189,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +1211,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -941,6 +1295,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,8 +1383,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -985,7 +1404,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -998,12 +1427,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1032,6 +1510,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1073,7 +1565,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -1090,6 +1582,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,7 +1597,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1107,6 +1640,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "seahash"
@@ -1173,6 +1712,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1764,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1785,22 @@ dependencies = [
  "static_assertions",
  "version_check",
 ]
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1270,6 +1843,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "windows",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,7 +1891,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1343,6 +1949,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,6 +1972,30 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
 
 [[package]]
 name = "toml"
@@ -1429,6 +2069,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,6 +2163,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,6 +2207,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1510,6 +2253,16 @@ dependencies = [
  "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1579,6 +2332,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,10 +2352,121 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1602,6 +2476,192 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -1619,6 +2679,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1710,6 +2780,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,6 +2817,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,6 +2860,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,6 +2894,39 @@ name = "zeroize_derive"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/ledgerr-mcp/Cargo.toml
+++ b/crates/ledgerr-mcp/Cargo.toml
@@ -13,6 +13,17 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 
+# plugin_info — always available (cross-platform system metadata)
+sysinfo = { version = "0.33", default-features = false, features = ["system"] }
+
+# self-update feature deps — only compiled when the feature is active
+reqwest = { version = "0.12", features = ["blocking", "rustls-tls"], default-features = false, optional = true }
+semver = { version = "1", optional = true }
+
+# winreg — Windows-only, safe registry wrapper; gated at the cfg level in code
+[target.'cfg(windows)'.dependencies]
+winreg = "0.52"
+
 [features]
 default = ["core", "events", "reconciliation", "hsm", "ontology", "classification", "audit", "tax"]
 core = []
@@ -24,6 +35,7 @@ classification = ["core"]
 audit = ["core"]
 tax = ["core"]
 full = ["core", "events", "reconciliation", "hsm", "ontology", "classification", "audit", "tax"]
+self-update = ["dep:reqwest", "dep:semver"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs
+++ b/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs
@@ -165,6 +165,10 @@ fn handle_request(request: Value) -> Option<Value> {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_ontology_upsert_edges(global_service(), &arguments)
                 }
+                mcp_adapter::PLUGIN_INFO_TOOL => {
+                    let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+                    mcp_adapter::handle_plugin_info(&arguments)
+                }
                 _ => mcp_adapter::unknown_tool_result(tool_name),
             };
             Some(json!({

--- a/crates/ledgerr-mcp/src/lib.rs
+++ b/crates/ledgerr-mcp/src/lib.rs
@@ -11,6 +11,7 @@ use rust_decimal::Decimal;
 use rust_xlsxwriter::Workbook;
 
 pub mod mcp_adapter;
+pub mod plugin_info;
 pub mod events;
 pub mod hsm;
 pub mod ontology;

--- a/crates/ledgerr-mcp/src/mcp_adapter.rs
+++ b/crates/ledgerr-mcp/src/mcp_adapter.rs
@@ -47,6 +47,9 @@ pub const EXPORT_CPA_WORKBOOK_TOOL: &str = "l3dg3rr_export_cpa_workbook";
 pub const ONTOLOGY_UPSERT_ENTITIES_TOOL: &str = "l3dg3rr_ontology_upsert_entities";
 pub const ONTOLOGY_UPSERT_EDGES_TOOL: &str = "l3dg3rr_ontology_upsert_edges";
 
+// Meta / self-management (always included regardless of feature flags)
+pub use crate::plugin_info::PLUGIN_INFO_TOOL;
+
 pub const TOOL_GROUP_CORE: &[&str] = &[
     LIST_ACCOUNTS_TOOL,
     GET_RAW_CONTEXT_TOOL,
@@ -133,6 +136,9 @@ pub fn tool_names_for(features: &[&str]) -> Vec<String> {
     if features.iter().any(|f| *f == "ontology") {
         tools.extend(TOOL_GROUP_ONTOLOGY_WRITE.iter().map(|s| s.to_string()));
     }
+
+    // plugin_info is always available — not gated by any feature flag.
+    tools.push(PLUGIN_INFO_TOOL.to_string());
 
     tools
 }
@@ -408,6 +414,9 @@ pub fn tool_input_schema(name: &str) -> Value {
             }
         }),
 
+        // ── plugin_info ───────────────────────────────────────────────────
+        PLUGIN_INFO_TOOL => crate::plugin_info::input_schema(),
+
         // ── unknown / future tools ────────────────────────────────────────
         _ => json!({ "type": "object" }),
     }
@@ -563,6 +572,16 @@ pub fn unknown_tool_result(tool_name: &str) -> Value {
                 "message": format!("unknown tool: {tool_name}")
             }))],
         "isError": true
+    })
+}
+
+/// Handle a `l3dg3rr_plugin_info` tool call.
+/// Wraps `crate::plugin_info::handle` in the standard MCP content envelope.
+pub fn handle_plugin_info(arguments: &Value) -> Value {
+    let payload = crate::plugin_info::handle(arguments);
+    json!({
+        "content": [text_content(payload)],
+        "isError": false
     })
 }
 

--- a/crates/ledgerr-mcp/src/plugin_info.rs
+++ b/crates/ledgerr-mcp/src/plugin_info.rs
@@ -1,0 +1,575 @@
+/// plugin_info — version check, host metadata, decision log, and (Windows-only) self-update.
+///
+/// The `plugin_info` MCP tool is always available and returns:
+///   - current embedded version
+///   - latest GitHub release version (when reachable)
+///   - whether an update is available
+///   - host system metadata
+///   - path to the decision/update log
+///
+/// Subcommands (passed as the optional `subcommand` argument):
+///   - `"check"` (default) — version info + host metadata
+///   - `"upgrade"` — Windows-only; downloads and applies the latest release
+///   - `"cleanup"` — removes `*.old.exe` and `*.new.exe` backup files
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{json, Value};
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+pub const PLUGIN_INFO_TOOL: &str = "l3dg3rr_plugin_info";
+
+const GITHUB_OWNER: &str = "PromptExecution";
+const GITHUB_REPO: &str = "l3dg3rr";
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+// ── Log path ──────────────────────────────────────────────────────────────────
+
+/// Returns the path to the NDJSON decision log.
+/// On Windows: `%APPDATA%\ledgerr-mcp\update.log`
+/// On other platforms: `~/.local/share/ledgerr-mcp/update.log`
+pub fn log_path() -> PathBuf {
+    #[cfg(target_os = "windows")]
+    let base = std::env::var("APPDATA")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir());
+    #[cfg(not(target_os = "windows"))]
+    let base = std::env::var("HOME")
+        .map(|h| PathBuf::from(h).join(".local").join("share"))
+        .unwrap_or_else(|_| std::env::temp_dir());
+
+    base.join("ledgerr-mcp").join("update.log")
+}
+
+// ── Update log ────────────────────────────────────────────────────────────────
+
+#[derive(serde::Serialize)]
+struct LogEntry<'a> {
+    ts: u64,
+    pid: u32,
+    event: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    old_version: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    new_version: Option<&'a str>,
+}
+
+/// Append a single NDJSON entry to the log file.  Best-effort — never panics.
+pub fn log_event(event: &str, detail: Option<&str>, old_ver: Option<&str>, new_ver: Option<&str>) {
+    use std::io::Write as _;
+
+    let path = log_path();
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let entry = LogEntry {
+        ts,
+        pid: std::process::id(),
+        event,
+        detail,
+        old_version: old_ver,
+        new_version: new_ver,
+    };
+    let Ok(mut line) = serde_json::to_string(&entry) else {
+        return;
+    };
+    line.push('\n');
+
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
+        let _ = f.write_all(line.as_bytes());
+    }
+}
+
+// ── Host metadata ─────────────────────────────────────────────────────────────
+
+/// Collect system metadata using `sysinfo` (cross-platform) plus
+/// Windows registry extras via `winreg` when on Windows.
+pub fn host_metadata() -> Value {
+    let exe_path = std::env::current_exe()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+
+    // sysinfo provides OS name/version, uptime, CPU count without any unsafe code.
+    let uptime_secs = sysinfo::System::uptime();
+    let os_name = sysinfo::System::name().unwrap_or_default();
+    let os_version = sysinfo::System::os_version().unwrap_or_default();
+    let kernel_version = sysinfo::System::kernel_version().unwrap_or_default();
+    let host_name = sysinfo::System::host_name().unwrap_or_default();
+    let cpu_count = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(0);
+
+    let mut meta = json!({
+        "os": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+        "family": std::env::consts::FAMILY,
+        "exe_path": exe_path,
+        "pid": std::process::id(),
+        "os_name": os_name,
+        "os_version": os_version,
+        "kernel_version": kernel_version,
+        "host_name": host_name,
+        "cpu_logical_cores": cpu_count,
+        "uptime_seconds": uptime_secs,
+    });
+
+    #[cfg(target_os = "windows")]
+    windows_registry_extras(&mut meta);
+
+    meta
+}
+
+/// Read additional Windows version strings from the registry via `winreg`.
+#[cfg(target_os = "windows")]
+fn windows_registry_extras(meta: &mut Value) {
+    use winreg::enums::HKEY_LOCAL_MACHINE;
+    use winreg::RegKey;
+
+    let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+    let obj = meta.as_object_mut().expect("meta is object");
+
+    if let Ok(key) = hklm.open_subkey("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion") {
+        let build: String = key.get_value("CurrentBuildNumber").unwrap_or_default();
+        let product: String = key.get_value("ProductName").unwrap_or_default();
+        let display: String = key.get_value("DisplayVersion").unwrap_or_default();
+        obj.insert("windows_build".to_string(), json!(build));
+        obj.insert("windows_product".to_string(), json!(product));
+        obj.insert("windows_display_version".to_string(), json!(display));
+    }
+}
+
+// ── GitHub release check ──────────────────────────────────────────────────────
+
+pub struct ReleaseInfo {
+    pub latest_tag: String,
+    pub download_url: Option<String>,
+}
+
+/// Returns `(current, latest_tag, update_available, download_url_opt)`.
+pub fn check_version() -> (String, String, bool, Option<String>) {
+    let current = CURRENT_VERSION.to_string();
+
+    #[cfg(feature = "self-update")]
+    {
+        if let Ok(info) = fetch_latest_release() {
+            let latest_clean = info.latest_tag.trim_start_matches('v').to_string();
+            let current_clean = current.trim_start_matches('v');
+            let newer = is_newer(&latest_clean, current_clean);
+            return (current, latest_clean, newer, info.download_url);
+        }
+    }
+
+    (current, "unknown".to_string(), false, None)
+}
+
+#[cfg(feature = "self-update")]
+fn fetch_latest_release() -> Result<ReleaseInfo, String> {
+    let url = format!(
+        "https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases/latest"
+    );
+    let client = reqwest::blocking::Client::builder()
+        .user_agent("ledgerr-mcp-self-update/1.0")
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let resp = client.get(&url).send().map_err(|e| e.to_string())?;
+    if !resp.status().is_success() {
+        return Err(format!("GitHub API returned {}", resp.status()));
+    }
+
+    let body: Value = resp.json().map_err(|e| e.to_string())?;
+    let tag = body["tag_name"]
+        .as_str()
+        .ok_or("missing tag_name")?
+        .to_string();
+
+    // Find the Windows exe asset.
+    let download_url = body["assets"]
+        .as_array()
+        .and_then(|assets| {
+            assets
+                .iter()
+                .find(|a| a["name"].as_str().map(|n| n.ends_with(".exe")).unwrap_or(false))
+        })
+        .and_then(|a| a["browser_download_url"].as_str())
+        .map(|s| s.to_string());
+
+    Ok(ReleaseInfo {
+        latest_tag: tag,
+        download_url,
+    })
+}
+
+/// Returns true when `latest` semver is strictly greater than `current`.
+/// Uses the `semver` crate when the `self-update` feature is active;
+/// falls back to a plain tuple comparison otherwise.
+pub fn is_newer(latest: &str, current: &str) -> bool {
+    #[cfg(feature = "self-update")]
+    {
+        use semver::Version;
+        match (Version::parse(latest), Version::parse(current)) {
+            (Ok(l), Ok(c)) => l > c,
+            _ => false,
+        }
+    }
+    #[cfg(not(feature = "self-update"))]
+    {
+        parse_ver(latest) > parse_ver(current)
+    }
+}
+
+#[cfg(not(feature = "self-update"))]
+fn parse_ver(v: &str) -> (u64, u64, u64) {
+    let mut parts = v.splitn(3, '.').map(|p| p.parse::<u64>().unwrap_or(0));
+    (
+        parts.next().unwrap_or(0),
+        parts.next().unwrap_or(0),
+        parts.next().unwrap_or(0),
+    )
+}
+
+// ── Subcommand: cleanup ───────────────────────────────────────────────────────
+
+/// Remove `*.old.exe` and `*.new.exe` sibling files next to the running binary.
+pub fn cleanup_old_binaries() -> Vec<String> {
+    let exe_dir = match std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+    {
+        Some(d) => d,
+        None => return vec!["error: could not determine exe directory".to_string()],
+    };
+
+    let Ok(entries) = std::fs::read_dir(&exe_dir) else {
+        return vec!["error: could not read exe directory".to_string()];
+    };
+
+    let mut removed = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        if name.contains(".old.exe") || name.ends_with(".new.exe") {
+            match std::fs::remove_file(&path) {
+                Ok(()) => {
+                    log_event("cleanup_removed", Some(name), None, None);
+                    removed.push(path.display().to_string());
+                }
+                Err(e) => removed.push(format!("error removing {}: {e}", path.display())),
+            }
+        }
+    }
+    removed
+}
+
+// ── Subcommand: upgrade (Windows + self-update feature only) ─────────────────
+
+#[cfg(all(target_os = "windows", feature = "self-update"))]
+pub fn perform_upgrade(download_url: &str, latest_version: &str) -> Value {
+    use std::io::Write as _;
+
+    log_event(
+        "upgrade_start",
+        Some(download_url),
+        Some(CURRENT_VERSION),
+        Some(latest_version),
+    );
+
+    let exe_path = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            log_event("upgrade_error", Some(&e.to_string()), None, None);
+            return json!({ "error": "could not determine current exe path", "detail": e.to_string() });
+        }
+    };
+    let exe_dir = exe_path.parent().expect("exe has parent");
+    let new_path = exe_dir.join("ledgerr-mcp-server.new.exe");
+    let old_path = exe_dir.join(format!("ledgerr-mcp-server-{CURRENT_VERSION}.old.exe"));
+
+    // Step 1: download to .new.exe
+    if let Err(e) = download_to(&new_path, download_url) {
+        log_event("upgrade_download_error", Some(&e), None, None);
+        return json!({ "error": "download failed", "detail": e });
+    }
+    log_event("upgrade_downloaded", Some(&new_path.display().to_string()), None, None);
+
+    // Step 2: strip Zone.Identifier ADS (Mark of the Web) so SmartScreen won't block execution.
+    strip_zone_identifier(&new_path);
+
+    // Step 3: hash the file twice with a short pause — if they differ, AV quarantined it.
+    let hash1 = blake3_file(&new_path);
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let hash2 = blake3_file(&new_path);
+    if hash1 != hash2 || hash1.is_empty() {
+        log_event(
+            "upgrade_hash_mismatch",
+            Some("file modified between hash checks — AV quarantine suspected"),
+            None,
+            None,
+        );
+        let _ = std::fs::remove_file(&new_path);
+        return json!({
+            "error": "hash instability detected — AV may have modified the download",
+            "detail": "retry after allowlisting the binary"
+        });
+    }
+    log_event("upgrade_hash_stable", Some(&hash1), None, None);
+
+    // Step 4: rename current exe → versioned .old.exe (Windows allows rename of running exe).
+    if let Err(e) = std::fs::rename(&exe_path, &old_path) {
+        log_event("upgrade_rename_old_error", Some(&e.to_string()), None, None);
+        let _ = std::fs::remove_file(&new_path);
+        return json!({ "error": "could not rename current binary to .old.exe", "detail": e.to_string() });
+    }
+    log_event("upgrade_renamed_old", Some(&old_path.display().to_string()), None, None);
+
+    // Step 5: rename .new.exe → current exe name.
+    if let Err(e) = std::fs::rename(&new_path, &exe_path) {
+        log_event("upgrade_rename_new_error", Some(&e.to_string()), None, None);
+        // Best-effort rollback.
+        let _ = std::fs::rename(&old_path, &exe_path);
+        return json!({ "error": "could not promote .new.exe (rolled back)", "detail": e.to_string() });
+    }
+    log_event(
+        "upgrade_complete",
+        Some(&exe_path.display().to_string()),
+        Some(CURRENT_VERSION),
+        Some(latest_version),
+    );
+
+    json!({
+        "status": "upgraded",
+        "old_version": CURRENT_VERSION,
+        "new_version": latest_version,
+        "old_binary": old_path.display().to_string(),
+        "note": "new binary is in place; restart the server to run the updated version"
+    })
+}
+
+#[cfg(all(target_os = "windows", feature = "self-update"))]
+fn download_to(dest: &std::path::Path, url: &str) -> Result<(), String> {
+    use std::io::Write as _;
+
+    let client = reqwest::blocking::Client::builder()
+        .user_agent("ledgerr-mcp-self-update/1.0")
+        .timeout(std::time::Duration::from_secs(120))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let mut resp = client.get(url).send().map_err(|e| e.to_string())?;
+    if !resp.status().is_success() {
+        return Err(format!("HTTP {}", resp.status()));
+    }
+    let mut f = std::fs::File::create(dest).map_err(|e| e.to_string())?;
+    resp.copy_to(&mut f).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Delete `<path>:Zone.Identifier` alternate data stream added by Windows to
+/// downloaded files.  Silently no-ops if the stream doesn't exist.
+#[cfg(target_os = "windows")]
+fn strip_zone_identifier(path: &std::path::Path) {
+    let ads = format!("{}:Zone.Identifier", path.display());
+    let _ = std::fs::remove_file(ads);
+}
+
+/// BLAKE3 hex digest of a file's contents; returns `""` on any I/O error.
+fn blake3_file(path: &std::path::Path) -> String {
+    std::fs::read(path)
+        .map(|bytes| blake3::hash(&bytes).to_hex().to_string())
+        .unwrap_or_default()
+}
+
+// ── Main dispatcher ───────────────────────────────────────────────────────────
+
+/// Entry point called from `mcp_adapter::handle_plugin_info`.
+///
+/// Accepts an optional `subcommand` field in `arguments`:
+/// - `"check"` (default) — version + host metadata
+/// - `"upgrade"` — self-update (Windows + `self-update` feature only)
+/// - `"cleanup"` — remove `.old.exe` / `.new.exe` backup files
+pub fn handle(arguments: &Value) -> Value {
+    match arguments
+        .get("subcommand")
+        .and_then(Value::as_str)
+        .unwrap_or("check")
+    {
+        "cleanup" => handle_cleanup(),
+        "upgrade" => handle_upgrade(),
+        _ => handle_check(),
+    }
+}
+
+fn handle_check() -> Value {
+    let (current, latest, update_available, _) = check_version();
+    log_event("plugin_info_check", None, Some(&current), Some(&latest));
+
+    json!({
+        "current_version": current,
+        "latest_version": latest,
+        "update_available": update_available,
+        "upgrade_hint": if update_available {
+            format!("call {PLUGIN_INFO_TOOL} with subcommand='upgrade' to update")
+        } else {
+            "no update available".to_string()
+        },
+        "log_path": log_path().display().to_string(),
+        "host": host_metadata(),
+    })
+}
+
+fn handle_cleanup() -> Value {
+    let removed = cleanup_old_binaries();
+    json!({
+        "removed": removed,
+        "count": removed.len(),
+        "log_path": log_path().display().to_string(),
+    })
+}
+
+fn handle_upgrade() -> Value {
+    #[cfg(all(target_os = "windows", feature = "self-update"))]
+    {
+        let (current, latest, update_available, download_url) = check_version();
+        if !update_available {
+            return json!({
+                "status": "already_current",
+                "version": current,
+                "latest": latest,
+            });
+        }
+        return match download_url {
+            Some(url) => perform_upgrade(&url, &latest),
+            None => json!({
+                "status": "error",
+                "error": "no Windows .exe asset found in latest release",
+                "latest_tag": latest,
+            }),
+        };
+    }
+
+    #[cfg(not(all(target_os = "windows", feature = "self-update")))]
+    json!({
+        "status": "not_supported",
+        "reason": "self-update requires a Windows build compiled with the self-update Cargo feature",
+        "current_version": CURRENT_VERSION,
+    })
+}
+
+// ── Tool schema ───────────────────────────────────────────────────────────────
+
+pub fn input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "subcommand": {
+                "type": "string",
+                "enum": ["check", "upgrade", "cleanup"],
+                "description": "Action: 'check' (default) returns version info and host metadata; 'upgrade' downloads and installs the latest release (Windows + self-update feature only); 'cleanup' removes *.old.exe backup files."
+            }
+        },
+        "required": []
+    })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_newer_returns_true_when_latest_greater() {
+        assert!(is_newer("1.4.0", "1.3.8"));
+        assert!(is_newer("2.0.0", "1.99.99"));
+        assert!(is_newer("1.3.9", "1.3.8"));
+    }
+
+    #[test]
+    fn is_newer_returns_false_when_same_or_older() {
+        assert!(!is_newer("1.3.8", "1.3.8"));
+        assert!(!is_newer("1.3.7", "1.3.8"));
+        assert!(!is_newer("0.1.0", "1.0.0"));
+    }
+
+    #[test]
+    fn log_path_is_non_empty() {
+        let p = log_path();
+        assert!(p.to_str().map(|s| !s.is_empty()).unwrap_or(false));
+        assert!(p.file_name().is_some());
+    }
+
+    #[test]
+    fn log_event_does_not_panic() {
+        log_event("test_event", Some("detail"), Some("0.1.0"), Some("0.2.0"));
+    }
+
+    #[test]
+    fn host_metadata_has_required_fields() {
+        let meta = host_metadata();
+        assert!(meta["os"].is_string());
+        assert!(meta["arch"].is_string());
+        assert!(meta["pid"].is_number());
+        assert!(meta["uptime_seconds"].is_number());
+    }
+
+    #[test]
+    fn handle_check_returns_expected_shape() {
+        let result = handle_check();
+        assert!(result["current_version"].is_string());
+        assert!(result["update_available"].is_boolean());
+        assert!(result["log_path"].is_string());
+        assert!(result["host"].is_object());
+    }
+
+    #[test]
+    fn handle_cleanup_returns_array() {
+        let result = handle_cleanup();
+        assert!(result["removed"].is_array());
+        assert!(result["count"].is_number());
+    }
+
+    #[test]
+    fn handle_upgrade_not_supported_without_windows_feature() {
+        #[cfg(not(all(target_os = "windows", feature = "self-update")))]
+        {
+            let result = handle_upgrade();
+            assert_eq!(result["status"], "not_supported");
+        }
+    }
+
+    #[test]
+    fn input_schema_valid_shape() {
+        let schema = input_schema();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["subcommand"]["enum"].is_array());
+    }
+
+    #[test]
+    fn blake3_file_empty_for_missing_path() {
+        assert_eq!(blake3_file(std::path::Path::new("/no/such/file.bin")), "");
+    }
+
+    #[test]
+    fn cleanup_old_binaries_no_panic() {
+        let _ = cleanup_old_binaries();
+    }
+
+    #[test]
+    fn handle_dispatches_to_check_by_default() {
+        let result = handle(&serde_json::Value::Object(Default::default()));
+        assert!(result["current_version"].is_string());
+    }
+}

--- a/crates/ledgerr-mcp/tests/plugin_info_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/plugin_info_mcp_e2e.rs
@@ -1,0 +1,266 @@
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+use serde_json::{json, Value};
+
+fn parse_response_payload(response: &Value) -> Value {
+    let text = response["content"][0]["text"].as_str().unwrap_or("null");
+    serde_json::from_str(text).unwrap_or(Value::Null)
+}
+
+const PLUGIN_INFO_TOOL: &str = "l3dg3rr_plugin_info";
+
+struct McpStdioClient {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: u64,
+}
+
+impl McpStdioClient {
+    fn spawn() -> Self {
+        let server_bin = env!("CARGO_BIN_EXE_ledgerr-mcp-server");
+        let mut child = Command::new(server_bin)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn ledgerr-mcp-server");
+        let stdin = child.stdin.take().expect("server stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("server stdout"));
+        Self { child, stdin, stdout, next_id: 1 }
+    }
+
+    fn request(&mut self, method: &str, params: Value) -> Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        let payload = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
+        self.send_and_read(payload)
+    }
+
+    fn send_notification_initialized(&mut self) {
+        let payload = json!({ "jsonrpc": "2.0", "method": "notifications/initialized", "params": {} });
+        let line = serde_json::to_string(&payload).expect("serialize");
+        writeln!(self.stdin, "{line}").expect("write");
+        self.stdin.flush().expect("flush");
+    }
+
+    fn send_and_read(&mut self, payload: Value) -> Value {
+        let line = serde_json::to_string(&payload).expect("serialize");
+        writeln!(self.stdin, "{line}").expect("write");
+        self.stdin.flush().expect("flush");
+        let mut response = String::new();
+        self.stdout.read_line(&mut response).expect("read");
+        serde_json::from_str::<Value>(response.trim()).expect("parse json")
+    }
+}
+
+impl Drop for McpStdioClient {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn initialize_client(client: &mut McpStdioClient) {
+    let resp = client.request(
+        "initialize",
+        json!({
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": { "name": "plugin-info-mcp-e2e", "version": "0.1.0" }
+        }),
+    );
+    assert!(resp.get("result").is_some(), "initialize must succeed");
+    client.send_notification_initialized();
+}
+
+// ── tools/list ────────────────────────────────────────────────────────────────
+
+#[test]
+fn pi_01_tools_list_advertises_plugin_info() {
+    let mut client = McpStdioClient::spawn();
+    initialize_client(&mut client);
+
+    let tools = client.request("tools/list", json!({}));
+    let names = tools["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|t| t["name"].as_str())
+        .collect::<Vec<_>>();
+
+    assert!(
+        names.contains(&PLUGIN_INFO_TOOL),
+        "tools/list must include {PLUGIN_INFO_TOOL}; got: {names:?}"
+    );
+}
+
+#[test]
+fn pi_01_plugin_info_schema_has_subcommand_enum() {
+    let mut client = McpStdioClient::spawn();
+    initialize_client(&mut client);
+
+    let tools = client.request("tools/list", json!({}));
+    let schema = tools["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .find(|t| t["name"] == PLUGIN_INFO_TOOL)
+        .expect("plugin_info in tools/list")["inputSchema"]
+        .clone();
+
+    let enum_values = schema["properties"]["subcommand"]["enum"]
+        .as_array()
+        .expect("subcommand enum");
+    let variants: Vec<&str> = enum_values.iter().filter_map(Value::as_str).collect();
+    assert!(variants.contains(&"check"));
+    assert!(variants.contains(&"upgrade"));
+    assert!(variants.contains(&"cleanup"));
+}
+
+// ── subcommand: check (default) ───────────────────────────────────────────────
+
+#[test]
+fn pi_02_check_returns_version_and_host_metadata() {
+    let mut client = McpStdioClient::spawn();
+    initialize_client(&mut client);
+
+    let resp = client.request(
+        "tools/call",
+        json!({ "name": PLUGIN_INFO_TOOL, "arguments": {} }),
+    );
+    assert_eq!(resp["result"]["isError"], Value::Bool(false));
+
+    let p = parse_response_payload(&resp["result"]);
+    assert!(p["current_version"].is_string(), "current_version missing");
+    assert!(p["latest_version"].is_string(), "latest_version missing");
+    assert!(p["update_available"].is_boolean(), "update_available missing");
+    assert!(p["log_path"].is_string(), "log_path missing");
+    assert!(p["host"].is_object(), "host metadata missing");
+    assert!(p["host"]["os"].is_string());
+    assert!(p["host"]["arch"].is_string());
+    assert!(p["host"]["pid"].is_number());
+}
+
+#[test]
+fn pi_02_explicit_check_subcommand_is_identical_to_default() {
+    let mut client = McpStdioClient::spawn();
+    initialize_client(&mut client);
+
+    let default_resp = client.request(
+        "tools/call",
+        json!({ "name": PLUGIN_INFO_TOOL, "arguments": {} }),
+    );
+    let explicit_resp = client.request(
+        "tools/call",
+        json!({ "name": PLUGIN_INFO_TOOL, "arguments": { "subcommand": "check" } }),
+    );
+
+    let default_p = parse_response_payload(&default_resp["result"]);
+    let explicit_p = parse_response_payload(&explicit_resp["result"]);
+
+    // Both must report the same embedded version.
+    assert_eq!(default_p["current_version"], explicit_p["current_version"]);
+    assert_eq!(default_p["update_available"], explicit_p["update_available"]);
+}
+
+#[test]
+fn pi_02_current_version_is_non_empty_semver_like() {
+    let mut client = McpStdioClient::spawn();
+    initialize_client(&mut client);
+
+    let resp = client.request(
+        "tools/call",
+        json!({ "name": PLUGIN_INFO_TOOL, "arguments": {} }),
+    );
+    let p = parse_response_payload(&resp["result"]);
+    let version = p["current_version"].as_str().expect("current_version string");
+
+    // Must have at least one dot — x.y or x.y.z shape.
+    assert!(version.contains('.'), "version should be semver-like, got: {version}");
+}
+
+// ── subcommand: cleanup ───────────────────────────────────────────────────────
+
+#[test]
+fn pi_03_cleanup_returns_removed_array_and_count() {
+    let mut client = McpStdioClient::spawn();
+    initialize_client(&mut client);
+
+    let resp = client.request(
+        "tools/call",
+        json!({ "name": PLUGIN_INFO_TOOL, "arguments": { "subcommand": "cleanup" } }),
+    );
+    assert_eq!(resp["result"]["isError"], Value::Bool(false));
+
+    let p = parse_response_payload(&resp["result"]);
+    assert!(p["removed"].is_array(), "removed must be array");
+    assert!(p["count"].is_number(), "count must be number");
+    assert!(p["log_path"].is_string(), "log_path must be present");
+    // In the test environment there are no .old.exe files next to the test binary.
+    assert_eq!(p["count"], json!(0));
+}
+
+// ── subcommand: upgrade ───────────────────────────────────────────────────────
+
+#[test]
+fn pi_04_upgrade_returns_not_supported_on_non_windows_without_feature() {
+    let mut client = McpStdioClient::spawn();
+    initialize_client(&mut client);
+
+    let resp = client.request(
+        "tools/call",
+        json!({ "name": PLUGIN_INFO_TOOL, "arguments": { "subcommand": "upgrade" } }),
+    );
+    assert_eq!(resp["result"]["isError"], Value::Bool(false));
+
+    let p = parse_response_payload(&resp["result"]);
+
+    // On Linux CI (no self-update feature) must report not_supported.
+    // On Windows+self-update it reports already_current or proceeds — both are valid statuses.
+    let status = p["status"].as_str().expect("status field");
+    assert!(
+        ["not_supported", "already_current", "upgraded", "error"].contains(&status),
+        "unexpected upgrade status: {status}"
+    );
+
+    #[cfg(not(all(target_os = "windows", feature = "self-update")))]
+    assert_eq!(status, "not_supported");
+}
+
+// ── response envelope ─────────────────────────────────────────────────────────
+
+#[test]
+fn pi_05_all_subcommands_return_text_content_type() {
+    let mut client = McpStdioClient::spawn();
+    initialize_client(&mut client);
+
+    for subcommand in ["check", "cleanup", "upgrade"] {
+        let resp = client.request(
+            "tools/call",
+            json!({ "name": PLUGIN_INFO_TOOL, "arguments": { "subcommand": subcommand } }),
+        );
+        let content_type = resp["result"]["content"][0]["type"].as_str().unwrap_or("");
+        assert_eq!(
+            content_type, "text",
+            "subcommand '{subcommand}' returned content type '{content_type}', expected 'text'"
+        );
+    }
+}
+
+#[test]
+fn pi_05_unknown_subcommand_falls_through_to_check() {
+    let mut client = McpStdioClient::spawn();
+    initialize_client(&mut client);
+
+    let resp = client.request(
+        "tools/call",
+        json!({ "name": PLUGIN_INFO_TOOL, "arguments": { "subcommand": "nonsense" } }),
+    );
+    assert_eq!(resp["result"]["isError"], Value::Bool(false));
+
+    let p = parse_response_payload(&resp["result"]);
+    // Falls through to check — must have current_version.
+    assert!(p["current_version"].is_string());
+}


### PR DESCRIPTION
## Summary

- **New MCP tool `l3dg3rr_plugin_info`** — always available, three subcommands:
  - `check` (default): current + latest GitHub release version, update availability flag, host metadata (OS/arch/uptime/CPU count via `sysinfo`, Windows build/product via `winreg`), log file path
  - `upgrade` — Windows + `self-update` Cargo feature only; safe two-step rename (`old→versioned-.old.exe`, `new→current`), double-hash AV race detection, Zone.Identifier ADS stripping
  - `cleanup` — removes `*.old.exe` / `*.new.exe` sibling files from the exe directory
- **NDJSON decision log** at `%APPDATA%\ledgerr-mcp\update.log` (Windows) / `~/.local/share/ledgerr-mcp/update.log` — every check, download, hash result, rename, and error is appended as a structured entry

## New dependencies

| Crate | Scope | Why |
|-------|-------|-----|
| `sysinfo = "0.33"` | always | OS name/version, kernel, hostname, uptime — cross-platform, no unsafe |
| `winreg = "0.52"` | `cfg(windows)` | Safe registry wrapper for Windows build/product strings |
| `reqwest = "0.12"` | `self-update` feature | GitHub releases API + binary download |
| `semver = "1"` | `self-update` feature | Strict version comparison |

## Test plan

- [x] 12 new unit tests in `plugin_info::tests` cover: `is_newer` comparison, log path, `log_event` no-panic, host metadata shape, `handle_check` envelope, `handle_cleanup` shape, upgrade `not_supported` on Linux, input schema, `blake3_file` error path, `cleanup_old_binaries` no-panic, dispatcher default
- [x] All 98 pre-existing tests pass unchanged
- [ ] On a real Windows build with `--features self-update`: smoke test `check` → `upgrade` → `cleanup` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)