### PR TITLE
feat: generate MCP contract artifacts from Rust

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,13 @@ For product scope and status, read `README.md` first, then use this file for exe
 
 ### MCP Capability Training (Concrete)
 
-Use `TurboLedgerService` in `crates/turbo-mcp/src/lib.rs` as the canonical contract.
+Use `TurboLedgerService` in `crates/ledgerr-mcp/src/lib.rs` as the canonical contract.
 Use `docs/mcp-capability-contract.md` as the canonical MCP surface map (tool names, arg contracts, service mapping, contrived usage flow).
+
+Published MCP surface rule:
+- Default `tools/list` should stay collapsed to the 7 top-level `ledgerr_*` capability families: `ledgerr_documents`, `ledgerr_review`, `ledgerr_reconciliation`, `ledgerr_workflow`, `ledgerr_audit`, `ledgerr_tax`, `ledgerr_ontology`.
+- Use required `action` parameters to expose sub-operations while keeping major capability families visible.
+- Keep any legacy `l3dg3rr_*` or proxy-style names hidden compatibility aliases only; do not advertise them in the default tool catalog.
 
 Core methods:
 - `list_accounts` / `list_accounts_tool`: enumerate account ids from manifest.
@@ -230,9 +235,12 @@ Treat this as a standing operational gate, not a one-time migration task.
 ### Validation Memo
 
 - 2026-04-02: executed post-commit plugin-doc validation against `https://code.claude.com/docs/en/plugins`.
-  - Updated stale tool examples from `l3dg3rr_context_summary` to live MCP tools (`l3dg3rr_get_pipeline_status`, `l3dg3rr_list_accounts`, `l3dg3rr_get_raw_context`).
+  - Updated stale tool examples from `l3dg3rr_context_summary` to then-live MCP tools (`l3dg3rr_get_pipeline_status`, `l3dg3rr_list_accounts`, `l3dg3rr_get_raw_context`).
   - Added plugin skill frontmatter `name` for plugin-doc compatibility.
   - Added runnable `just test` outcome flow (Rust executable) with both simple and blocked-diagnostics scenarios.
+- 2026-04-17: reduced the default MCP catalog to 7 top-level `ledgerr_*` tools and relocated plugin info under `ledgerr_workflow`.
+  - Keep docs/examples aligned to the reduced surface; `tools/list` is now intended to be a trustworthy small catalog for agents.
+  - Legacy `l3dg3rr_*` and proxy tool names remain compatibility aliases only and should not be reintroduced into the advertised catalog.
 
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,10 @@ Treat this as a standing operational gate, not a one-time migration task.
 - 2026-04-17: reduced the default MCP catalog to 7 top-level `ledgerr_*` tools and relocated plugin info under `ledgerr_workflow`.
   - Keep docs/examples aligned to the reduced surface; `tools/list` is now intended to be a trustworthy small catalog for agents.
   - Legacy `l3dg3rr_*` and proxy tool names remain compatibility aliases only and should not be reintroduced into the advertised catalog.
+- 2026-04-17: issue `#22` established a code-first MCP contract path.
+  - The published MCP surface now lives in `crates/ledgerr-mcp/src/contract.rs`; treat it as the only source of truth for parser shapes, generated JSON Schema, and checked-in operator docs/examples.
+  - Regenerate `docs/mcp-capability-contract.md`, `docs/agent-mcp-runbook.md`, and `scripts/mcp_cli_demo.sh` via `cargo run -p xtask-mcpb -- generate-mcp-artifacts` after changing the published MCP surface.
+  - Drift between `contract.rs` and those generated artifacts is a test failure, not a documentation chore.
 
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1058,7 @@ dependencies = [
  "reqwest",
  "rust_decimal",
  "rust_xlsxwriter",
+ "schemars",
  "semver",
  "serde",
  "serde_json",
@@ -1648,6 +1655,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +1714,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2800,6 +2842,7 @@ version = "1.3.7"
 dependencies = [
  "clap",
  "hex",
+ "ledgerr-mcp",
  "serde",
  "serde_json",
  "sha2",

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 COPY xtask ./xtask
+COPY docs ./docs
+COPY scripts ./scripts
 
 RUN cargo test --workspace --all-features
 RUN cargo build -p ledgerr-mcp --release --bin ledgerr-mcp-server

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See [docs/mcp-capability-contract.md](docs/mcp-capability-contract.md) for the c
 - Session manifest parsing and account listing
 - Workbook initialization with required sheet names
 - Git-friendly plain-text ingest output via Beancount journal entries (rustledger-compatible)
-- Idiomatic turbo MCP interface surface for `list_accounts` and `ingest_statement_rows`
+- Reduced 7-tool MCP interface surface using top-level `ledgerr_*` capabilities with action-based subcommands
 
 ## Prerequisites
 
@@ -70,7 +70,7 @@ curl -fsSL "https://github.com/PromptExecution/l3dg3rr/releases/latest/download/
 claude mcp add ledgerr /tmp/ledgerr-mcp.mcpb
 ```
 
-After adding, restart Claude Code. The `l3dg3rr_*` tools will appear automatically.
+After adding, restart Claude Code. The 7 top-level `ledgerr_*` tools will appear automatically.
 
 ## Docker
 

--- a/crates/ledgerr-mcp/Cargo.toml
+++ b/crates/ledgerr-mcp/Cargo.toml
@@ -9,6 +9,7 @@ blake3 = "1.8.3"
 ledger-core = { version = "=1.3.7", path = "../ledger-core" }
 rust_decimal = "1.41.0"
 rust_xlsxwriter = { workspace = true }
+schemars = { version = "0.8", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs
+++ b/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs
@@ -57,9 +57,35 @@ fn handle_request(request: Value) -> Option<Value> {
             let params = request.get("params").cloned().unwrap_or(Value::Null);
             let tool_name = params.get("name").and_then(Value::as_str).unwrap_or("");
             let result = match tool_name {
-                mcp_adapter::LIST_ACCOUNTS_TOOL => {
-                    mcp_adapter::handle_list_accounts(global_service())
+                mcp_adapter::DOCUMENTS_TOOL => {
+                    let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+                    mcp_adapter::handle_documents_tool(global_service(), &arguments)
                 }
+                mcp_adapter::REVIEW_TOOL => {
+                    let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+                    mcp_adapter::handle_review_tool(global_service(), &arguments)
+                }
+                mcp_adapter::RECONCILIATION_TOOL => {
+                    let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+                    mcp_adapter::handle_reconciliation_tool(global_service(), &arguments)
+                }
+                mcp_adapter::WORKFLOW_TOOL => {
+                    let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+                    mcp_adapter::handle_workflow_tool(global_service(), &arguments)
+                }
+                mcp_adapter::AUDIT_TOOL => {
+                    let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+                    mcp_adapter::handle_audit_tool(global_service(), &arguments)
+                }
+                mcp_adapter::TAX_TOOL => {
+                    let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+                    mcp_adapter::handle_tax_tool(global_service(), &arguments)
+                }
+                mcp_adapter::ONTOLOGY_TOOL => {
+                    let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+                    mcp_adapter::handle_ontology_tool(global_service(), &arguments)
+                }
+                "l3dg3rr_list_accounts" => mcp_adapter::handle_list_accounts(global_service()),
                 "l3dg3rr_get_pipeline_status" => {
                     mcp_adapter::handle_pipeline_status(true, true, true, Vec::new())
                 }
@@ -79,95 +105,104 @@ fn handle_request(request: Value) -> Option<Value> {
                         Some(format!("mcp-call-{id}")),
                     )
                 }
-                mcp_adapter::GET_RAW_CONTEXT_TOOL => {
+                "l3dg3rr_get_raw_context" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_get_raw_context(global_service(), &arguments)
                 }
-                mcp_adapter::ONTOLOGY_QUERY_PATH_TOOL => {
+                "l3dg3rr_ontology_query_path" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_ontology_query_path(global_service(), &arguments)
                 }
-                mcp_adapter::ONTOLOGY_EXPORT_SNAPSHOT_TOOL => {
+                "l3dg3rr_ontology_export_snapshot" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_ontology_export_snapshot(global_service(), &arguments)
                 }
-                mcp_adapter::RECON_VALIDATE_TOOL
-                | mcp_adapter::RECON_RECONCILE_TOOL
-                | mcp_adapter::RECON_COMMIT_TOOL => {
+                "l3dg3rr_validate_reconciliation" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::dispatch_reconciliation(global_service(), tool_name, &arguments)
+                    mcp_adapter::dispatch_reconciliation(global_service(), "validate", &arguments)
                 }
-                mcp_adapter::HSM_TRANSITION_TOOL
-                | mcp_adapter::HSM_STATUS_TOOL
-                | mcp_adapter::HSM_RESUME_TOOL => {
+                "l3dg3rr_reconcile_postings" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::dispatch_hsm(global_service(), tool_name, &arguments)
+                    mcp_adapter::dispatch_reconciliation(global_service(), "reconcile", &arguments)
                 }
-                mcp_adapter::EVENT_HISTORY_TOOL => {
+                "l3dg3rr_commit_guarded" => {
+                    let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+                    mcp_adapter::dispatch_reconciliation(global_service(), "commit", &arguments)
+                }
+                "l3dg3rr_hsm_transition" => {
+                    let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+                    mcp_adapter::dispatch_hsm(global_service(), "transition", &arguments)
+                }
+                "l3dg3rr_hsm_status" => {
+                    let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+                    mcp_adapter::dispatch_hsm(global_service(), "status", &arguments)
+                }
+                "l3dg3rr_hsm_resume" => {
+                    let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+                    mcp_adapter::dispatch_hsm(global_service(), "resume", &arguments)
+                }
+                "l3dg3rr_event_history" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_event_history(global_service(), &arguments)
                 }
-                mcp_adapter::EVENT_REPLAY_TOOL => {
+                "l3dg3rr_event_replay" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_event_replay(global_service(), &arguments)
                 }
-                mcp_adapter::TAX_ASSIST_TOOL => {
+                "l3dg3rr_tax_assist" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_tax_assist(global_service(), &arguments)
                 }
-                mcp_adapter::TAX_EVIDENCE_CHAIN_TOOL => {
+                "l3dg3rr_tax_evidence_chain" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_tax_evidence_chain(global_service(), &arguments)
                 }
-                mcp_adapter::TAX_AMBIGUITY_REVIEW_TOOL => {
+                "l3dg3rr_tax_ambiguity_review" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_tax_ambiguity_review(global_service(), &arguments)
                 }
-                // P0 tools
-                mcp_adapter::CLASSIFY_INGESTED_TOOL => {
+                "l3dg3rr_classify_ingested" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_classify_ingested(global_service(), &arguments)
                 }
-                mcp_adapter::QUERY_FLAGS_TOOL => {
+                "l3dg3rr_query_flags" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_query_flags(global_service(), &arguments)
                 }
-                mcp_adapter::QUERY_AUDIT_LOG_TOOL => {
+                "l3dg3rr_query_audit_log" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_query_audit_log(global_service(), &arguments)
                 }
-                // P1 tools
-                mcp_adapter::CLASSIFY_TRANSACTION_TOOL => {
+                "l3dg3rr_classify_transaction" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_classify_transaction(global_service(), &arguments)
                 }
-                mcp_adapter::RECONCILE_EXCEL_CLASSIFICATION_TOOL => {
+                "l3dg3rr_reconcile_excel_classification" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::handle_reconcile_excel_classification(
-                        global_service(),
-                        &arguments,
-                    )
+                    mcp_adapter::handle_reconcile_excel_classification(global_service(), &arguments)
                 }
-                mcp_adapter::GET_SCHEDULE_SUMMARY_TOOL => {
+                "l3dg3rr_get_schedule_summary" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_get_schedule_summary(global_service(), &arguments)
                 }
-                // P2 tools
-                mcp_adapter::EXPORT_CPA_WORKBOOK_TOOL => {
+                "l3dg3rr_export_cpa_workbook" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_export_cpa_workbook(global_service(), &arguments)
                 }
-                mcp_adapter::ONTOLOGY_UPSERT_ENTITIES_TOOL => {
+                "l3dg3rr_ontology_upsert_entities" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_ontology_upsert_entities(global_service(), &arguments)
                 }
-                mcp_adapter::ONTOLOGY_UPSERT_EDGES_TOOL => {
+                "l3dg3rr_ontology_upsert_edges" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
                     mcp_adapter::handle_ontology_upsert_edges(global_service(), &arguments)
                 }
-                mcp_adapter::PLUGIN_INFO_TOOL => {
+                "l3dg3rr_plugin_info" => {
                     let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
-                    mcp_adapter::handle_plugin_info(&arguments)
+                    mcp_adapter::handle_workflow_tool(
+                        global_service(),
+                        &json!({ "action": "plugin_info", "subcommand": arguments.get("subcommand").cloned().unwrap_or(Value::String("check".to_string())) }),
+                    )
                 }
                 _ => mcp_adapter::unknown_tool_result(tool_name),
             };

--- a/crates/ledgerr-mcp/src/bin/mcp-outcome-test.rs
+++ b/crates/ledgerr-mcp/src/bin/mcp-outcome-test.rs
@@ -165,10 +165,10 @@ fn step_tools_list(ctx: &mut FlowContext) -> Result<(), String> {
         .collect::<Vec<_>>();
 
     for required in [
-        "l3dg3rr_get_pipeline_status",
-        "l3dg3rr_list_accounts",
-        "proxy_docling_ingest_pdf",
-        "l3dg3rr_get_raw_context",
+        "ledgerr_documents",
+        "ledgerr_workflow",
+        "ledgerr_reconciliation",
+        "ledgerr_audit",
     ] {
         if !names.contains(&required) {
             return Err(format!(
@@ -183,8 +183,8 @@ fn step_pipeline_status(ctx: &mut FlowContext) -> Result<(), String> {
     let response = ctx.client.request(
         "tools/call",
         json!({
-            "name": "l3dg3rr_get_pipeline_status",
-            "arguments": {}
+            "name": "ledgerr_documents",
+            "arguments": { "action": "pipeline_status" }
         }),
     )?;
     let p = parse_response_payload(&response["result"]);
@@ -199,8 +199,8 @@ fn step_list_accounts(ctx: &mut FlowContext) -> Result<(), String> {
     let response = ctx.client.request(
         "tools/call",
         json!({
-            "name": "l3dg3rr_list_accounts",
-            "arguments": {}
+            "name": "ledgerr_documents",
+            "arguments": { "action": "list_accounts" }
         }),
     )?;
     let accounts_p = parse_response_payload(&response["result"]);
@@ -217,8 +217,9 @@ fn step_ingest_sample(ctx: &mut FlowContext) -> Result<(), String> {
     let response = ctx.client.request(
         "tools/call",
         json!({
-            "name": "proxy_docling_ingest_pdf",
+            "name": "ledgerr_documents",
             "arguments": {
+                "action": "ingest_pdf",
                 "pdf_path": "WF--BH-CHK--2023-01--statement.pdf",
                 "journal_path": path_json(&ctx.journal_path),
                 "workbook_path": path_json(&ctx.workbook_path),
@@ -246,8 +247,9 @@ fn step_get_raw_context(ctx: &mut FlowContext) -> Result<(), String> {
     let response = ctx.client.request(
         "tools/call",
         json!({
-            "name": "l3dg3rr_get_raw_context",
+            "name": "ledgerr_documents",
             "arguments": {
+                "action": "get_raw_context",
                 "rkyv_ref": path_json(&ctx.source_ref)
             }
         }),
@@ -265,8 +267,9 @@ fn step_hsm_resume_blocked(ctx: &mut FlowContext) -> Result<(), String> {
     let response = ctx.client.request(
         "tools/call",
         json!({
-            "name": "l3dg3rr_hsm_resume",
+            "name": "ledgerr_workflow",
             "arguments": {
+                "action": "resume",
                 "state_marker": "invalid-checkpoint"
             }
         }),
@@ -286,8 +289,9 @@ fn step_reconciliation_blocked(ctx: &mut FlowContext) -> Result<(), String> {
     let response = ctx.client.request(
         "tools/call",
         json!({
-            "name": "l3dg3rr_commit_guarded",
+            "name": "ledgerr_reconciliation",
             "arguments": {
+                "action": "commit",
                 "source_total": "100.00",
                 "extracted_total": "95.00",
                 "posting_amounts": ["-95.00", "95.00"]
@@ -313,8 +317,9 @@ fn step_event_history_blocked(ctx: &mut FlowContext) -> Result<(), String> {
     let response = ctx.client.request(
         "tools/call",
         json!({
-            "name": "l3dg3rr_event_history",
+            "name": "ledgerr_audit",
             "arguments": {
+                "action": "event_history",
                 "time_start": "2026-12-31",
                 "time_end": "2026-01-01"
             }

--- a/crates/ledgerr-mcp/src/contract.rs
+++ b/crates/ledgerr-mcp/src/contract.rs
@@ -1,0 +1,690 @@
+//! Canonical MCP transport contract for the published `ledgerr_*` surface.
+//!
+//! Design decision, captured here intentionally because it affects how future
+//! agents extend the MCP boundary:
+//! - Rust code is the only source of truth for the published MCP surface.
+//! - `tools/list` schemas, operator docs, and runnable examples are generated
+//!   from this module.
+//! - Drift between parser, schema, and docs is a bug and should fail tests.
+//!
+//! Hidden compatibility aliases may continue to parse legacy shapes elsewhere,
+//! but the advertised 7-tool catalog must stay defined here.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use schemars::{
+    schema::{InstanceType, Metadata, RootSchema, Schema, SchemaObject, SingleOrVec},
+    schema_for, JsonSchema,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::ToolError;
+
+pub const DOCUMENTS_TOOL: &str = "ledgerr_documents";
+pub const REVIEW_TOOL: &str = "ledgerr_review";
+pub const RECONCILIATION_TOOL: &str = "ledgerr_reconciliation";
+pub const WORKFLOW_TOOL: &str = "ledgerr_workflow";
+pub const AUDIT_TOOL: &str = "ledgerr_audit";
+pub const TAX_TOOL: &str = "ledgerr_tax";
+pub const ONTOLOGY_TOOL: &str = "ledgerr_ontology";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolContractSpec {
+    pub name: &'static str,
+    pub purpose: &'static str,
+    pub actions: &'static [&'static str],
+}
+
+pub const PUBLISHED_TOOLS: [ToolContractSpec; 7] = [
+    ToolContractSpec {
+        name: DOCUMENTS_TOOL,
+        purpose: "document intake, routing, manifest/account discovery, raw context retrieval",
+        actions: &[
+            "list_accounts",
+            "pipeline_status",
+            "validate_filename",
+            "ingest_pdf",
+            "ingest_rows",
+            "get_raw_context",
+        ],
+    },
+    ToolContractSpec {
+        name: REVIEW_TOOL,
+        purpose: "classification and human-review workflows",
+        actions: &[
+            "run_rule",
+            "classify_ingested",
+            "query_flags",
+            "classify_transaction",
+            "reconcile_excel_classification",
+        ],
+    },
+    ToolContractSpec {
+        name: RECONCILIATION_TOOL,
+        purpose: "staged totals/postings guardrails",
+        actions: &["validate", "reconcile", "commit"],
+    },
+    ToolContractSpec {
+        name: WORKFLOW_TOOL,
+        purpose: "lifecycle/HSM orchestration plus relocated plugin ops",
+        actions: &["status", "transition", "resume", "plugin_info"],
+    },
+    ToolContractSpec {
+        name: AUDIT_TOOL,
+        purpose: "append-only event and audit-log views",
+        actions: &["event_history", "event_replay", "query_audit_log"],
+    },
+    ToolContractSpec {
+        name: TAX_TOOL,
+        purpose: "tax summaries, evidence, ambiguity review, workbook export",
+        actions: &[
+            "assist",
+            "evidence_chain",
+            "ambiguity_review",
+            "schedule_summary",
+            "export_workbook",
+        ],
+    },
+    ToolContractSpec {
+        name: ONTOLOGY_TOOL,
+        purpose: "ontology query/export/write operations",
+        actions: &[
+            "query_path",
+            "export_snapshot",
+            "upsert_entities",
+            "upsert_edges",
+        ],
+    },
+];
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TransportRow {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account: Option<String>,
+    pub date: String,
+    pub amount: String,
+    pub description: String,
+    pub source_ref: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SampleTxInput {
+    pub tx_id: String,
+    pub account_id: String,
+    pub date: String,
+    pub amount: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ReconciliationInput {
+    pub source_total: String,
+    pub extracted_total: String,
+    pub posting_amounts: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum FlexibleF64 {
+    Number(f64),
+    String(String),
+}
+
+impl FlexibleF64 {
+    pub fn as_json(&self) -> Value {
+        match self {
+            Self::Number(value) => json!(value),
+            Self::String(value) => json!(value),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PluginInfoSubcommand(pub String);
+
+impl JsonSchema for PluginInfoSubcommand {
+    fn schema_name() -> String {
+        "PluginInfoSubcommand".to_string()
+    }
+
+    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> Schema {
+        Schema::Object(SchemaObject {
+            instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::String))),
+            enum_values: Some(vec![json!("check"), json!("upgrade"), json!("cleanup")]),
+            metadata: Some(Box::new(Metadata {
+                description: Some("Recognized values are check, upgrade, and cleanup. Unknown strings intentionally fall through to the default check behavior.".to_string()),
+                ..Metadata::default()
+            })),
+            ..SchemaObject::default()
+        })
+    }
+
+    fn is_referenceable() -> bool {
+        false
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowPluginInfoInput {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subcommand: Option<PluginInfoSubcommand>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum ReviewStatusInput {
+    #[serde(rename = "open")]
+    Open,
+    #[serde(rename = "resolved")]
+    Resolved,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum ScheduleInput {
+    #[serde(rename = "ScheduleC")]
+    ScheduleC,
+    #[serde(rename = "ScheduleD")]
+    ScheduleD,
+    #[serde(rename = "ScheduleE")]
+    ScheduleE,
+    #[serde(rename = "Fbar")]
+    Fbar,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum OntologyEntityKindInput {
+    Document,
+    Account,
+    Institution,
+    Transaction,
+    TaxCategory,
+    EvidenceReference,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct OntologyEntityInput {
+    pub kind: OntologyEntityKindInput,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub properties: Option<BTreeMap<String, Value>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct OntologyEdgeInput {
+    pub from_id: String,
+    pub to_id: String,
+    pub relation: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<BTreeMap<String, Value>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DocumentsArgs {
+    ListAccounts,
+    PipelineStatus,
+    ValidateFilename {
+        file_name: String,
+    },
+    GetRawContext {
+        rkyv_ref: PathBuf,
+    },
+    IngestPdf {
+        pdf_path: String,
+        journal_path: PathBuf,
+        workbook_path: PathBuf,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        raw_context_bytes: Option<Vec<u8>>,
+        #[serde(default)]
+        extracted_rows: Vec<TransportRow>,
+    },
+    IngestRows {
+        journal_path: PathBuf,
+        workbook_path: PathBuf,
+        rows: Vec<TransportRow>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ReviewArgs {
+    RunRule {
+        rule_file: PathBuf,
+        sample_tx: SampleTxInput,
+    },
+    ClassifyIngested {
+        rule_file: PathBuf,
+        review_threshold: FlexibleF64,
+    },
+    QueryFlags {
+        year: i32,
+        status: ReviewStatusInput,
+    },
+    ClassifyTransaction {
+        tx_id: String,
+        category: String,
+        confidence: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        note: Option<String>,
+        actor: String,
+    },
+    ReconcileExcelClassification {
+        tx_id: String,
+        category: String,
+        confidence: String,
+        actor: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        note: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ReconciliationArgs {
+    Validate {
+        source_total: String,
+        extracted_total: String,
+        posting_amounts: Vec<String>,
+    },
+    Reconcile {
+        source_total: String,
+        extracted_total: String,
+        posting_amounts: Vec<String>,
+    },
+    Commit {
+        source_total: String,
+        extracted_total: String,
+        posting_amounts: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
+pub enum WorkflowArgs {
+    Status,
+    Transition {
+        target_state: String,
+        target_substate: String,
+    },
+    Resume {
+        state_marker: String,
+    },
+    PluginInfo {
+        #[serde(flatten)]
+        payload: WorkflowPluginInfoInput,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AuditArgs {
+    EventHistory {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tx_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        document_ref: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        time_start: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        time_end: Option<String>,
+    },
+    EventReplay {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tx_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        document_ref: Option<String>,
+    },
+    QueryAuditLog,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
+pub enum TaxArgs {
+    Assist {
+        ontology_path: PathBuf,
+        from_entity_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_depth: Option<usize>,
+        reconciliation: ReconciliationInput,
+    },
+    EvidenceChain {
+        ontology_path: PathBuf,
+        from_entity_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tx_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        document_ref: Option<String>,
+    },
+    AmbiguityReview {
+        ontology_path: PathBuf,
+        from_entity_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_depth: Option<usize>,
+        reconciliation: ReconciliationInput,
+    },
+    ScheduleSummary {
+        year: i32,
+        schedule: ScheduleInput,
+    },
+    ExportWorkbook {
+        workbook_path: PathBuf,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
+pub enum OntologyArgs {
+    QueryPath {
+        ontology_path: PathBuf,
+        from_entity_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_depth: Option<usize>,
+    },
+    ExportSnapshot {
+        ontology_path: PathBuf,
+    },
+    UpsertEntities {
+        ontology_path: PathBuf,
+        entities: Vec<OntologyEntityInput>,
+    },
+    UpsertEdges {
+        ontology_path: PathBuf,
+        edges: Vec<OntologyEdgeInput>,
+    },
+}
+
+pub fn parse_documents(arguments: &Value) -> Result<DocumentsArgs, ToolError> {
+    parse_args(arguments)
+}
+
+pub fn parse_review(arguments: &Value) -> Result<ReviewArgs, ToolError> {
+    parse_args(arguments)
+}
+
+pub fn parse_reconciliation(arguments: &Value) -> Result<ReconciliationArgs, ToolError> {
+    parse_args(arguments)
+}
+
+pub fn parse_workflow(arguments: &Value) -> Result<WorkflowArgs, ToolError> {
+    parse_args(arguments)
+}
+
+pub fn parse_audit(arguments: &Value) -> Result<AuditArgs, ToolError> {
+    parse_args(arguments)
+}
+
+pub fn parse_tax(arguments: &Value) -> Result<TaxArgs, ToolError> {
+    parse_args(arguments)
+}
+
+pub fn parse_ontology(arguments: &Value) -> Result<OntologyArgs, ToolError> {
+    parse_args(arguments)
+}
+
+fn parse_args<T>(arguments: &Value) -> Result<T, ToolError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    serde_json::from_value(arguments.clone())
+        .map_err(|err| ToolError::InvalidInput(format!("invalid tool arguments: {err}")))
+}
+
+pub fn tool_input_schema(name: &str) -> Value {
+    match name {
+        DOCUMENTS_TOOL => root_schema_to_value(schema_for!(DocumentsArgs)),
+        REVIEW_TOOL => root_schema_to_value(schema_for!(ReviewArgs)),
+        RECONCILIATION_TOOL => root_schema_to_value(schema_for!(ReconciliationArgs)),
+        WORKFLOW_TOOL => root_schema_to_value(schema_for!(WorkflowArgs)),
+        AUDIT_TOOL => root_schema_to_value(schema_for!(AuditArgs)),
+        TAX_TOOL => root_schema_to_value(schema_for!(TaxArgs)),
+        ONTOLOGY_TOOL => root_schema_to_value(schema_for!(OntologyArgs)),
+        _ => json!({ "type": "object" }),
+    }
+}
+
+fn root_schema_to_value(schema: RootSchema) -> Value {
+    serde_json::to_value(schema).expect("schema serializes")
+}
+
+pub fn generated_capability_contract_markdown() -> String {
+    let mut doc = String::new();
+    doc.push_str("# MCP Capability Contract (Generated)\n\n");
+    doc.push_str(
+        "This file is generated from `crates/ledgerr-mcp/src/contract.rs`.\n\n\
+Rust code is the only source of truth for the published MCP surface. If this file drifts from the contract module, tests should fail.\n\n",
+    );
+    doc.push_str(
+        "The default catalog is intentionally small: 7 top-level `ledgerr_*` tools. Each tool uses a required `action` field so the major capability families stay visible while related operations are grouped under one top-level command.\n\n",
+    );
+    doc.push_str("## Published MCP Tools\n\n");
+    doc.push_str("| Tool | Purpose | Common actions |\n|---|---|---|\n");
+    for spec in PUBLISHED_TOOLS {
+        doc.push_str(&format!(
+            "| `{}` | {} | {} |\n",
+            spec.name,
+            spec.purpose,
+            spec.actions
+                .iter()
+                .map(|action| format!("`{action}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    doc.push_str(
+        "\nThe concrete parser, action enums, field aliases, and JSON Schemas all live in [crates/ledgerr-mcp/src/contract.rs](../crates/ledgerr-mcp/src/contract.rs).\n\n\
+The transport adapter in [crates/ledgerr-mcp/src/mcp_adapter.rs](../crates/ledgerr-mcp/src/mcp_adapter.rs) consumes that contract rather than re-describing it by hand.\n\n",
+    );
+    doc.push_str(
+        "## Compatibility\n\n\
+The server still accepts older `l3dg3rr_*` and proxy-style call names as hidden compatibility aliases, but they are no longer advertised in `tools/list`. Agents should use the `ledgerr_*` tools above by default.\n\n",
+    );
+    doc.push_str(
+        "## Internal Service API\n\n\
+Canonical trait:\n[TurboLedgerTools in crates/ledgerr-mcp/src/lib.rs](../crates/ledgerr-mcp/src/lib.rs#L289)\n\n\
+Important distinction:\n- The MCP surface is the reduced 7-tool catalog defined in Rust.\n- The internal service trait remains more granular and implementation-oriented.\n\n\
+API layering:\n1. `ledgerr-mcp-server` (stdio transport)\n2. `contract` (published tool families, action enums, generated schema/doc artifacts)\n3. `mcp_adapter` (dispatch + envelope shaping)\n4. `TurboLedgerService` (domain logic, guardrails, state/event/HSM ops)\n5. `ledger-core` (ingest, filename validation, classification primitives)\n\n",
+    );
+    doc.push_str("## Example Flow\n\n");
+    doc.push_str("### Step A: initialize and list tools\n\n");
+    doc.push_str("```json\n");
+    doc.push_str("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"clientInfo\":{\"name\":\"demo\",\"version\":\"0.1.0\"}}}\n");
+    doc.push_str("{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\",\"params\":{}}\n");
+    doc.push_str("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}\n");
+    doc.push_str("```\n\n");
+    doc.push_str("### Step B: ingest a PDF through `ledgerr_documents`\n\n```json\n");
+    doc.push_str(&pretty_json(&documents_ingest_pdf_example()));
+    doc.push_str("\n```\n\n");
+    doc.push_str("### Step C: run reconciliation commit gate\n\n```json\n");
+    doc.push_str(&pretty_json(&reconciliation_commit_example()));
+    doc.push_str("\n```\n\n");
+    doc.push_str("### Step D: inspect workflow status and audit replay\n\n```json\n");
+    doc.push_str("{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_workflow\",\"arguments\":{\"action\":\"status\"}}}\n");
+    doc.push_str("{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_audit\",\"arguments\":{\"action\":\"event_replay\",\"document_ref\":\"wf-2023-01.rkyv\"}}}\n");
+    doc.push_str("```\n\n");
+    doc.push_str("### Step E: ask for tax evidence\n\n```json\n");
+    doc.push_str(&pretty_json(&tax_evidence_chain_example()));
+    doc.push_str("\n```\n\n");
+    doc.push_str(
+        "## Current Gaps\n\n\
+Open design/roadmap gaps are tracked in:\n\
+- `#20` persistent state across restart\n\
+- `#21` workbook export completeness\n\
+- `#22` schema/doc drift elimination\n\
+- `#23` document inventory/queue\n\
+- `#24` unified work queue\n\
+- `#25` batch review actions\n\
+- `#26` transaction query + preflight/rule preview\n",
+    );
+    doc
+}
+
+pub fn generated_agent_runbook_markdown() -> String {
+    format!(
+        "# Agent MCP Runbook (Generated)\n\n\
+This file is generated from `crates/ledgerr-mcp/src/contract.rs`.\n\n\
+Agent workflows must use `initialize`, `notifications/initialized`, `tools/list`, and `tools/call` over stdio.\n\n\
+## Runtime Model\n\n\
+The default published surface is the reduced 7-tool catalog:\n\n{}\n\
+Each tool requires an `action` argument.\n\n\
+## Bootstrap\n\n\
+From repo root:\n\n```bash\ncargo build -p ledgerr-mcp --bin ledgerr-mcp-server\n```\n\n\
+## Lifecycle\n\n\
+Required order:\n\n\
+1. `initialize`\n\
+2. `notifications/initialized`\n\
+3. `tools/list`\n\
+4. `tools/call`\n\n\
+## Basic Happy Path\n\n```json\n{}\n{}\n{}\n{}\n```\n\n\
+## Troubleshooting / Spinning Wheels\n\n```json\n{}\n{}\n{}\n```\n\n\
+Expected blocked outcomes:\n\n\
+- invalid workflow resume returns `HsmResumeBlocked`\n\
+- imbalanced reconciliation commit returns `ReconciliationBlocked`\n\
+- invalid audit time range returns `EventHistoryBlocked`\n\n\
+## Suggested Test Commands\n\n```bash\ncargo test -p ledgerr-mcp --test mcp_stdio_e2e -- --nocapture\ncargo test -p ledgerr-mcp --test plugin_info_mcp_e2e -- --nocapture\nbash scripts/mcp_cli_demo.sh\nbash scripts/mcp_e2e.sh\n```\n\n\
+## Notes\n\n\
+- Hidden compatibility aliases still exist for older `l3dg3rr_*` and proxy-style calls, but agents should not depend on them.\n\
+- Use `docs/mcp-capability-contract.md` as the concise surface map.\n",
+        PUBLISHED_TOOLS
+            .iter()
+            .map(|spec| format!("- `{}`\n", spec.name))
+            .collect::<String>(),
+        compact_tool_call(DOCUMENTS_TOOL, json!({"action":"pipeline_status"})),
+        compact_tool_call(DOCUMENTS_TOOL, json!({"action":"list_accounts"})),
+        compact_tool_call(
+            DOCUMENTS_TOOL,
+            json!({
+                "action":"ingest_pdf",
+                "pdf_path":"WF--BH-CHK--2023-01--statement.pdf",
+                "journal_path":"/tmp/demo.beancount",
+                "workbook_path":"/tmp/demo.xlsx",
+                "raw_context_bytes":[99,116,120],
+                "extracted_rows":[{
+                    "account_id":"WF-BH-CHK",
+                    "date":"2023-01-15",
+                    "amount":"-42.11",
+                    "description":"Coffee Shop",
+                    "source_ref":"wf-2023-01.rkyv"
+                }]
+            })
+        ),
+        compact_tool_call(
+            DOCUMENTS_TOOL,
+            json!({"action":"get_raw_context","rkyv_ref":"wf-2023-01.rkyv"})
+        ),
+        compact_tool_call(
+            WORKFLOW_TOOL,
+            json!({"action":"resume","state_marker":"invalid-checkpoint"})
+        ),
+        compact_tool_call(
+            RECONCILIATION_TOOL,
+            json!({"action":"commit","source_total":"100.00","extracted_total":"95.00","posting_amounts":["-95.00","95.00"]})
+        ),
+        compact_tool_call(
+            AUDIT_TOOL,
+            json!({"action":"event_history","time_start":"2026-12-31","time_end":"2026-01-01"})
+        ),
+    )
+}
+
+pub fn generated_mcp_cli_demo_script() -> String {
+    format!(
+        "#!/usr/bin/env bash\nset -euo pipefail\n\n\
+JOURNAL_PATH=\"${{JOURNAL_PATH:-/tmp/demo.beancount}}\"\n\
+WORKBOOK_PATH=\"${{WORKBOOK_PATH:-/tmp/demo.xlsx}}\"\n\
+SOURCE_REF=\"${{SOURCE_REF:-wf-2023-01.rkyv}}\"\n\n\
+cargo run -q -p ledgerr-mcp --bin ledgerr-mcp-server <<EOF\n\
+{{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{{\"clientInfo\":{{\"name\":\"demo\",\"version\":\"0.1.0\"}}}}}}\n\
+{{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\",\"params\":{{}}}}\n\
+{{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{{}}}}\n\
+{{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{{\"name\":\"ledgerr_documents\",\"arguments\":{{\"action\":\"pipeline_status\"}}}}}}\n\
+{{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{{\"name\":\"ledgerr_documents\",\"arguments\":{{\"action\":\"list_accounts\"}}}}}}\n\
+{{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{{\"name\":\"ledgerr_documents\",\"arguments\":{{\"action\":\"ingest_pdf\",\"pdf_path\":\"WF--BH-CHK--2023-01--statement.pdf\",\"journal_path\":\"$JOURNAL_PATH\",\"workbook_path\":\"$WORKBOOK_PATH\",\"raw_context_bytes\":[99,116,120],\"extracted_rows\":[{{\"account_id\":\"WF-BH-CHK\",\"date\":\"2023-01-15\",\"amount\":\"-42.11\",\"description\":\"Coffee Shop\",\"source_ref\":\"$SOURCE_REF\"}}]}}}}}}\n\
+{{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"tools/call\",\"params\":{{\"name\":\"ledgerr_documents\",\"arguments\":{{\"action\":\"get_raw_context\",\"rkyv_ref\":\"$SOURCE_REF\"}}}}}}\n\
+EOF\n\n\
+# Troubleshooting path\n\
+cat <<'EOF'\n\
+{{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{{\"name\":\"ledgerr_workflow\",\"arguments\":{{\"action\":\"resume\",\"state_marker\":\"invalid-checkpoint\"}}}}}}\n\
+{{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{{\"name\":\"ledgerr_reconciliation\",\"arguments\":{{\"action\":\"commit\",\"source_total\":\"100.00\",\"extracted_total\":\"95.00\",\"posting_amounts\":[\"-95.00\",\"95.00\"]}}}}}}\n\
+{{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{{\"name\":\"ledgerr_audit\",\"arguments\":{{\"action\":\"event_history\",\"time_start\":\"2026-12-31\",\"time_end\":\"2026-01-01\"}}}}}}\n\
+EOF\n"
+    )
+}
+
+fn documents_ingest_pdf_example() -> Value {
+    json!({
+      "jsonrpc":"2.0",
+      "id":3,
+      "method":"tools/call",
+      "params":{
+        "name":"ledgerr_documents",
+        "arguments":{
+          "action":"ingest_pdf",
+          "pdf_path":"WF--BH-CHK--2023-01--statement.pdf",
+          "journal_path":"/tmp/demo.beancount",
+          "workbook_path":"/tmp/demo.xlsx",
+          "raw_context_bytes":[99,116,120],
+          "extracted_rows":[{
+            "account_id":"WF-BH-CHK",
+            "date":"2023-01-05",
+            "amount":"-42.50",
+            "description":"Coffee Beans",
+            "source_ref":"wf-2023-01.rkyv"
+          }]
+        }
+      }
+    })
+}
+
+fn reconciliation_commit_example() -> Value {
+    json!({
+      "jsonrpc":"2.0",
+      "id":4,
+      "method":"tools/call",
+      "params":{
+        "name":"ledgerr_reconciliation",
+        "arguments":{
+          "action":"commit",
+          "source_total":"42.50",
+          "extracted_total":"42.50",
+          "posting_amounts":["-42.50","42.50"]
+        }
+      }
+    })
+}
+
+fn tax_evidence_chain_example() -> Value {
+    json!({
+      "jsonrpc":"2.0",
+      "id":7,
+      "method":"tools/call",
+      "params":{
+        "name":"ledgerr_tax",
+        "arguments":{
+          "action":"evidence_chain",
+          "ontology_path":"/tmp/ontology.json",
+          "from_entity_id":"WF-BH-CHK",
+          "document_ref":"wf-2023-01.rkyv"
+        }
+      }
+    })
+}
+
+fn pretty_json(value: &Value) -> String {
+    serde_json::to_string_pretty(value).expect("json example")
+}
+
+fn compact_tool_call(name: &str, arguments: Value) -> String {
+    serde_json::to_string(&json!({ "name": name, "arguments": arguments })).expect("json line")
+}

--- a/crates/ledgerr-mcp/src/lib.rs
+++ b/crates/ledgerr-mcp/src/lib.rs
@@ -10,6 +10,7 @@ use ledger_core::manifest::Manifest;
 use rust_decimal::Decimal;
 use rust_xlsxwriter::Workbook;
 
+pub mod contract;
 pub mod mcp_adapter;
 pub mod plugin_info;
 pub mod events;

--- a/crates/ledgerr-mcp/src/mcp_adapter.rs
+++ b/crates/ledgerr-mcp/src/mcp_adapter.rs
@@ -5,24 +5,25 @@ use serde::Serialize;
 use serde_json::{json, Value};
 
 use crate::{
+    contract::{
+        self, AuditArgs, DocumentsArgs, OntologyArgs, ReconciliationArgs, ReviewArgs, TaxArgs,
+        WorkflowArgs,
+    },
     ClassifyIngestedRequest, ClassifyTransactionRequest, EventHistoryFilter,
     ExportCpaWorkbookRequest, FlagStatusRequest, GetRawContextRequest, GetScheduleSummaryRequest,
     HsmResumeRequest, HsmStatusRequest, HsmTransitionRequest, IngestPdfRequest,
     IngestStatementRowsRequest, ListAccountsRequest, OntologyExportSnapshotRequest,
     OntologyQueryPathRequest, OntologyUpsertEdgesRequest, OntologyUpsertEntitiesRequest,
     QueryAuditLogRequest, QueryFlagsRequest, ReconcileExcelClassificationRequest,
-    ReconciliationStageRequest, ReplayLifecycleRequest, ScheduleKindRequest,
-    RunRhaiRuleRequest, SampleTxRequest, TaxAmbiguityReviewRequest, TaxAssistRequest,
-    TaxEvidenceChainRequest, ToolError, TurboLedgerService, TurboLedgerTools,
+    ReconciliationStageRequest, ReplayLifecycleRequest, RunRhaiRuleRequest, SampleTxRequest,
+    ScheduleKindRequest, TaxAmbiguityReviewRequest, TaxAssistRequest, TaxEvidenceChainRequest,
+    ToolError, TurboLedgerService, TurboLedgerTools,
 };
 
-pub const DOCUMENTS_TOOL: &str = "ledgerr_documents";
-pub const REVIEW_TOOL: &str = "ledgerr_review";
-pub const RECONCILIATION_TOOL: &str = "ledgerr_reconciliation";
-pub const WORKFLOW_TOOL: &str = "ledgerr_workflow";
-pub const AUDIT_TOOL: &str = "ledgerr_audit";
-pub const TAX_TOOL: &str = "ledgerr_tax";
-pub const ONTOLOGY_TOOL: &str = "ledgerr_ontology";
+pub use crate::contract::{
+    AUDIT_TOOL, DOCUMENTS_TOOL, ONTOLOGY_TOOL, RECONCILIATION_TOOL, REVIEW_TOOL, TAX_TOOL,
+    WORKFLOW_TOOL,
+};
 
 #[allow(clippy::vec_init_then_push)]
 pub fn tool_names() -> Vec<String> {
@@ -94,175 +95,7 @@ pub fn tool_descriptors() -> Vec<Value> {
 
 /// Returns the JSON Schema for the input arguments of a named tool.
 pub fn tool_input_schema(name: &str) -> Value {
-    match name {
-        DOCUMENTS_TOOL => json!({
-            "type": "object",
-            "required": ["action"],
-            "properties": {
-                "action": {
-                    "type": "string",
-                    "enum": ["list_accounts", "get_raw_context", "pipeline_status", "validate_filename", "ingest_pdf", "ingest_rows"]
-                },
-                "file_name": { "type": "string", "description": "Contract filename to validate" },
-                "rkyv_ref": { "type": "string", "description": "Path to the rkyv context file" },
-                "pdf_path": { "type": "string", "description": "Path to the PDF file (VENDOR--ACCOUNT--YYYY-MM--DOCTYPE naming required)" },
-                "journal_path": { "type": "string", "description": "Path to the journal file" },
-                "workbook_path": { "type": "string", "description": "Path to the Excel workbook" },
-                "raw_context_bytes": {
-                    "type": "array",
-                    "items": { "type": "integer", "minimum": 0, "maximum": 255 },
-                    "description": "Raw PDF bytes as a byte array (required when source file does not yet exist on disk)"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "required": ["date", "amount", "description", "source_ref"],
-                        "properties": {
-                            "account_id": { "type": "string" },
-                            "account": { "type": "string" },
-                            "date": { "type": "string", "format": "date" },
-                            "amount": { "type": "string" },
-                            "description": { "type": "string" },
-                            "source_ref": { "type": "string" }
-                        }
-                    }
-                },
-                "extracted_rows": {
-                    "type": "array",
-                    "items": { "type": "object" },
-                    "description": "Pre-extracted transaction rows from Docling"
-                }
-            }
-        }),
-        REVIEW_TOOL => json!({
-            "type": "object",
-            "required": ["action"],
-            "properties": {
-                "action": {
-                    "type": "string",
-                    "enum": ["run_rule", "classify_ingested", "query_flags", "classify_transaction", "reconcile_excel_classification"]
-                },
-                "rule_file": { "type": "string", "description": "Path to the Rhai rule file" },
-                "review_threshold": { "type": "number" },
-                "year": { "type": "integer" },
-                "status": { "type": "string", "enum": ["open", "resolved"] },
-                "tx_id": { "type": "string" },
-                "category": { "type": "string" },
-                "confidence": { "type": "string" },
-                "note": { "type": "string" },
-                "actor": { "type": "string" },
-                "sample_tx": {
-                    "type": "object",
-                    "properties": {
-                        "tx_id": { "type": "string" },
-                        "account_id": { "type": "string" },
-                        "date": { "type": "string" },
-                        "amount": { "type": "string" },
-                        "description": { "type": "string" }
-                    }
-                }
-            }
-        }),
-        RECONCILIATION_TOOL => json!({
-            "type": "object",
-            "required": ["action", "source_total", "extracted_total", "posting_amounts"],
-            "properties": {
-                "action": { "type": "string", "enum": ["validate", "reconcile", "commit"] },
-                "source_total": { "type": "string" },
-                "extracted_total": { "type": "string" },
-                "posting_amounts": { "type": "array", "items": { "type": "string" } }
-            }
-        }),
-        WORKFLOW_TOOL => json!({
-            "type": "object",
-            "required": ["action"],
-            "properties": {
-                "action": {
-                    "type": "string",
-                    "enum": ["status", "transition", "resume", "plugin_info"]
-                },
-                "target_state": { "type": "string" },
-                "target_substate": { "type": "string" },
-                "state_marker": { "type": "string" },
-                "subcommand": { "type": "string", "enum": ["check", "upgrade", "cleanup"] }
-            }
-        }),
-        AUDIT_TOOL => json!({
-            "type": "object",
-            "required": ["action"],
-            "properties": {
-                "action": { "type": "string", "enum": ["event_history", "event_replay", "query_audit_log"] },
-                "tx_id": { "type": "string" },
-                "document_ref": { "type": "string" },
-                "time_start": { "type": "string", "format": "date-time" },
-                "time_end": { "type": "string", "format": "date-time" }
-            }
-        }),
-        TAX_TOOL => json!({
-            "type": "object",
-            "required": ["action"],
-            "properties": {
-                "action": {
-                    "type": "string",
-                    "enum": ["assist", "evidence_chain", "ambiguity_review", "schedule_summary", "export_workbook"]
-                },
-                "ontology_path": { "type": "string" },
-                "from_entity_id": { "type": "string" },
-                "max_depth": { "type": "integer", "minimum": 0 },
-                "reconciliation": {
-                    "type": "object",
-                    "properties": {
-                        "source_total": { "type": "string" },
-                        "extracted_total": { "type": "string" },
-                        "posting_amounts": { "type": "array", "items": { "type": "string" } }
-                    }
-                },
-                "tx_id": { "type": "string" },
-                "document_ref": { "type": "string" },
-                "year": { "type": "integer" },
-                "schedule": { "type": "string", "enum": ["ScheduleC", "ScheduleD", "ScheduleE", "Fbar"] },
-                "workbook_path": { "type": "string" }
-            }
-        }),
-        ONTOLOGY_TOOL => json!({
-            "type": "object",
-            "required": ["action", "ontology_path"],
-            "properties": {
-                "action": { "type": "string", "enum": ["query_path", "export_snapshot", "upsert_entities", "upsert_edges"] },
-                "ontology_path": { "type": "string" },
-                "from_entity_id": { "type": "string" },
-                "max_depth": { "type": "integer", "minimum": 0 },
-                "entities": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "required": ["kind"],
-                        "properties": {
-                            "kind": { "type": "string", "enum": ["Document", "Account", "Institution", "Transaction", "TaxCategory", "EvidenceReference"] },
-                            "id": { "type": "string" },
-                            "label": { "type": "string" },
-                            "properties": { "type": "object" }
-                        }
-                    }
-                },
-                "edges": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "required": ["from_id", "to_id", "relation"],
-                        "properties": {
-                            "from_id": { "type": "string" },
-                            "to_id": { "type": "string" },
-                            "relation": { "type": "string" },
-                            "provenance": { "type": "object" }
-                        }
-                    }
-                }
-            }
-        }),
-        _ => json!({ "type": "object" }),
-    }
+    contract::tool_input_schema(name)
 }
 
 pub fn handle_list_accounts(service: &TurboLedgerService) -> Value {
@@ -427,21 +260,19 @@ fn handle_plugin_info(arguments: &Value) -> Value {
 }
 
 pub fn handle_documents_tool(service: &TurboLedgerService, arguments: &Value) -> Value {
-    let action = match required_str(arguments, "action") {
-        Ok(action) => action,
+    let request = match contract::parse_documents(arguments) {
+        Ok(request) => request,
         Err(err) => return error_envelope(&err),
     };
 
-    match action {
-        "list_accounts" => handle_list_accounts(service),
-        "get_raw_context" => handle_get_raw_context(service, arguments),
-        "pipeline_status" => handle_pipeline_status(true, true, true, Vec::new()),
-        "validate_filename" => {
-            let file_name = match required_str(arguments, "file_name") {
-                Ok(file_name) => file_name,
-                Err(err) => return error_envelope(&err),
-            };
-            match service.validate_source_filename(file_name) {
+    match request {
+        DocumentsArgs::ListAccounts => handle_list_accounts(service),
+        DocumentsArgs::GetRawContext { rkyv_ref } => {
+            handle_get_raw_context(service, &json!({ "rkyv_ref": rkyv_ref }))
+        }
+        DocumentsArgs::PipelineStatus => handle_pipeline_status(true, true, true, Vec::new()),
+        DocumentsArgs::ValidateFilename { file_name } => {
+            match service.validate_source_filename(&file_name) {
                 Ok(parsed) => json!({
                     "content": [text_content(json!({
                         "vendor": parsed.vendor,
@@ -455,21 +286,54 @@ pub fn handle_documents_tool(service: &TurboLedgerService, arguments: &Value) ->
                 Err(err) => error_envelope(&err),
             }
         }
-        "ingest_pdf" => handle_ingest_pdf(service, arguments, None),
-        "ingest_rows" => handle_ingest_statement_rows(service, arguments, None),
-        other => unknown_tool_action_result(DOCUMENTS_TOOL, other),
+        DocumentsArgs::IngestPdf {
+            pdf_path,
+            journal_path,
+            workbook_path,
+            raw_context_bytes,
+            extracted_rows,
+        } => handle_ingest_pdf(
+            service,
+            &json!({
+                "pdf_path": pdf_path,
+                "journal_path": journal_path,
+                "workbook_path": workbook_path,
+                "raw_context_bytes": raw_context_bytes,
+                "extracted_rows": extracted_rows,
+            }),
+            None,
+        ),
+        DocumentsArgs::IngestRows {
+            journal_path,
+            workbook_path,
+            rows,
+        } => handle_ingest_statement_rows(
+            service,
+            &json!({
+                "journal_path": journal_path,
+                "workbook_path": workbook_path,
+                "rows": rows,
+            }),
+            None,
+        ),
     }
 }
 
 pub fn handle_review_tool(service: &TurboLedgerService, arguments: &Value) -> Value {
-    let action = match required_str(arguments, "action") {
-        Ok(action) => action,
+    let request = match contract::parse_review(arguments) {
+        Ok(request) => request,
         Err(err) => return error_envelope(&err),
     };
 
-    match action {
-        "run_rule" => {
-            let request = match parse_run_rhai_rule_request(arguments) {
+    match request {
+        ReviewArgs::RunRule {
+            rule_file,
+            sample_tx,
+        } => {
+            let request = match parse_run_rhai_rule_request(&json!({
+                "rule_file": rule_file,
+                "sample_tx": sample_tx,
+            })) {
                 Ok(request) => request,
                 Err(err) => return error_envelope(&err),
             };
@@ -486,83 +350,292 @@ pub fn handle_review_tool(service: &TurboLedgerService, arguments: &Value) -> Va
                 Err(err) => error_envelope(&err),
             }
         }
-        "classify_ingested" => handle_classify_ingested(service, arguments),
-        "query_flags" => handle_query_flags(service, arguments),
-        "classify_transaction" => handle_classify_transaction(service, arguments),
-        "reconcile_excel_classification" => handle_reconcile_excel_classification(service, arguments),
-        other => unknown_tool_action_result(REVIEW_TOOL, other),
+        ReviewArgs::ClassifyIngested {
+            rule_file,
+            review_threshold,
+        } => handle_classify_ingested(
+            service,
+            &json!({
+                "rule_file": rule_file,
+                "review_threshold": review_threshold.as_json(),
+            }),
+        ),
+        ReviewArgs::QueryFlags { year, status } => handle_query_flags(
+            service,
+            &json!({
+                "year": year,
+                "status": match status {
+                    crate::contract::ReviewStatusInput::Open => "open",
+                    crate::contract::ReviewStatusInput::Resolved => "resolved",
+                }
+            }),
+        ),
+        ReviewArgs::ClassifyTransaction {
+            tx_id,
+            category,
+            confidence,
+            note,
+            actor,
+        } => handle_classify_transaction(
+            service,
+            &json!({
+                "tx_id": tx_id,
+                "category": category,
+                "confidence": confidence,
+                "note": note,
+                "actor": actor,
+            }),
+        ),
+        ReviewArgs::ReconcileExcelClassification {
+            tx_id,
+            category,
+            confidence,
+            actor,
+            note,
+        } => handle_reconcile_excel_classification(
+            service,
+            &json!({
+                "tx_id": tx_id,
+                "category": category,
+                "confidence": confidence,
+                "actor": actor,
+                "note": note,
+            }),
+        ),
     }
 }
 
 pub fn handle_reconciliation_tool(service: &TurboLedgerService, arguments: &Value) -> Value {
-    let action = match required_str(arguments, "action") {
-        Ok(action) => action,
+    let request = match contract::parse_reconciliation(arguments) {
+        Ok(request) => request,
         Err(err) => return error_envelope(&err),
     };
 
-    match action {
-        "validate" | "reconcile" | "commit" => dispatch_reconciliation(service, action, arguments),
-        other => unknown_tool_action_result(RECONCILIATION_TOOL, other),
+    match request {
+        ReconciliationArgs::Validate {
+            source_total,
+            extracted_total,
+            posting_amounts,
+        } => dispatch_reconciliation(
+            service,
+            "validate",
+            &json!({
+                "source_total": source_total,
+                "extracted_total": extracted_total,
+                "posting_amounts": posting_amounts,
+            }),
+        ),
+        ReconciliationArgs::Reconcile {
+            source_total,
+            extracted_total,
+            posting_amounts,
+        } => dispatch_reconciliation(
+            service,
+            "reconcile",
+            &json!({
+                "source_total": source_total,
+                "extracted_total": extracted_total,
+                "posting_amounts": posting_amounts,
+            }),
+        ),
+        ReconciliationArgs::Commit {
+            source_total,
+            extracted_total,
+            posting_amounts,
+        } => dispatch_reconciliation(
+            service,
+            "commit",
+            &json!({
+                "source_total": source_total,
+                "extracted_total": extracted_total,
+                "posting_amounts": posting_amounts,
+            }),
+        ),
     }
 }
 
 pub fn handle_workflow_tool(service: &TurboLedgerService, arguments: &Value) -> Value {
-    let action = match required_str(arguments, "action") {
-        Ok(action) => action,
+    let request = match contract::parse_workflow(arguments) {
+        Ok(request) => request,
         Err(err) => return error_envelope(&err),
     };
 
-    match action {
-        "status" => dispatch_hsm(service, "status", arguments),
-        "transition" => dispatch_hsm(service, "transition", arguments),
-        "resume" => dispatch_hsm(service, "resume", arguments),
-        "plugin_info" => handle_plugin_info(arguments),
-        other => unknown_tool_action_result(WORKFLOW_TOOL, other),
+    match request {
+        WorkflowArgs::Status => dispatch_hsm(service, "status", &json!({})),
+        WorkflowArgs::Transition {
+            target_state,
+            target_substate,
+        } => dispatch_hsm(
+            service,
+            "transition",
+            &json!({
+                "target_state": target_state,
+                "target_substate": target_substate,
+            }),
+        ),
+        WorkflowArgs::Resume { state_marker } => dispatch_hsm(
+            service,
+            "resume",
+            &json!({
+                "state_marker": state_marker,
+            }),
+        ),
+        WorkflowArgs::PluginInfo { payload } => handle_plugin_info(&json!({
+            "subcommand": payload.subcommand.map(|value| value.0),
+        })),
     }
 }
 
 pub fn handle_audit_tool(service: &TurboLedgerService, arguments: &Value) -> Value {
-    let action = match required_str(arguments, "action") {
-        Ok(action) => action,
+    let request = match contract::parse_audit(arguments) {
+        Ok(request) => request,
         Err(err) => return error_envelope(&err),
     };
 
-    match action {
-        "event_history" => handle_event_history(service, arguments),
-        "event_replay" => handle_event_replay(service, arguments),
-        "query_audit_log" => handle_query_audit_log(service, arguments),
-        other => unknown_tool_action_result(AUDIT_TOOL, other),
+    match request {
+        AuditArgs::EventHistory {
+            tx_id,
+            document_ref,
+            time_start,
+            time_end,
+        } => handle_event_history(
+            service,
+            &json!({
+                "tx_id": tx_id,
+                "document_ref": document_ref,
+                "time_start": time_start,
+                "time_end": time_end,
+            }),
+        ),
+        AuditArgs::EventReplay {
+            tx_id,
+            document_ref,
+        } => handle_event_replay(
+            service,
+            &json!({
+                "tx_id": tx_id,
+                "document_ref": document_ref,
+            }),
+        ),
+        AuditArgs::QueryAuditLog => handle_query_audit_log(service, &json!({})),
     }
 }
 
 pub fn handle_tax_tool(service: &TurboLedgerService, arguments: &Value) -> Value {
-    let action = match required_str(arguments, "action") {
-        Ok(action) => action,
+    let request = match contract::parse_tax(arguments) {
+        Ok(request) => request,
         Err(err) => return error_envelope(&err),
     };
 
-    match action {
-        "assist" => handle_tax_assist(service, arguments),
-        "evidence_chain" => handle_tax_evidence_chain(service, arguments),
-        "ambiguity_review" => handle_tax_ambiguity_review(service, arguments),
-        "schedule_summary" => handle_get_schedule_summary(service, arguments),
-        "export_workbook" => handle_export_cpa_workbook(service, arguments),
-        other => unknown_tool_action_result(TAX_TOOL, other),
+    match request {
+        TaxArgs::Assist {
+            ontology_path,
+            from_entity_id,
+            max_depth,
+            reconciliation,
+        } => handle_tax_assist(
+            service,
+            &json!({
+                "ontology_path": ontology_path,
+                "from_entity_id": from_entity_id,
+                "max_depth": max_depth,
+                "reconciliation": reconciliation,
+            }),
+        ),
+        TaxArgs::EvidenceChain {
+            ontology_path,
+            from_entity_id,
+            tx_id,
+            document_ref,
+        } => handle_tax_evidence_chain(
+            service,
+            &json!({
+                "ontology_path": ontology_path,
+                "from_entity_id": from_entity_id,
+                "tx_id": tx_id,
+                "document_ref": document_ref,
+            }),
+        ),
+        TaxArgs::AmbiguityReview {
+            ontology_path,
+            from_entity_id,
+            max_depth,
+            reconciliation,
+        } => handle_tax_ambiguity_review(
+            service,
+            &json!({
+                "ontology_path": ontology_path,
+                "from_entity_id": from_entity_id,
+                "max_depth": max_depth,
+                "reconciliation": reconciliation,
+            }),
+        ),
+        TaxArgs::ScheduleSummary { year, schedule } => handle_get_schedule_summary(
+            service,
+            &json!({
+                "year": year,
+                "schedule": match schedule {
+                    crate::contract::ScheduleInput::ScheduleC => "ScheduleC",
+                    crate::contract::ScheduleInput::ScheduleD => "ScheduleD",
+                    crate::contract::ScheduleInput::ScheduleE => "ScheduleE",
+                    crate::contract::ScheduleInput::Fbar => "Fbar",
+                }
+            }),
+        ),
+        TaxArgs::ExportWorkbook { workbook_path } => handle_export_cpa_workbook(
+            service,
+            &json!({
+                "workbook_path": workbook_path,
+            }),
+        ),
     }
 }
 
 pub fn handle_ontology_tool(service: &TurboLedgerService, arguments: &Value) -> Value {
-    let action = match required_str(arguments, "action") {
-        Ok(action) => action,
+    let request = match contract::parse_ontology(arguments) {
+        Ok(request) => request,
         Err(err) => return error_envelope(&err),
     };
 
-    match action {
-        "query_path" => handle_ontology_query_path(service, arguments),
-        "export_snapshot" => handle_ontology_export_snapshot(service, arguments),
-        "upsert_entities" => handle_ontology_upsert_entities(service, arguments),
-        "upsert_edges" => handle_ontology_upsert_edges(service, arguments),
-        other => unknown_tool_action_result(ONTOLOGY_TOOL, other),
+    match request {
+        OntologyArgs::QueryPath {
+            ontology_path,
+            from_entity_id,
+            max_depth,
+        } => handle_ontology_query_path(
+            service,
+            &json!({
+                "ontology_path": ontology_path,
+                "from_entity_id": from_entity_id,
+                "max_depth": max_depth,
+            }),
+        ),
+        OntologyArgs::ExportSnapshot { ontology_path } => handle_ontology_export_snapshot(
+            service,
+            &json!({
+                "ontology_path": ontology_path,
+            }),
+        ),
+        OntologyArgs::UpsertEntities {
+            ontology_path,
+            entities,
+        } => handle_ontology_upsert_entities(
+            service,
+            &json!({
+                "ontology_path": ontology_path,
+                "entities": entities,
+            }),
+        ),
+        OntologyArgs::UpsertEdges {
+            ontology_path,
+            edges,
+        } => handle_ontology_upsert_edges(
+            service,
+            &json!({
+                "ontology_path": ontology_path,
+                "edges": edges,
+            }),
+        ),
     }
 }
 
@@ -1307,10 +1380,7 @@ pub fn handle_export_cpa_workbook(service: &TurboLedgerService, arguments: &Valu
     }
 }
 
-pub fn handle_ontology_upsert_entities(
-    service: &TurboLedgerService,
-    arguments: &Value,
-) -> Value {
+pub fn handle_ontology_upsert_entities(service: &TurboLedgerService, arguments: &Value) -> Value {
     let request = match parse_ontology_upsert_entities_request(arguments) {
         Ok(request) => request,
         Err(err) => return error_envelope(&err),

--- a/crates/ledgerr-mcp/src/mcp_adapter.rs
+++ b/crates/ledgerr-mcp/src/mcp_adapter.rs
@@ -12,72 +12,17 @@ use crate::{
     OntologyQueryPathRequest, OntologyUpsertEdgesRequest, OntologyUpsertEntitiesRequest,
     QueryAuditLogRequest, QueryFlagsRequest, ReconcileExcelClassificationRequest,
     ReconciliationStageRequest, ReplayLifecycleRequest, ScheduleKindRequest,
-    TaxAmbiguityReviewRequest, TaxAssistRequest, TaxEvidenceChainRequest, ToolError,
-    TurboLedgerService, TurboLedgerTools,
+    RunRhaiRuleRequest, SampleTxRequest, TaxAmbiguityReviewRequest, TaxAssistRequest,
+    TaxEvidenceChainRequest, ToolError, TurboLedgerService, TurboLedgerTools,
 };
 
-pub const LIST_ACCOUNTS_TOOL: &str = "l3dg3rr_list_accounts";
-pub const GET_RAW_CONTEXT_TOOL: &str = "l3dg3rr_get_raw_context";
-pub const ONTOLOGY_QUERY_PATH_TOOL: &str = "l3dg3rr_ontology_query_path";
-pub const ONTOLOGY_EXPORT_SNAPSHOT_TOOL: &str = "l3dg3rr_ontology_export_snapshot";
-pub const RECON_VALIDATE_TOOL: &str = "l3dg3rr_validate_reconciliation";
-pub const RECON_RECONCILE_TOOL: &str = "l3dg3rr_reconcile_postings";
-pub const RECON_COMMIT_TOOL: &str = "l3dg3rr_commit_guarded";
-pub const HSM_TRANSITION_TOOL: &str = "l3dg3rr_hsm_transition";
-pub const HSM_STATUS_TOOL: &str = "l3dg3rr_hsm_status";
-pub const HSM_RESUME_TOOL: &str = "l3dg3rr_hsm_resume";
-pub const EVENT_REPLAY_TOOL: &str = "l3dg3rr_event_replay";
-pub const EVENT_HISTORY_TOOL: &str = "l3dg3rr_event_history";
-pub const TAX_ASSIST_TOOL: &str = "l3dg3rr_tax_assist";
-pub const TAX_EVIDENCE_CHAIN_TOOL: &str = "l3dg3rr_tax_evidence_chain";
-pub const TAX_AMBIGUITY_REVIEW_TOOL: &str = "l3dg3rr_tax_ambiguity_review";
-
-// P0 tools
-pub const CLASSIFY_INGESTED_TOOL: &str = "l3dg3rr_classify_ingested";
-pub const QUERY_FLAGS_TOOL: &str = "l3dg3rr_query_flags";
-pub const QUERY_AUDIT_LOG_TOOL: &str = "l3dg3rr_query_audit_log";
-
-// P1 tools
-pub const CLASSIFY_TRANSACTION_TOOL: &str = "l3dg3rr_classify_transaction";
-pub const RECONCILE_EXCEL_CLASSIFICATION_TOOL: &str = "l3dg3rr_reconcile_excel_classification";
-pub const GET_SCHEDULE_SUMMARY_TOOL: &str = "l3dg3rr_get_schedule_summary";
-
-// P2 tools
-pub const EXPORT_CPA_WORKBOOK_TOOL: &str = "l3dg3rr_export_cpa_workbook";
-pub const ONTOLOGY_UPSERT_ENTITIES_TOOL: &str = "l3dg3rr_ontology_upsert_entities";
-pub const ONTOLOGY_UPSERT_EDGES_TOOL: &str = "l3dg3rr_ontology_upsert_edges";
-
-// Meta / self-management (always included regardless of feature flags)
-pub use crate::plugin_info::PLUGIN_INFO_TOOL;
-
-pub const TOOL_GROUP_CORE: &[&str] = &[
-    LIST_ACCOUNTS_TOOL,
-    GET_RAW_CONTEXT_TOOL,
-    "proxy_docling_ingest_pdf",
-    "proxy_rustledger_ingest_statement_rows",
-    "l3dg3rr_get_pipeline_status",
-];
-pub const TOOL_GROUP_ONTOLOGY: &[&str] = &[ONTOLOGY_QUERY_PATH_TOOL, ONTOLOGY_EXPORT_SNAPSHOT_TOOL];
-pub const TOOL_GROUP_RECONCILIATION: &[&str] =
-    &[RECON_VALIDATE_TOOL, RECON_RECONCILE_TOOL, RECON_COMMIT_TOOL];
-pub const TOOL_GROUP_HSM: &[&str] = &[HSM_TRANSITION_TOOL, HSM_STATUS_TOOL, HSM_RESUME_TOOL];
-pub const TOOL_GROUP_EVENTS: &[&str] = &[EVENT_REPLAY_TOOL, EVENT_HISTORY_TOOL];
-pub const TOOL_GROUP_CLASSIFICATION: &[&str] = &[
-    CLASSIFY_INGESTED_TOOL,
-    QUERY_FLAGS_TOOL,
-    CLASSIFY_TRANSACTION_TOOL,
-    RECONCILE_EXCEL_CLASSIFICATION_TOOL,
-];
-pub const TOOL_GROUP_TAX: &[&str] = &[
-    TAX_ASSIST_TOOL,
-    TAX_EVIDENCE_CHAIN_TOOL,
-    TAX_AMBIGUITY_REVIEW_TOOL,
-    GET_SCHEDULE_SUMMARY_TOOL,
-    EXPORT_CPA_WORKBOOK_TOOL,
-];
-pub const TOOL_GROUP_AUDIT: &[&str] = &[QUERY_AUDIT_LOG_TOOL];
-pub const TOOL_GROUP_ONTOLOGY_WRITE: &[&str] =
-    &[ONTOLOGY_UPSERT_ENTITIES_TOOL, ONTOLOGY_UPSERT_EDGES_TOOL];
+pub const DOCUMENTS_TOOL: &str = "ledgerr_documents";
+pub const REVIEW_TOOL: &str = "ledgerr_review";
+pub const RECONCILIATION_TOOL: &str = "ledgerr_reconciliation";
+pub const WORKFLOW_TOOL: &str = "ledgerr_workflow";
+pub const AUDIT_TOOL: &str = "ledgerr_audit";
+pub const TAX_TOOL: &str = "ledgerr_tax";
+pub const ONTOLOGY_TOOL: &str = "ledgerr_ontology";
 
 #[allow(clippy::vec_init_then_push)]
 pub fn tool_names() -> Vec<String> {
@@ -111,36 +56,27 @@ pub fn tool_names_for(features: &[&str]) -> Vec<String> {
     let mut tools = Vec::new();
 
     if features.contains(&"core") {
-        tools.extend(TOOL_GROUP_CORE.iter().map(|s| s.to_string()));
-    }
-    if features.contains(&"ontology") || features.contains(&"tax") {
-        tools.extend(TOOL_GROUP_ONTOLOGY.iter().map(|s| s.to_string()));
-    }
-    if features.contains(&"reconciliation") || features.contains(&"tax") {
-        tools.extend(TOOL_GROUP_RECONCILIATION.iter().map(|s| s.to_string()));
-    }
-    if features.contains(&"hsm") || features.contains(&"tax") {
-        tools.extend(TOOL_GROUP_HSM.iter().map(|s| s.to_string()));
-    }
-    if features.contains(&"events") || features.contains(&"tax") {
-        tools.extend(TOOL_GROUP_EVENTS.iter().map(|s| s.to_string()));
+        tools.push(DOCUMENTS_TOOL.to_string());
+        tools.push(WORKFLOW_TOOL.to_string());
     }
     if features.contains(&"classification") {
-        tools.extend(TOOL_GROUP_CLASSIFICATION.iter().map(|s| s.to_string()));
+        tools.push(REVIEW_TOOL.to_string());
+    }
+    if features.contains(&"reconciliation") {
+        tools.push(RECONCILIATION_TOOL.to_string());
+    }
+    if features.contains(&"events") || features.contains(&"audit") {
+        tools.push(AUDIT_TOOL.to_string());
     }
     if features.contains(&"tax") {
-        tools.extend(TOOL_GROUP_TAX.iter().map(|s| s.to_string()));
-    }
-    if features.contains(&"audit") {
-        tools.extend(TOOL_GROUP_AUDIT.iter().map(|s| s.to_string()));
+        tools.push(TAX_TOOL.to_string());
     }
     if features.contains(&"ontology") {
-        tools.extend(TOOL_GROUP_ONTOLOGY_WRITE.iter().map(|s| s.to_string()));
+        tools.push(ONTOLOGY_TOOL.to_string());
     }
 
-    // plugin_info is always available — not gated by any feature flag.
-    tools.push(PLUGIN_INFO_TOOL.to_string());
-
+    tools.sort();
+    tools.dedup();
     tools
 }
 
@@ -159,224 +95,144 @@ pub fn tool_descriptors() -> Vec<Value> {
 /// Returns the JSON Schema for the input arguments of a named tool.
 pub fn tool_input_schema(name: &str) -> Value {
     match name {
-        // ── no-argument tools ──────────────────────────────────────────────
-        LIST_ACCOUNTS_TOOL
-        | "l3dg3rr_get_pipeline_status"
-        | HSM_STATUS_TOOL
-        | QUERY_AUDIT_LOG_TOOL => json!({ "type": "object", "properties": {} }),
-
-        // ── ontology_export_snapshot ───────────────────────────────────────
-        ONTOLOGY_EXPORT_SNAPSHOT_TOOL => json!({
+        DOCUMENTS_TOOL => json!({
             "type": "object",
-            "required": ["ontology_path"],
+            "required": ["action"],
             "properties": {
-                "ontology_path": { "type": "string", "description": "Path to the ontology file" }
-            }
-        }),
-
-        // ── get_raw_context ───────────────────────────────────────────────
-        GET_RAW_CONTEXT_TOOL => json!({
-            "type": "object",
-            "required": ["path"],
-            "properties": {
-                "path": { "type": "string", "description": "Path to the rkyv context file" }
-            }
-        }),
-
-        // ── proxy_docling_ingest_pdf ───────────────────────────────────────
-        "proxy_docling_ingest_pdf" => json!({
-            "type": "object",
-            "required": ["pdf_path", "journal_path", "workbook_path"],
-            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list_accounts", "get_raw_context", "pipeline_status", "validate_filename", "ingest_pdf", "ingest_rows"]
+                },
+                "file_name": { "type": "string", "description": "Contract filename to validate" },
+                "rkyv_ref": { "type": "string", "description": "Path to the rkyv context file" },
                 "pdf_path": { "type": "string", "description": "Path to the PDF file (VENDOR--ACCOUNT--YYYY-MM--DOCTYPE naming required)" },
                 "journal_path": { "type": "string", "description": "Path to the journal file" },
                 "workbook_path": { "type": "string", "description": "Path to the Excel workbook" },
                 "raw_context_bytes": {
-                    "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 255 },
+                    "type": "array",
+                    "items": { "type": "integer", "minimum": 0, "maximum": 255 },
                     "description": "Raw PDF bytes as a byte array (required when source file does not yet exist on disk)"
                 },
-                "extracted_rows": {
-                    "type": "array", "items": { "type": "object" },
-                    "description": "Pre-extracted transaction rows from Docling (optional; omit or pass [] to ingest without rows)"
-                }
-            }
-        }),
-
-        // ── proxy_rustledger_ingest_statement_rows ────────────────────────
-        "proxy_rustledger_ingest_statement_rows" => json!({
-            "type": "object",
-            "required": ["rows"],
-            "properties": {
                 "rows": {
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "required": ["account_id", "date", "amount", "description", "source_ref"],
+                        "required": ["date", "amount", "description", "source_ref"],
                         "properties": {
                             "account_id": { "type": "string" },
+                            "account": { "type": "string" },
                             "date": { "type": "string", "format": "date" },
-                            "amount": { "type": "string", "description": "Decimal string, e.g. \"-42.11\"" },
+                            "amount": { "type": "string" },
                             "description": { "type": "string" },
                             "source_ref": { "type": "string" }
                         }
                     }
+                },
+                "extracted_rows": {
+                    "type": "array",
+                    "items": { "type": "object" },
+                    "description": "Pre-extracted transaction rows from Docling"
                 }
             }
         }),
-
-        // ── ontology_query_path ───────────────────────────────────────────
-        ONTOLOGY_QUERY_PATH_TOOL => json!({
+        REVIEW_TOOL => json!({
             "type": "object",
-            "required": ["path"],
+            "required": ["action"],
             "properties": {
-                "path": { "type": "string", "description": "Filesystem path to the ontology file" },
-                "max_depth": { "type": "integer", "minimum": 0, "description": "Maximum traversal depth (optional)" }
-            }
-        }),
-
-        // ── reconciliation tools (validate / reconcile / commit) ──────────
-        RECON_VALIDATE_TOOL | RECON_RECONCILE_TOOL | RECON_COMMIT_TOOL => json!({
-            "type": "object",
-            "required": ["source_total", "extracted_total", "posting_amounts"],
-            "properties": {
-                "source_total": { "type": "string", "description": "Total from source document (decimal string)" },
-                "extracted_total": { "type": "string", "description": "Total of extracted rows (decimal string)" },
-                "posting_amounts": {
-                    "type": "array", "items": { "type": "string" },
-                    "description": "Individual posting amounts as decimal strings"
+                "action": {
+                    "type": "string",
+                    "enum": ["run_rule", "classify_ingested", "query_flags", "classify_transaction", "reconcile_excel_classification"]
+                },
+                "rule_file": { "type": "string", "description": "Path to the Rhai rule file" },
+                "review_threshold": { "type": "number" },
+                "year": { "type": "integer" },
+                "status": { "type": "string", "enum": ["open", "resolved"] },
+                "tx_id": { "type": "string" },
+                "category": { "type": "string" },
+                "confidence": { "type": "string" },
+                "note": { "type": "string" },
+                "actor": { "type": "string" },
+                "sample_tx": {
+                    "type": "object",
+                    "properties": {
+                        "tx_id": { "type": "string" },
+                        "account_id": { "type": "string" },
+                        "date": { "type": "string" },
+                        "amount": { "type": "string" },
+                        "description": { "type": "string" }
+                    }
                 }
             }
         }),
-
-        // ── hsm_transition ────────────────────────────────────────────────
-        HSM_TRANSITION_TOOL => json!({
+        RECONCILIATION_TOOL => json!({
             "type": "object",
-            "required": ["target_state", "target_substate"],
+            "required": ["action", "source_total", "extracted_total", "posting_amounts"],
             "properties": {
+                "action": { "type": "string", "enum": ["validate", "reconcile", "commit"] },
+                "source_total": { "type": "string" },
+                "extracted_total": { "type": "string" },
+                "posting_amounts": { "type": "array", "items": { "type": "string" } }
+            }
+        }),
+        WORKFLOW_TOOL => json!({
+            "type": "object",
+            "required": ["action"],
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["status", "transition", "resume", "plugin_info"]
+                },
                 "target_state": { "type": "string" },
-                "target_substate": { "type": "string" }
+                "target_substate": { "type": "string" },
+                "state_marker": { "type": "string" },
+                "subcommand": { "type": "string", "enum": ["check", "upgrade", "cleanup"] }
             }
         }),
-
-        // ── hsm_resume ────────────────────────────────────────────────────
-        HSM_RESUME_TOOL => json!({
+        AUDIT_TOOL => json!({
             "type": "object",
-            "required": ["state_marker"],
+            "required": ["action"],
             "properties": {
-                "state_marker": { "type": "string" }
-            }
-        }),
-
-        // ── event_history ─────────────────────────────────────────────────
-        EVENT_HISTORY_TOOL => json!({
-            "type": "object",
-            "properties": {
+                "action": { "type": "string", "enum": ["event_history", "event_replay", "query_audit_log"] },
                 "tx_id": { "type": "string" },
                 "document_ref": { "type": "string" },
                 "time_start": { "type": "string", "format": "date-time" },
                 "time_end": { "type": "string", "format": "date-time" }
             }
         }),
-
-        // ── event_replay ──────────────────────────────────────────────────
-        EVENT_REPLAY_TOOL => json!({
+        TAX_TOOL => json!({
             "type": "object",
+            "required": ["action"],
             "properties": {
-                "tx_id": { "type": "string" },
-                "document_ref": { "type": "string" }
-            }
-        }),
-
-        // ── classify_ingested ─────────────────────────────────────────────
-        CLASSIFY_INGESTED_TOOL => json!({
-            "type": "object",
-            "required": ["rule_file", "review_threshold"],
-            "properties": {
-                "rule_file": { "type": "string", "description": "Path to the Rhai rule file" },
-                "review_threshold": { "type": "number", "description": "Confidence threshold below which transactions are flagged for review" }
-            }
-        }),
-
-        // ── query_flags ───────────────────────────────────────────────────
-        QUERY_FLAGS_TOOL => json!({
-            "type": "object",
-            "required": ["year", "status"],
-            "properties": {
-                "year": { "type": "integer" },
-                "status": { "type": "string", "enum": ["open", "resolved"] }
-            }
-        }),
-
-        // ── classify_transaction / reconcile_excel_classification ─────────
-        CLASSIFY_TRANSACTION_TOOL | RECONCILE_EXCEL_CLASSIFICATION_TOOL => json!({
-            "type": "object",
-            "required": ["tx_id", "category", "confidence", "actor"],
-            "properties": {
-                "tx_id": { "type": "string" },
-                "category": { "type": "string" },
-                "confidence": { "type": "string" },
-                "note": { "type": "string" },
-                "actor": { "type": "string" }
-            }
-        }),
-
-        // ── tax_assist / tax_ambiguity_review ─────────────────────────────
-        TAX_ASSIST_TOOL | TAX_AMBIGUITY_REVIEW_TOOL => json!({
-            "type": "object",
-            "required": ["ontology_path", "from_entity_id", "reconciliation"],
-            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["assist", "evidence_chain", "ambiguity_review", "schedule_summary", "export_workbook"]
+                },
                 "ontology_path": { "type": "string" },
                 "from_entity_id": { "type": "string" },
                 "max_depth": { "type": "integer", "minimum": 0 },
                 "reconciliation": {
                     "type": "object",
-                    "required": ["source_total", "extracted_total", "posting_amounts"],
                     "properties": {
                         "source_total": { "type": "string" },
                         "extracted_total": { "type": "string" },
                         "posting_amounts": { "type": "array", "items": { "type": "string" } }
                     }
-                }
+                },
+                "tx_id": { "type": "string" },
+                "document_ref": { "type": "string" },
+                "year": { "type": "integer" },
+                "schedule": { "type": "string", "enum": ["ScheduleC", "ScheduleD", "ScheduleE", "Fbar"] },
+                "workbook_path": { "type": "string" }
             }
         }),
-
-        // ── tax_evidence_chain ────────────────────────────────────────────
-        TAX_EVIDENCE_CHAIN_TOOL => json!({
+        ONTOLOGY_TOOL => json!({
             "type": "object",
-            "required": ["ontology_path", "from_entity_id"],
+            "required": ["action", "ontology_path"],
             "properties": {
+                "action": { "type": "string", "enum": ["query_path", "export_snapshot", "upsert_entities", "upsert_edges"] },
                 "ontology_path": { "type": "string" },
                 "from_entity_id": { "type": "string" },
-                "tx_id": { "type": "string" },
-                "document_ref": { "type": "string" }
-            }
-        }),
-
-        // ── get_schedule_summary ──────────────────────────────────────────
-        GET_SCHEDULE_SUMMARY_TOOL => json!({
-            "type": "object",
-            "required": ["year", "schedule"],
-            "properties": {
-                "year": { "type": "integer" },
-                "schedule": { "type": "string", "enum": ["ScheduleC", "ScheduleD", "ScheduleE", "Fbar"] }
-            }
-        }),
-
-        // ── export_cpa_workbook ───────────────────────────────────────────
-        EXPORT_CPA_WORKBOOK_TOOL => json!({
-            "type": "object",
-            "required": ["workbook_path"],
-            "properties": {
-                "workbook_path": { "type": "string", "description": "Output path for the Excel workbook" }
-            }
-        }),
-
-        // ── ontology_upsert_entities ──────────────────────────────────────
-        ONTOLOGY_UPSERT_ENTITIES_TOOL => json!({
-            "type": "object",
-            "required": ["path", "entities"],
-            "properties": {
-                "path": { "type": "string" },
+                "max_depth": { "type": "integer", "minimum": 0 },
                 "entities": {
                     "type": "array",
                     "items": {
@@ -389,16 +245,7 @@ pub fn tool_input_schema(name: &str) -> Value {
                             "properties": { "type": "object" }
                         }
                     }
-                }
-            }
-        }),
-
-        // ── ontology_upsert_edges ─────────────────────────────────────────
-        ONTOLOGY_UPSERT_EDGES_TOOL => json!({
-            "type": "object",
-            "required": ["path", "edges"],
-            "properties": {
-                "path": { "type": "string" },
+                },
                 "edges": {
                     "type": "array",
                     "items": {
@@ -414,11 +261,6 @@ pub fn tool_input_schema(name: &str) -> Value {
                 }
             }
         }),
-
-        // ── plugin_info ───────────────────────────────────────────────────
-        PLUGIN_INFO_TOOL => crate::plugin_info::input_schema(),
-
-        // ── unknown / future tools ────────────────────────────────────────
         _ => json!({ "type": "object" }),
     }
 }
@@ -576,14 +418,152 @@ pub fn unknown_tool_result(tool_name: &str) -> Value {
     })
 }
 
-/// Handle a `l3dg3rr_plugin_info` tool call.
-/// Wraps `crate::plugin_info::handle` in the standard MCP content envelope.
-pub fn handle_plugin_info(arguments: &Value) -> Value {
+fn handle_plugin_info(arguments: &Value) -> Value {
     let payload = crate::plugin_info::handle(arguments);
     json!({
         "content": [text_content(payload)],
         "isError": false
     })
+}
+
+pub fn handle_documents_tool(service: &TurboLedgerService, arguments: &Value) -> Value {
+    let action = match required_str(arguments, "action") {
+        Ok(action) => action,
+        Err(err) => return error_envelope(&err),
+    };
+
+    match action {
+        "list_accounts" => handle_list_accounts(service),
+        "get_raw_context" => handle_get_raw_context(service, arguments),
+        "pipeline_status" => handle_pipeline_status(true, true, true, Vec::new()),
+        "validate_filename" => {
+            let file_name = match required_str(arguments, "file_name") {
+                Ok(file_name) => file_name,
+                Err(err) => return error_envelope(&err),
+            };
+            match service.validate_source_filename(file_name) {
+                Ok(parsed) => json!({
+                    "content": [text_content(json!({
+                        "vendor": parsed.vendor,
+                        "account": parsed.account,
+                        "year": parsed.year,
+                        "month": parsed.month,
+                        "doc_type": parsed.doc_type,
+                    }))],
+                    "isError": false
+                }),
+                Err(err) => error_envelope(&err),
+            }
+        }
+        "ingest_pdf" => handle_ingest_pdf(service, arguments, None),
+        "ingest_rows" => handle_ingest_statement_rows(service, arguments, None),
+        other => unknown_tool_action_result(DOCUMENTS_TOOL, other),
+    }
+}
+
+pub fn handle_review_tool(service: &TurboLedgerService, arguments: &Value) -> Value {
+    let action = match required_str(arguments, "action") {
+        Ok(action) => action,
+        Err(err) => return error_envelope(&err),
+    };
+
+    match action {
+        "run_rule" => {
+            let request = match parse_run_rhai_rule_request(arguments) {
+                Ok(request) => request,
+                Err(err) => return error_envelope(&err),
+            };
+            match service.run_rhai_rule(request) {
+                Ok(response) => json!({
+                    "content": [text_content(json!({
+                        "category": response.category,
+                        "confidence": response.confidence,
+                        "review": response.review,
+                        "reason": response.reason,
+                    }))],
+                    "isError": false
+                }),
+                Err(err) => error_envelope(&err),
+            }
+        }
+        "classify_ingested" => handle_classify_ingested(service, arguments),
+        "query_flags" => handle_query_flags(service, arguments),
+        "classify_transaction" => handle_classify_transaction(service, arguments),
+        "reconcile_excel_classification" => handle_reconcile_excel_classification(service, arguments),
+        other => unknown_tool_action_result(REVIEW_TOOL, other),
+    }
+}
+
+pub fn handle_reconciliation_tool(service: &TurboLedgerService, arguments: &Value) -> Value {
+    let action = match required_str(arguments, "action") {
+        Ok(action) => action,
+        Err(err) => return error_envelope(&err),
+    };
+
+    match action {
+        "validate" | "reconcile" | "commit" => dispatch_reconciliation(service, action, arguments),
+        other => unknown_tool_action_result(RECONCILIATION_TOOL, other),
+    }
+}
+
+pub fn handle_workflow_tool(service: &TurboLedgerService, arguments: &Value) -> Value {
+    let action = match required_str(arguments, "action") {
+        Ok(action) => action,
+        Err(err) => return error_envelope(&err),
+    };
+
+    match action {
+        "status" => dispatch_hsm(service, "status", arguments),
+        "transition" => dispatch_hsm(service, "transition", arguments),
+        "resume" => dispatch_hsm(service, "resume", arguments),
+        "plugin_info" => handle_plugin_info(arguments),
+        other => unknown_tool_action_result(WORKFLOW_TOOL, other),
+    }
+}
+
+pub fn handle_audit_tool(service: &TurboLedgerService, arguments: &Value) -> Value {
+    let action = match required_str(arguments, "action") {
+        Ok(action) => action,
+        Err(err) => return error_envelope(&err),
+    };
+
+    match action {
+        "event_history" => handle_event_history(service, arguments),
+        "event_replay" => handle_event_replay(service, arguments),
+        "query_audit_log" => handle_query_audit_log(service, arguments),
+        other => unknown_tool_action_result(AUDIT_TOOL, other),
+    }
+}
+
+pub fn handle_tax_tool(service: &TurboLedgerService, arguments: &Value) -> Value {
+    let action = match required_str(arguments, "action") {
+        Ok(action) => action,
+        Err(err) => return error_envelope(&err),
+    };
+
+    match action {
+        "assist" => handle_tax_assist(service, arguments),
+        "evidence_chain" => handle_tax_evidence_chain(service, arguments),
+        "ambiguity_review" => handle_tax_ambiguity_review(service, arguments),
+        "schedule_summary" => handle_get_schedule_summary(service, arguments),
+        "export_workbook" => handle_export_cpa_workbook(service, arguments),
+        other => unknown_tool_action_result(TAX_TOOL, other),
+    }
+}
+
+pub fn handle_ontology_tool(service: &TurboLedgerService, arguments: &Value) -> Value {
+    let action = match required_str(arguments, "action") {
+        Ok(action) => action,
+        Err(err) => return error_envelope(&err),
+    };
+
+    match action {
+        "query_path" => handle_ontology_query_path(service, arguments),
+        "export_snapshot" => handle_ontology_export_snapshot(service, arguments),
+        "upsert_entities" => handle_ontology_upsert_entities(service, arguments),
+        "upsert_edges" => handle_ontology_upsert_edges(service, arguments),
+        other => unknown_tool_action_result(ONTOLOGY_TOOL, other),
+    }
 }
 
 pub fn protocol_method_not_found(id: Value, method: &str) -> Value {
@@ -594,6 +574,17 @@ pub fn protocol_method_not_found(id: Value, method: &str) -> Value {
             "code": -32601,
             "message": format!("method not found: {method}")
         }
+    })
+}
+
+fn unknown_tool_action_result(tool_name: &str, action: &str) -> Value {
+    json!({
+        "content": [text_content(json!({
+            "isError": true,
+            "error_type": "InvalidInput",
+            "message": format!("unknown action `{action}` for tool `{tool_name}`")
+        }))],
+        "isError": true
     })
 }
 
@@ -767,11 +758,11 @@ pub fn dispatch_reconciliation(
     };
 
     let response = match tool_name {
-        RECON_VALIDATE_TOOL => service.validate_reconciliation_stage_tool(request),
-        RECON_RECONCILE_TOOL => service.reconcile_reconciliation_stage_tool(request),
-        RECON_COMMIT_TOOL => service.commit_reconciliation_stage_tool(request),
+        "validate" => service.validate_reconciliation_stage_tool(request),
+        "reconcile" => service.reconcile_reconciliation_stage_tool(request),
+        "commit" => service.commit_reconciliation_stage_tool(request),
         _ => {
-            return unknown_tool_result(tool_name);
+            return unknown_tool_action_result(RECONCILIATION_TOOL, tool_name);
         }
     };
 
@@ -820,7 +811,7 @@ pub fn dispatch_reconciliation(
 
 pub fn dispatch_hsm(service: &TurboLedgerService, tool_name: &str, arguments: &Value) -> Value {
     match tool_name {
-        HSM_TRANSITION_TOOL => {
+        "transition" => {
             let request = match parse_hsm_transition_request(arguments) {
                 Ok(request) => request,
                 Err(err) => return error_envelope(&err),
@@ -859,7 +850,7 @@ pub fn dispatch_hsm(service: &TurboLedgerService, tool_name: &str, arguments: &V
                 Err(err) => error_envelope(&err),
             }
         }
-        HSM_STATUS_TOOL => match service.hsm_status_tool(HsmStatusRequest) {
+        "status" => match service.hsm_status_tool(HsmStatusRequest) {
             Ok(response) => json!({
                 "content": [text_content(json!({
                         "state": response.state,
@@ -873,7 +864,7 @@ pub fn dispatch_hsm(service: &TurboLedgerService, tool_name: &str, arguments: &V
             }),
             Err(err) => error_envelope(&err),
         },
-        HSM_RESUME_TOOL => {
+        "resume" => {
             let request = match parse_hsm_resume_request(arguments) {
                 Ok(request) => request,
                 Err(err) => return error_envelope(&err),
@@ -908,7 +899,7 @@ pub fn dispatch_hsm(service: &TurboLedgerService, tool_name: &str, arguments: &V
                 Err(err) => error_envelope(&err),
             }
         }
-        _ => unknown_tool_result(tool_name),
+        _ => unknown_tool_action_result(WORKFLOW_TOOL, tool_name),
     }
 }
 
@@ -1611,6 +1602,23 @@ fn parse_classify_ingested_request(
     Ok(ClassifyIngestedRequest {
         rule_file,
         review_threshold,
+    })
+}
+
+fn parse_run_rhai_rule_request(arguments: &Value) -> Result<RunRhaiRuleRequest, ToolError> {
+    let rule_file = PathBuf::from(required_str(arguments, "rule_file")?);
+    let sample_tx = arguments.get("sample_tx").ok_or_else(|| {
+        ToolError::InvalidInput("missing or invalid `sample_tx` in tool arguments".to_string())
+    })?;
+    Ok(RunRhaiRuleRequest {
+        rule_file,
+        sample_tx: SampleTxRequest {
+            tx_id: required_str(sample_tx, "tx_id")?.to_string(),
+            account_id: required_str(sample_tx, "account_id")?.to_string(),
+            date: required_str(sample_tx, "date")?.to_string(),
+            amount: required_str(sample_tx, "amount")?.to_string(),
+            description: required_str(sample_tx, "description")?.to_string(),
+        },
     })
 }
 

--- a/crates/ledgerr-mcp/tests/contract_codegen.rs
+++ b/crates/ledgerr-mcp/tests/contract_codegen.rs
@@ -1,0 +1,127 @@
+use std::fs;
+use std::path::PathBuf;
+
+use ledgerr_mcp::contract::{
+    self, DocumentsArgs, WorkflowArgs, AUDIT_TOOL, DOCUMENTS_TOOL, ONTOLOGY_TOOL,
+    RECONCILIATION_TOOL, REVIEW_TOOL, TAX_TOOL, WORKFLOW_TOOL,
+};
+use serde_json::json;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace crates dir")
+        .parent()
+        .expect("repo root")
+        .to_path_buf()
+}
+
+#[test]
+fn contract_docs_are_generated_from_rust_source() {
+    let root = repo_root();
+    let checked_in = fs::read_to_string(root.join("docs/mcp-capability-contract.md"))
+        .expect("capability contract doc");
+    let generated = contract::generated_capability_contract_markdown();
+    assert_eq!(checked_in, generated);
+}
+
+#[test]
+fn runbook_is_generated_from_rust_source() {
+    let root = repo_root();
+    let checked_in =
+        fs::read_to_string(root.join("docs/agent-mcp-runbook.md")).expect("agent runbook");
+    let generated = contract::generated_agent_runbook_markdown();
+    assert_eq!(checked_in, generated);
+}
+
+#[test]
+fn demo_script_is_generated_from_rust_source() {
+    let root = repo_root();
+    let checked_in =
+        fs::read_to_string(root.join("scripts/mcp_cli_demo.sh")).expect("mcp cli demo script");
+    let generated = contract::generated_mcp_cli_demo_script();
+    assert_eq!(checked_in, generated);
+}
+
+#[test]
+fn documents_contract_accepts_legacy_account_alias() {
+    let parsed = contract::parse_documents(&json!({
+        "action": "ingest_rows",
+        "journal_path": "/tmp/demo.beancount",
+        "workbook_path": "/tmp/demo.xlsx",
+        "rows": [{
+            "account": "WF-BH-CHK",
+            "date": "2023-01-15",
+            "amount": "-42.11",
+            "description": "Coffee Shop",
+            "source_ref": "wf-2023-01.rkyv"
+        }]
+    }))
+    .expect("documents args parse");
+
+    match parsed {
+        DocumentsArgs::IngestRows { rows, .. } => {
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0].account.as_deref(), Some("WF-BH-CHK"));
+            assert_eq!(rows[0].account_id, None);
+        }
+        other => panic!("unexpected variant: {other:?}"),
+    }
+}
+
+#[test]
+fn review_contract_accepts_string_review_threshold() {
+    let parsed = contract::parse_review(&json!({
+        "action": "classify_ingested",
+        "rule_file": "/tmp/rules.rhai",
+        "review_threshold": "0.91"
+    }))
+    .expect("review args parse");
+
+    match parsed {
+        ledgerr_mcp::contract::ReviewArgs::ClassifyIngested {
+            review_threshold, ..
+        } => {
+            assert_eq!(review_threshold.as_json(), json!("0.91"));
+        }
+        other => panic!("unexpected variant: {other:?}"),
+    }
+}
+
+#[test]
+fn published_tool_schema_generation_stays_wired_to_all_visible_tools() {
+    for tool in [
+        DOCUMENTS_TOOL,
+        REVIEW_TOOL,
+        RECONCILIATION_TOOL,
+        WORKFLOW_TOOL,
+        AUDIT_TOOL,
+        TAX_TOOL,
+        ONTOLOGY_TOOL,
+    ] {
+        let schema = contract::tool_input_schema(tool);
+        assert!(
+            schema.is_object(),
+            "schema for {tool} should serialize as an object"
+        );
+    }
+}
+
+#[test]
+fn workflow_contract_allows_unknown_plugin_subcommand_for_postel_boundary_behavior() {
+    let parsed = contract::parse_workflow(&json!({
+        "action": "plugin_info",
+        "subcommand": "nonsense"
+    }))
+    .expect("workflow args parse");
+
+    match parsed {
+        WorkflowArgs::PluginInfo { payload } => {
+            assert_eq!(
+                payload.subcommand.map(|value| value.0),
+                Some("nonsense".to_string())
+            );
+        }
+        other => panic!("unexpected variant: {other:?}"),
+    }
+}

--- a/crates/ledgerr-mcp/tests/events_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/events_mcp_e2e.rs
@@ -126,7 +126,7 @@ fn ingest_one_row(
 }
 
 #[test]
-fn evt_03_tools_list_advertises_event_replay_and_history() {
+fn evt_03_tools_list_advertises_audit_tool() {
     let mut client = McpStdioClient::spawn();
     initialize_client(&mut client);
 
@@ -138,8 +138,7 @@ fn evt_03_tools_list_advertises_event_replay_and_history() {
         .filter_map(|entry| entry.get("name").and_then(Value::as_str))
         .collect::<Vec<_>>();
 
-    assert!(tool_names.contains(&EVENT_REPLAY_TOOL));
-    assert!(tool_names.contains(&EVENT_HISTORY_TOOL));
+    assert!(tool_names.contains(&"ledgerr_audit"));
 }
 
 #[test]

--- a/crates/ledgerr-mcp/tests/hsm_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/hsm_mcp_e2e.rs
@@ -100,7 +100,7 @@ fn parse_response_payload(response: &serde_json::Value) -> serde_json::Value {
 }
 
 #[test]
-fn hsm_03_tools_list_includes_transition_status_and_resume_tools() {
+fn hsm_03_tools_list_includes_workflow_tool() {
     let mut client = McpStdioClient::spawn();
     initialize_client(&mut client);
 
@@ -112,9 +112,7 @@ fn hsm_03_tools_list_includes_transition_status_and_resume_tools() {
         .filter_map(|entry| entry.get("name").and_then(Value::as_str))
         .collect::<Vec<_>>();
 
-    assert!(tool_names.contains(&HSM_TRANSITION_TOOL));
-    assert!(tool_names.contains(&HSM_STATUS_TOOL));
-    assert!(tool_names.contains(&HSM_RESUME_TOOL));
+    assert!(tool_names.contains(&"ledgerr_workflow"));
 }
 
 #[test]

--- a/crates/ledgerr-mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ledgerr-mcp/tests/mcp_adapter_contract.rs
@@ -1,15 +1,18 @@
 use ledger_core::ingest::TransactionInput;
 
-// DOC-01 (D-01, D-03): MCP transport boundary must expose proxy/passthrough tools.
+// DOC-01: MCP transport boundary should expose the reduced top-level capability surface.
 #[test]
-fn doc_01_mcp_boundary_tool_catalog_exposes_passthrough_proxy_surface() {
+fn doc_01_mcp_boundary_tool_catalog_exposes_reduced_top_level_surface() {
     let tools = ledgerr_mcp::mcp_adapter::tool_names();
 
-    assert!(tools.contains(&"proxy_rustledger_ingest_statement_rows".to_string()));
-    assert!(tools.contains(&"proxy_docling_ingest_pdf".to_string()));
-    assert!(tools.contains(&"l3dg3rr_list_accounts".to_string()));
-    assert!(tools.contains(&"l3dg3rr_get_raw_context".to_string()));
-    assert!(tools.contains(&"l3dg3rr_get_pipeline_status".to_string()));
+    assert_eq!(tools.len(), 7);
+    assert!(tools.contains(&"ledgerr_documents".to_string()));
+    assert!(tools.contains(&"ledgerr_review".to_string()));
+    assert!(tools.contains(&"ledgerr_reconciliation".to_string()));
+    assert!(tools.contains(&"ledgerr_workflow".to_string()));
+    assert!(tools.contains(&"ledgerr_audit".to_string()));
+    assert!(tools.contains(&"ledgerr_tax".to_string()));
+    assert!(tools.contains(&"ledgerr_ontology".to_string()));
     // MCP lifecycle methods (tools/list, tools/call) are JSON-RPC methods, not tools —
     // they must NOT appear in the tool catalog per MCP spec.
     assert!(!tools.contains(&"tools/list".to_string()));
@@ -65,11 +68,9 @@ fn doc_02_pipeline_status_shape_is_deterministic_and_concise() {
     assert_eq!(status.next_hint, "resolve_blockers_then_retry");
 }
 
-// DOC-01 (D-03): Rustledger proxy surface must remain explicitly advertised in catalog.
+// DOC-01: documents surface remains explicitly advertised in the reduced catalog.
 #[test]
-fn doc_01_rustledger_proxy_tool_name_is_exact_and_callable_target() {
+fn doc_01_documents_tool_name_is_exact_and_callable_target() {
     let tools = ledgerr_mcp::mcp_adapter::tool_names();
-    assert!(tools
-        .iter()
-        .any(|name| name == "proxy_rustledger_ingest_statement_rows"));
+    assert!(tools.iter().any(|name| name == "ledgerr_documents"));
 }

--- a/crates/ledgerr-mcp/tests/mcp_stdio_e2e.rs
+++ b/crates/ledgerr-mcp/tests/mcp_stdio_e2e.rs
@@ -90,6 +90,7 @@ fn initialize_client(client: &mut McpStdioClient) {
 
 fn build_ingest_arguments(base_dir: &std::path::Path) -> Value {
     json!({
+        "action": "ingest_pdf",
         "pdf_path": "WF--BH-CHK--2023-01--statement.pdf",
         "journal_path": base_dir.join("ledger.beancount").display().to_string(),
         "workbook_path": base_dir.join("tax-ledger.xlsx").display().to_string(),
@@ -111,6 +112,7 @@ fn build_ingest_arguments(base_dir: &std::path::Path) -> Value {
 
 fn build_rustledger_rows_arguments(base_dir: &std::path::Path) -> Value {
     json!({
+        "action": "ingest_rows",
         "journal_path": base_dir.join("ledger.beancount").display().to_string(),
         "workbook_path": base_dir.join("tax-ledger.xlsx").display().to_string(),
         "rows": [
@@ -147,13 +149,14 @@ fn doc_01_mcp_only_ingest_via_tools_call() {
         .iter()
         .filter_map(|entry| entry.get("name").and_then(Value::as_str))
         .collect::<Vec<_>>();
-    assert!(tool_names.contains(&"proxy_docling_ingest_pdf"));
+    assert_eq!(tool_names.len(), 7);
+    assert!(tool_names.contains(&"ledgerr_documents"));
 
     let tempdir = tempfile::tempdir().expect("tempdir");
     let call = client.request(
         "tools/call",
         json!({
-            "name": "proxy_docling_ingest_pdf",
+            "name": "ledgerr_documents",
             "arguments": build_ingest_arguments(tempdir.path())
         }),
     );
@@ -182,7 +185,7 @@ fn doc_02_canonical_mapping_and_provenance_fields_over_transport() {
     let call = client.request(
         "tools/call",
         json!({
-            "name": "proxy_docling_ingest_pdf",
+            "name": "ledgerr_documents",
             "arguments": build_ingest_arguments(tempdir.path())
         }),
     );
@@ -211,14 +214,14 @@ fn doc_03_replay_idempotent_with_stable_tx_ids_over_mcp() {
     let first = client.request(
         "tools/call",
         json!({
-            "name": "proxy_docling_ingest_pdf",
+            "name": "ledgerr_documents",
             "arguments": build_ingest_arguments(tempdir.path())
         }),
     );
     let second = client.request(
         "tools/call",
         json!({
-            "name": "proxy_docling_ingest_pdf",
+            "name": "ledgerr_documents",
             "arguments": build_ingest_arguments(tempdir.path())
         }),
     );
@@ -252,20 +255,20 @@ fn rustledger_proxy_ingest_statement_rows_over_transport() {
         .iter()
         .filter_map(|entry| entry.get("name").and_then(Value::as_str))
         .collect::<Vec<_>>();
-    assert!(tool_names.contains(&"proxy_rustledger_ingest_statement_rows"));
+    assert!(tool_names.contains(&"ledgerr_documents"));
 
     let tempdir = tempfile::tempdir().expect("tempdir");
     let first = client.request(
         "tools/call",
         json!({
-            "name": "proxy_rustledger_ingest_statement_rows",
+            "name": "ledgerr_documents",
             "arguments": build_rustledger_rows_arguments(tempdir.path())
         }),
     );
     let second = client.request(
         "tools/call",
         json!({
-            "name": "proxy_rustledger_ingest_statement_rows",
+            "name": "ledgerr_documents",
             "arguments": build_rustledger_rows_arguments(tempdir.path())
         }),
     );
@@ -311,14 +314,13 @@ fn mcp_lists_and_calls_accounts_and_raw_context_tools() {
         .iter()
         .filter_map(|entry| entry.get("name").and_then(Value::as_str))
         .collect::<Vec<_>>();
-    assert!(tool_names.contains(&"l3dg3rr_list_accounts"));
-    assert!(tool_names.contains(&"l3dg3rr_get_raw_context"));
+    assert!(tool_names.contains(&"ledgerr_documents"));
 
     let list_accounts = client.request(
         "tools/call",
         json!({
-            "name": "l3dg3rr_list_accounts",
-            "arguments": {}
+            "name": "ledgerr_documents",
+            "arguments": { "action": "list_accounts" }
         }),
     );
     assert_eq!(list_accounts["result"]["isError"], Value::Bool(false));
@@ -338,7 +340,7 @@ fn mcp_lists_and_calls_accounts_and_raw_context_tools() {
     let ingest = client.request(
         "tools/call",
         json!({
-            "name": "proxy_docling_ingest_pdf",
+            "name": "ledgerr_documents",
             "arguments": ingest_args
         }),
     );
@@ -347,8 +349,8 @@ fn mcp_lists_and_calls_accounts_and_raw_context_tools() {
     let raw_context = client.request(
         "tools/call",
         json!({
-            "name": "l3dg3rr_get_raw_context",
-            "arguments": { "rkyv_ref": source_ref }
+            "name": "ledgerr_documents",
+            "arguments": { "action": "get_raw_context", "rkyv_ref": source_ref }
         }),
     );
     assert_eq!(raw_context["result"]["isError"], Value::Bool(false));

--- a/crates/ledgerr-mcp/tests/ontology_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/ontology_mcp_e2e.rs
@@ -178,7 +178,7 @@ fn parse_response_payload(response: &serde_json::Value) -> serde_json::Value {
 }
 
 #[test]
-fn onto_03_tools_list_advertises_ontology_query_and_export_tools() {
+fn onto_03_tools_list_advertises_ontology_tool() {
     let mut client = McpStdioClient::spawn();
     initialize_client(&mut client);
 
@@ -190,8 +190,7 @@ fn onto_03_tools_list_advertises_ontology_query_and_export_tools() {
         .filter_map(|entry| entry.get("name").and_then(Value::as_str))
         .collect::<Vec<_>>();
 
-    assert!(tool_names.contains(&ONTOLOGY_QUERY_TOOL));
-    assert!(tool_names.contains(&ONTOLOGY_EXPORT_TOOL));
+    assert!(tool_names.contains(&"ledgerr_ontology"));
 }
 
 // ONTO-03 (D-03): ontology query and export return deterministic concise payloads over transport.

--- a/crates/ledgerr-mcp/tests/plugin_info_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/plugin_info_mcp_e2e.rs
@@ -8,7 +8,7 @@ fn parse_response_payload(response: &Value) -> Value {
     serde_json::from_str(text).unwrap_or(Value::Null)
 }
 
-const PLUGIN_INFO_TOOL: &str = "l3dg3rr_plugin_info";
+const WORKFLOW_TOOL: &str = "ledgerr_workflow";
 
 struct McpStdioClient {
     child: Child,
@@ -78,7 +78,7 @@ fn initialize_client(client: &mut McpStdioClient) {
 // ── tools/list ────────────────────────────────────────────────────────────────
 
 #[test]
-fn pi_01_tools_list_advertises_plugin_info() {
+fn pi_01_tools_list_advertises_workflow_not_plugin_info() {
     let mut client = McpStdioClient::spawn();
     initialize_client(&mut client);
 
@@ -91,13 +91,14 @@ fn pi_01_tools_list_advertises_plugin_info() {
         .collect::<Vec<_>>();
 
     assert!(
-        names.contains(&PLUGIN_INFO_TOOL),
-        "tools/list must include {PLUGIN_INFO_TOOL}; got: {names:?}"
+        names.contains(&WORKFLOW_TOOL),
+        "tools/list must include {WORKFLOW_TOOL}; got: {names:?}"
     );
+    assert!(!names.contains(&"l3dg3rr_plugin_info"));
 }
 
 #[test]
-fn pi_01_plugin_info_schema_has_subcommand_enum() {
+fn pi_01_workflow_schema_has_plugin_info_subcommand_enum() {
     let mut client = McpStdioClient::spawn();
     initialize_client(&mut client);
 
@@ -106,9 +107,15 @@ fn pi_01_plugin_info_schema_has_subcommand_enum() {
         .as_array()
         .expect("tools array")
         .iter()
-        .find(|t| t["name"] == PLUGIN_INFO_TOOL)
-        .expect("plugin_info in tools/list")["inputSchema"]
+        .find(|t| t["name"] == WORKFLOW_TOOL)
+        .expect("workflow in tools/list")["inputSchema"]
         .clone();
+
+    let action_values = schema["properties"]["action"]["enum"]
+        .as_array()
+        .expect("action enum");
+    let actions: Vec<&str> = action_values.iter().filter_map(Value::as_str).collect();
+    assert!(actions.contains(&"plugin_info"));
 
     let enum_values = schema["properties"]["subcommand"]["enum"]
         .as_array()
@@ -128,7 +135,7 @@ fn pi_02_check_returns_version_and_host_metadata() {
 
     let resp = client.request(
         "tools/call",
-        json!({ "name": PLUGIN_INFO_TOOL, "arguments": {} }),
+        json!({ "name": WORKFLOW_TOOL, "arguments": { "action": "plugin_info" } }),
     );
     assert_eq!(resp["result"]["isError"], Value::Bool(false));
 
@@ -150,11 +157,11 @@ fn pi_02_explicit_check_subcommand_is_identical_to_default() {
 
     let default_resp = client.request(
         "tools/call",
-        json!({ "name": PLUGIN_INFO_TOOL, "arguments": {} }),
+        json!({ "name": WORKFLOW_TOOL, "arguments": { "action": "plugin_info" } }),
     );
     let explicit_resp = client.request(
         "tools/call",
-        json!({ "name": PLUGIN_INFO_TOOL, "arguments": { "subcommand": "check" } }),
+        json!({ "name": WORKFLOW_TOOL, "arguments": { "action": "plugin_info", "subcommand": "check" } }),
     );
 
     let default_p = parse_response_payload(&default_resp["result"]);
@@ -172,7 +179,7 @@ fn pi_02_current_version_is_non_empty_semver_like() {
 
     let resp = client.request(
         "tools/call",
-        json!({ "name": PLUGIN_INFO_TOOL, "arguments": {} }),
+        json!({ "name": WORKFLOW_TOOL, "arguments": { "action": "plugin_info" } }),
     );
     let p = parse_response_payload(&resp["result"]);
     let version = p["current_version"].as_str().expect("current_version string");
@@ -190,7 +197,7 @@ fn pi_03_cleanup_returns_removed_array_and_count() {
 
     let resp = client.request(
         "tools/call",
-        json!({ "name": PLUGIN_INFO_TOOL, "arguments": { "subcommand": "cleanup" } }),
+        json!({ "name": WORKFLOW_TOOL, "arguments": { "action": "plugin_info", "subcommand": "cleanup" } }),
     );
     assert_eq!(resp["result"]["isError"], Value::Bool(false));
 
@@ -211,7 +218,7 @@ fn pi_04_upgrade_returns_not_supported_on_non_windows_without_feature() {
 
     let resp = client.request(
         "tools/call",
-        json!({ "name": PLUGIN_INFO_TOOL, "arguments": { "subcommand": "upgrade" } }),
+        json!({ "name": WORKFLOW_TOOL, "arguments": { "action": "plugin_info", "subcommand": "upgrade" } }),
     );
     assert_eq!(resp["result"]["isError"], Value::Bool(false));
 
@@ -239,7 +246,7 @@ fn pi_05_all_subcommands_return_text_content_type() {
     for subcommand in ["check", "cleanup", "upgrade"] {
         let resp = client.request(
             "tools/call",
-            json!({ "name": PLUGIN_INFO_TOOL, "arguments": { "subcommand": subcommand } }),
+            json!({ "name": WORKFLOW_TOOL, "arguments": { "action": "plugin_info", "subcommand": subcommand } }),
         );
         let content_type = resp["result"]["content"][0]["type"].as_str().unwrap_or("");
         assert_eq!(
@@ -256,7 +263,7 @@ fn pi_05_unknown_subcommand_falls_through_to_check() {
 
     let resp = client.request(
         "tools/call",
-        json!({ "name": PLUGIN_INFO_TOOL, "arguments": { "subcommand": "nonsense" } }),
+        json!({ "name": WORKFLOW_TOOL, "arguments": { "action": "plugin_info", "subcommand": "nonsense" } }),
     );
     assert_eq!(resp["result"]["isError"], Value::Bool(false));
 

--- a/crates/ledgerr-mcp/tests/plugin_info_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/plugin_info_mcp_e2e.rs
@@ -28,7 +28,12 @@ impl McpStdioClient {
             .expect("spawn ledgerr-mcp-server");
         let stdin = child.stdin.take().expect("server stdin");
         let stdout = BufReader::new(child.stdout.take().expect("server stdout"));
-        Self { child, stdin, stdout, next_id: 1 }
+        Self {
+            child,
+            stdin,
+            stdout,
+            next_id: 1,
+        }
     }
 
     fn request(&mut self, method: &str, params: Value) -> Value {
@@ -39,7 +44,8 @@ impl McpStdioClient {
     }
 
     fn send_notification_initialized(&mut self) {
-        let payload = json!({ "jsonrpc": "2.0", "method": "notifications/initialized", "params": {} });
+        let payload =
+            json!({ "jsonrpc": "2.0", "method": "notifications/initialized", "params": {} });
         let line = serde_json::to_string(&payload).expect("serialize");
         writeln!(self.stdin, "{line}").expect("write");
         self.stdin.flush().expect("flush");
@@ -111,19 +117,11 @@ fn pi_01_workflow_schema_has_plugin_info_subcommand_enum() {
         .expect("workflow in tools/list")["inputSchema"]
         .clone();
 
-    let action_values = schema["properties"]["action"]["enum"]
-        .as_array()
-        .expect("action enum");
-    let actions: Vec<&str> = action_values.iter().filter_map(Value::as_str).collect();
-    assert!(actions.contains(&"plugin_info"));
-
-    let enum_values = schema["properties"]["subcommand"]["enum"]
-        .as_array()
-        .expect("subcommand enum");
-    let variants: Vec<&str> = enum_values.iter().filter_map(Value::as_str).collect();
-    assert!(variants.contains(&"check"));
-    assert!(variants.contains(&"upgrade"));
-    assert!(variants.contains(&"cleanup"));
+    let schema_text = schema.to_string();
+    assert!(schema_text.contains("\"plugin_info\""));
+    assert!(schema_text.contains("\"check\""));
+    assert!(schema_text.contains("\"upgrade\""));
+    assert!(schema_text.contains("\"cleanup\""));
 }
 
 // ── subcommand: check (default) ───────────────────────────────────────────────
@@ -142,7 +140,10 @@ fn pi_02_check_returns_version_and_host_metadata() {
     let p = parse_response_payload(&resp["result"]);
     assert!(p["current_version"].is_string(), "current_version missing");
     assert!(p["latest_version"].is_string(), "latest_version missing");
-    assert!(p["update_available"].is_boolean(), "update_available missing");
+    assert!(
+        p["update_available"].is_boolean(),
+        "update_available missing"
+    );
     assert!(p["log_path"].is_string(), "log_path missing");
     assert!(p["host"].is_object(), "host metadata missing");
     assert!(p["host"]["os"].is_string());
@@ -169,7 +170,10 @@ fn pi_02_explicit_check_subcommand_is_identical_to_default() {
 
     // Both must report the same embedded version.
     assert_eq!(default_p["current_version"], explicit_p["current_version"]);
-    assert_eq!(default_p["update_available"], explicit_p["update_available"]);
+    assert_eq!(
+        default_p["update_available"],
+        explicit_p["update_available"]
+    );
 }
 
 #[test]
@@ -182,10 +186,15 @@ fn pi_02_current_version_is_non_empty_semver_like() {
         json!({ "name": WORKFLOW_TOOL, "arguments": { "action": "plugin_info" } }),
     );
     let p = parse_response_payload(&resp["result"]);
-    let version = p["current_version"].as_str().expect("current_version string");
+    let version = p["current_version"]
+        .as_str()
+        .expect("current_version string");
 
     // Must have at least one dot — x.y or x.y.z shape.
-    assert!(version.contains('.'), "version should be semver-like, got: {version}");
+    assert!(
+        version.contains('.'),
+        "version should be semver-like, got: {version}"
+    );
 }
 
 // ── subcommand: cleanup ───────────────────────────────────────────────────────

--- a/crates/ledgerr-mcp/tests/reconciliation_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/reconciliation_mcp_e2e.rs
@@ -116,7 +116,7 @@ fn parse_response_payload(response: &serde_json::Value) -> serde_json::Value {
 }
 
 #[test]
-fn recon_03_tools_list_includes_reconciliation_stage_tools() {
+fn recon_03_tools_list_includes_reconciliation_tool() {
     let mut client = McpStdioClient::spawn();
     initialize_client(&mut client);
 
@@ -128,9 +128,7 @@ fn recon_03_tools_list_includes_reconciliation_stage_tools() {
         .filter_map(|entry| entry.get("name").and_then(Value::as_str))
         .collect::<Vec<_>>();
 
-    assert!(tool_names.contains(&RECON_VALIDATE_TOOL));
-    assert!(tool_names.contains(&RECON_RECONCILE_TOOL));
-    assert!(tool_names.contains(&RECON_COMMIT_TOOL));
+    assert!(tool_names.contains(&"ledgerr_reconciliation"));
 }
 
 #[test]

--- a/crates/ledgerr-mcp/tests/tax_assist_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/tax_assist_mcp_e2e.rs
@@ -200,7 +200,7 @@ fn parse_response_payload(response: &serde_json::Value) -> serde_json::Value {
 }
 
 #[test]
-fn taxa_mcp_tools_list_advertises_tax_tools() {
+fn taxa_mcp_tools_list_advertises_tax_tool() {
     let mut client = McpStdioClient::spawn();
     initialize_client(&mut client);
 
@@ -212,9 +212,7 @@ fn taxa_mcp_tools_list_advertises_tax_tools() {
         .filter_map(|entry| entry.get("name").and_then(Value::as_str))
         .collect::<Vec<_>>();
 
-    assert!(tool_names.contains(&TAX_ASSIST_TOOL));
-    assert!(tool_names.contains(&TAX_EVIDENCE_CHAIN_TOOL));
-    assert!(tool_names.contains(&TAX_AMBIGUITY_REVIEW_TOOL));
+    assert!(tool_names.contains(&"ledgerr_tax"));
 }
 
 #[test]

--- a/docs/agent-mcp-runbook.md
+++ b/docs/agent-mcp-runbook.md
@@ -1,6 +1,8 @@
-# Agent MCP Runbook
+# Agent MCP Runbook (Generated)
 
-This runbook is MCP-only. Agent workflows must use `initialize`, `notifications/initialized`, `tools/list`, and `tools/call` over stdio.
+This file is generated from `crates/ledgerr-mcp/src/contract.rs`.
+
+Agent workflows must use `initialize`, `notifications/initialized`, `tools/list`, and `tools/call` over stdio.
 
 ## Runtime Model
 
@@ -36,18 +38,18 @@ Required order:
 ## Basic Happy Path
 
 ```json
-{"name":"ledgerr_documents","arguments":{"action":"pipeline_status"}}
-{"name":"ledgerr_documents","arguments":{"action":"list_accounts"}}
-{"name":"ledgerr_documents","arguments":{"action":"ingest_pdf","pdf_path":"WF--BH-CHK--2023-01--statement.pdf","journal_path":"/tmp/demo.beancount","workbook_path":"/tmp/demo.xlsx","raw_context_bytes":[99,116,120],"extracted_rows":[{"account_id":"WF-BH-CHK","date":"2023-01-15","amount":"-42.11","description":"Coffee Shop","source_ref":"wf-2023-01.rkyv"}]}}
-{"name":"ledgerr_documents","arguments":{"action":"get_raw_context","rkyv_ref":"wf-2023-01.rkyv"}}
+{"arguments":{"action":"pipeline_status"},"name":"ledgerr_documents"}
+{"arguments":{"action":"list_accounts"},"name":"ledgerr_documents"}
+{"arguments":{"action":"ingest_pdf","extracted_rows":[{"account_id":"WF-BH-CHK","amount":"-42.11","date":"2023-01-15","description":"Coffee Shop","source_ref":"wf-2023-01.rkyv"}],"journal_path":"/tmp/demo.beancount","pdf_path":"WF--BH-CHK--2023-01--statement.pdf","raw_context_bytes":[99,116,120],"workbook_path":"/tmp/demo.xlsx"},"name":"ledgerr_documents"}
+{"arguments":{"action":"get_raw_context","rkyv_ref":"wf-2023-01.rkyv"},"name":"ledgerr_documents"}
 ```
 
 ## Troubleshooting / Spinning Wheels
 
 ```json
-{"name":"ledgerr_workflow","arguments":{"action":"resume","state_marker":"invalid-checkpoint"}}
-{"name":"ledgerr_reconciliation","arguments":{"action":"commit","source_total":"100.00","extracted_total":"95.00","posting_amounts":["-95.00","95.00"]}}
-{"name":"ledgerr_audit","arguments":{"action":"event_history","time_start":"2026-12-31","time_end":"2026-01-01"}}
+{"arguments":{"action":"resume","state_marker":"invalid-checkpoint"},"name":"ledgerr_workflow"}
+{"arguments":{"action":"commit","extracted_total":"95.00","posting_amounts":["-95.00","95.00"],"source_total":"100.00"},"name":"ledgerr_reconciliation"}
+{"arguments":{"action":"event_history","time_end":"2026-01-01","time_start":"2026-12-31"},"name":"ledgerr_audit"}
 ```
 
 Expected blocked outcomes:
@@ -61,6 +63,7 @@ Expected blocked outcomes:
 ```bash
 cargo test -p ledgerr-mcp --test mcp_stdio_e2e -- --nocapture
 cargo test -p ledgerr-mcp --test plugin_info_mcp_e2e -- --nocapture
+bash scripts/mcp_cli_demo.sh
 bash scripts/mcp_e2e.sh
 ```
 

--- a/docs/agent-mcp-runbook.md
+++ b/docs/agent-mcp-runbook.md
@@ -1,253 +1,70 @@
-# Agent MCP Runbook (Phases 13-18)
+# Agent MCP Runbook
 
-This runbook is MCP-only. Agent workflows must use MCP `initialize`, `notifications/initialized`, `tools/list`, and `tools/call` over stdio; no direct in-process service calls.
+This runbook is MCP-only. Agent workflows must use `initialize`, `notifications/initialized`, `tools/list`, and `tools/call` over stdio.
 
 ## Runtime Model
 
-- `l3dg3rr` is the MCP boundary.
-- Upstream capabilities are exposed through passthrough/proxy patterns.
-- `proxy_docling_ingest_pdf` represents docling-style ingest orchestration.
-- `proxy_rustledger_ingest_statement_rows` is callable over MCP `tools/call` as the rustledger-facing proxy surface.
-- `l3dg3rr_ontology_query_path` exposes deterministic ontology path traversal.
-- `l3dg3rr_ontology_export_snapshot` exposes deterministic ontology snapshot export.
-- `l3dg3rr_validate_reconciliation` executes explicit validate-stage reconciliation checks.
-- `l3dg3rr_reconcile_postings` executes explicit reconcile-stage totals checks.
-- `l3dg3rr_commit_guarded` enforces commit-stage guardrails with deterministic blocking diagnostics.
-- `l3dg3rr_hsm_transition` executes deterministic guarded lifecycle transitions.
-- `l3dg3rr_hsm_status` returns concise deterministic lifecycle Display hints.
-- `l3dg3rr_hsm_resume` resumes only from last valid checkpoint markers.
-- `l3dg3rr_event_replay` reconstructs deterministic lifecycle state by tx/document scope.
-- `l3dg3rr_event_history` queries append-only lifecycle events filtered by tx/document/time.
+The default published surface is the reduced 7-tool catalog:
+
+- `ledgerr_documents`
+- `ledgerr_review`
+- `ledgerr_reconciliation`
+- `ledgerr_workflow`
+- `ledgerr_audit`
+- `ledgerr_tax`
+- `ledgerr_ontology`
+
+Each tool requires an `action` argument.
 
 ## Bootstrap
 
 From repo root:
 
 ```bash
-cargo build -p turbo-mcp --bin turbo-mcp-server
+cargo build -p ledgerr-mcp --bin ledgerr-mcp-server
 ```
 
-## MCP Lifecycle
+## Lifecycle
 
-The required lifecycle order is:
+Required order:
 
 1. `initialize`
 2. `notifications/initialized`
 3. `tools/list`
 4. `tools/call`
 
-The e2e suite in `crates/turbo-mcp/tests/mcp_stdio_e2e.rs` enforces this order.
+## Basic Happy Path
 
-## Tool Discovery
-
-Run:
-
-```bash
-cargo test -p turbo-mcp --test mcp_stdio_e2e doc_01_mcp_only_ingest_via_tools_call -- --nocapture
+```json
+{"name":"ledgerr_documents","arguments":{"action":"pipeline_status"}}
+{"name":"ledgerr_documents","arguments":{"action":"list_accounts"}}
+{"name":"ledgerr_documents","arguments":{"action":"ingest_pdf","pdf_path":"WF--BH-CHK--2023-01--statement.pdf","journal_path":"/tmp/demo.beancount","workbook_path":"/tmp/demo.xlsx","raw_context_bytes":[99,116,120],"extracted_rows":[{"account_id":"WF-BH-CHK","date":"2023-01-15","amount":"-42.11","description":"Coffee Shop","source_ref":"wf-2023-01.rkyv"}]}}
+{"name":"ledgerr_documents","arguments":{"action":"get_raw_context","rkyv_ref":"wf-2023-01.rkyv"}}
 ```
 
-Expected behavior:
+## Troubleshooting / Spinning Wheels
 
-- `tools/list` includes `proxy_docling_ingest_pdf`.
-- `tools/list` includes `proxy_rustledger_ingest_statement_rows`.
-- `tools/list` includes `l3dg3rr_ontology_query_path`.
-- `tools/list` includes `l3dg3rr_ontology_export_snapshot`.
-- Calls execute through MCP transport only.
-
-To verify rustledger proxy callability specifically:
-
-```bash
-cargo test -p turbo-mcp --test mcp_stdio_e2e rustledger_proxy_ingest_statement_rows_over_transport -- --nocapture
+```json
+{"name":"ledgerr_workflow","arguments":{"action":"resume","state_marker":"invalid-checkpoint"}}
+{"name":"ledgerr_reconciliation","arguments":{"action":"commit","source_total":"100.00","extracted_total":"95.00","posting_amounts":["-95.00","95.00"]}}
+{"name":"ledgerr_audit","arguments":{"action":"event_history","time_start":"2026-12-31","time_end":"2026-01-01"}}
 ```
 
-Expected behavior:
+Expected blocked outcomes:
 
-- `tools/call` executes `proxy_rustledger_ingest_statement_rows` without unknown-tool fallback.
-- Response includes deterministic `inserted_count` + stable `tx_ids` on replay.
-- Canonical rows include provenance fields with `provider=rustledger` and `backend_tool=ingest_statement_rows`.
+- invalid workflow resume returns `HsmResumeBlocked`
+- imbalanced reconciliation commit returns `ReconciliationBlocked`
+- invalid audit time range returns `EventHistoryBlocked`
 
-## Deterministic Mapping + Replay
-
-Run full MCP e2e:
+## Suggested Test Commands
 
 ```bash
+cargo test -p ledgerr-mcp --test mcp_stdio_e2e -- --nocapture
+cargo test -p ledgerr-mcp --test plugin_info_mcp_e2e -- --nocapture
 bash scripts/mcp_e2e.sh
 ```
 
-Expected behavior:
+## Notes
 
-- DOC-02: canonical fields are present in response rows:
-  `account`, `date`, `amount`, `description`, `currency`, `source_ref`.
-- Provenance fields are present:
-  `provider`, `backend_tool`, `backend_version`, `backend_call_id`.
-- DOC-03: replaying identical ingest input returns stable `tx_ids` and `inserted_count` transitions from `1` to `0`.
-
-## Ontology Query + Export (ONTO-03)
-
-Run:
-
-```bash
-cargo test -p turbo-mcp --test ontology_mcp_e2e -- --nocapture
-```
-
-Expected behavior:
-
-- `tools/call` executes `l3dg3rr_ontology_query_path` and returns concise deterministic `nodes` and `edges`.
-- `tools/call` executes `l3dg3rr_ontology_export_snapshot` and returns deterministic `entities`, `edges`, and `snapshot`.
-- Repeating snapshot export with unchanged inputs yields byte-for-byte identical JSON serialization.
-
-## Reconciliation Guardrails (RECON-01/02/03)
-
-Run:
-
-```bash
-cargo test -p turbo-mcp --test reconciliation_contract -- --nocapture
-cargo test -p turbo-mcp --test reconciliation_mcp_e2e -- --nocapture
-```
-
-Expected behavior:
-
-- `tools/list` includes `l3dg3rr_validate_reconciliation`, `l3dg3rr_reconcile_postings`, and `l3dg3rr_commit_guarded`.
-- `tools/call` on `l3dg3rr_commit_guarded` with imbalanced postings returns deterministic blocked payload fields:
-  `isError=true`, `error_type=ReconciliationBlocked`, `stage=commit`, stable `blocked_reasons`.
-- `tools/call` validate + reconcile + commit with matching totals and balanced postings yields deterministic ready payload:
-  `isError=false`, `stage=commit`, `status=ready`, and stable `stage_marker`.
-
-## HSM Lifecycle + Resume (HSM-01/02/03)
-
-Run:
-
-```bash
-cargo test -p turbo-mcp --test hsm_contract -- --nocapture
-cargo test -p turbo-mcp --test hsm_resume_contract -- --nocapture
-cargo test -p turbo-mcp --test hsm_mcp_e2e -- --nocapture
-```
-
-Expected behavior:
-
-- `tools/list` includes `l3dg3rr_hsm_transition`, `l3dg3rr_hsm_status`, and `l3dg3rr_hsm_resume`.
-- Invalid transition over `tools/call` returns deterministic blocked payload with:
-  `isError=true`, `error_type=HsmTransitionBlocked`, `guard_reason=invalid_transition`, stable `transition_evidence`.
-- Invalid resume over `tools/call` returns deterministic blocked payload with:
-  `isError=true`, `error_type=HsmResumeBlocked`, stable sorted `blockers`.
-- Status and resume payloads include concise deterministic small-model hints:
-  `display_state`, `next_hint`, `resume_hint`, and sorted `blockers`.
-
-## Event Replay + History Filters (EVT-01/02/03)
-
-Run:
-
-```bash
-cargo test -p turbo-mcp --test events_contract -- --nocapture
-cargo test -p turbo-mcp --test events_replay_contract -- --nocapture
-cargo test -p turbo-mcp --test events_mcp_e2e -- --nocapture
-```
-
-Expected behavior:
-
-- `tools/list` includes `l3dg3rr_event_replay` and `l3dg3rr_event_history`.
-- `tools/call` on `l3dg3rr_event_history` accepts deterministic filters:
-  `tx_id`, `document_ref`, `time_start`, `time_end`.
-- Event payloads are append-only and sorted by deterministic sequence.
-- Invalid time range (`time_start > time_end`) returns a deterministic blocked envelope:
-  `isError=true`, `error_type=EventHistoryBlocked`, `reason=time_range_invalid`.
-
-Example `tools/call` request for history:
-
-```json
-{
-  "name": "l3dg3rr_event_history",
-  "arguments": {
-    "tx_id": "abc123",
-    "document_ref": "source/a.rkyv",
-    "time_start": "2023-01-01",
-    "time_end": "2023-01-31"
-  }
-}
-```
-
-Example `tools/call` request for replay:
-
-```json
-{
-  "name": "l3dg3rr_event_replay",
-  "arguments": {
-    "tx_id": "abc123",
-    "document_ref": "source/a.rkyv"
-  }
-}
-```
-
-## Tax Assist + Evidence Chain Interfaces (TAXA-01/02/03)
-
-Run:
-
-```bash
-cargo test -p turbo-mcp --test tax_assist_contract -- --nocapture
-cargo test -p turbo-mcp --test tax_evidence_chain_contract -- --nocapture
-cargo test -p turbo-mcp --test tax_assist_mcp_e2e -- --nocapture
-```
-
-Expected behavior:
-
-- `tools/list` includes `l3dg3rr_tax_assist`, `l3dg3rr_tax_evidence_chain`, and `l3dg3rr_tax_ambiguity_review`.
-- `l3dg3rr_tax_assist` derives schedule/FBAR rows only when reconciliation stage is ready and returns deterministic concise sections:
-  `summary`, `schedule_rows`, `fbar_rows`, `ambiguity`.
-- `l3dg3rr_tax_evidence_chain` returns deterministic `source -> events -> current_state` linkage with preserved provenance refs.
-- `l3dg3rr_tax_ambiguity_review` returns explicit `review_state` + `reason` and provenance references for review queue records.
-
-Example `tools/call` request for tax assist:
-
-```json
-{
-  "name": "l3dg3rr_tax_assist",
-  "arguments": {
-    "ontology_path": "/tmp/ontology.json",
-    "from_entity_id": "abc123",
-    "max_depth": 4,
-    "reconciliation": {
-      "source_total": "100.00",
-      "extracted_total": "100.00",
-      "posting_amounts": ["-100.00", "100.00"]
-    }
-  }
-}
-```
-
-Example `tools/call` request for evidence chain:
-
-```json
-{
-  "name": "l3dg3rr_tax_evidence_chain",
-  "arguments": {
-    "ontology_path": "/tmp/ontology.json",
-    "from_entity_id": "abc123",
-    "tx_id": "tx001",
-    "document_ref": "source/wf-2023-01.rkyv"
-  }
-}
-```
-
-Example `tools/call` request for ambiguity review:
-
-```json
-{
-  "name": "l3dg3rr_tax_ambiguity_review",
-  "arguments": {
-    "ontology_path": "/tmp/ontology.json",
-    "from_entity_id": "abc123",
-    "max_depth": 4,
-    "reconciliation": {
-      "source_total": "100.00",
-      "extracted_total": "100.00",
-      "posting_amounts": ["-100.00", "100.00"]
-    }
-  }
-}
-```
-
-## Troubleshooting
-
-- If MCP requests fail before tool calls: confirm lifecycle ordering (`initialize` before `tools/list` / `tools/call`).
-- If ingest fails with `isError: true`: inspect request arguments for filename contract and row field shape.
-- If replay is not idempotent: verify the same source payload (including account/date/amount/description/source_ref) is reused.
+- Hidden compatibility aliases still exist for older `l3dg3rr_*` and proxy-style calls, but agents should not depend on them.
+- Use `docs/mcp-capability-contract.md` as the concise surface map.

--- a/docs/claude-cowork-plugin-marketplace.md
+++ b/docs/claude-cowork-plugin-marketplace.md
@@ -12,7 +12,7 @@ This repo now includes a Claude plugin marketplace and a plugin entry intended f
 - Marketplace catalog: [marketplace.json](/home/brianh/promptexecution/mbse/l3dg3rr/.claude-plugin/marketplace.json)
 - Plugin manifest: [plugin.json](/home/brianh/promptexecution/mbse/l3dg3rr/plugins/l3dg3rr-plugin-create/.claude-plugin/plugin.json)
 - Plugin skill: [SKILL.md](/home/brianh/promptexecution/mbse/l3dg3rr/plugins/l3dg3rr-plugin-create/skills/plugin-create-for-l3dg3rr/SKILL.md)
-- MCP server entrypoint: [turbo-mcp-server.rs](/home/brianh/promptexecution/mbse/l3dg3rr/crates/turbo-mcp/src/bin/turbo-mcp-server.rs)
+- MCP server entrypoint: [ledgerr-mcp-server.rs](/mnt/c/users/wendy/l3dg3rr/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs)
 - Runtime helper commands: [Justfile](/home/brianh/promptexecution/mbse/l3dg3rr/Justfile)
 - MCP regression script: [mcp_e2e.sh](/home/brianh/promptexecution/mbse/l3dg3rr/scripts/mcp_e2e.sh)
 - Container build: [Dockerfile](/home/brianh/promptexecution/mbse/l3dg3rr/Dockerfile)
@@ -51,7 +51,7 @@ just mcp-start
 ### 2) Compiled binary
 
 ```bash
-cargo build --release -p turbo-mcp --bin turbo-mcp-server
+cargo build --release -p ledgerr-mcp --bin ledgerr-mcp-server
 just mcp-start-release
 ```
 
@@ -60,7 +60,7 @@ just mcp-start-release
 ```bash
 docker build -t tax-ledger:dev .
 docker run -i --rm -v "$PWD:/workspace" -w /workspace tax-ledger:dev \
-  cargo run -p turbo-mcp --bin turbo-mcp-server
+  cargo run -p ledgerr-mcp --bin ledgerr-mcp-server
 ```
 
 ### 4) Python packaging / launcher
@@ -75,7 +75,7 @@ Run:
 
 ```bash
 l3dg3rr-mcp --mode cargo
-l3dg3rr-mcp --mode binary --binary ./target/release/turbo-mcp-server
+l3dg3rr-mcp --mode binary --binary ./target/release/ledgerr-mcp-server
 l3dg3rr-mcp --mode docker --image tax-ledger:dev
 ```
 
@@ -93,14 +93,14 @@ After install, in a Cowork task:
 
 ```text
 tools/list
-tools/call l3dg3rr_get_pipeline_status {}
-tools/call l3dg3rr_list_accounts {}
+tools/call ledgerr_documents {"action":"pipeline_status"}
+tools/call ledgerr_documents {"action":"list_accounts"}
 ```
 
 Optional raw-context retrieval check (after an ingest tool call writes a `.rkyv` path within your workbook directory):
 
 ```text
-tools/call l3dg3rr_get_raw_context {"rkyv_ref":"relative/path/to/context.rkyv"}
+tools/call ledgerr_documents {"action":"get_raw_context","rkyv_ref":"relative/path/to/context.rkyv"}
 ```
 
 Then run deeper checks from shell:

--- a/docs/mcp-capability-contract.md
+++ b/docs/mcp-capability-contract.md
@@ -1,6 +1,8 @@
-# MCP Capability Contract (Operator View)
+# MCP Capability Contract (Generated)
 
-This document describes the published MCP surface for `ledgerr-mcp-server`.
+This file is generated from `crates/ledgerr-mcp/src/contract.rs`.
+
+Rust code is the only source of truth for the published MCP surface. If this file drifts from the contract module, tests should fail.
 
 The default catalog is intentionally small: 7 top-level `ledgerr_*` tools. Each tool uses a required `action` field so the major capability families stay visible while related operations are grouped under one top-level command.
 
@@ -16,7 +18,9 @@ The default catalog is intentionally small: 7 top-level `ledgerr_*` tools. Each 
 | `ledgerr_tax` | tax summaries, evidence, ambiguity review, workbook export | `assist`, `evidence_chain`, `ambiguity_review`, `schedule_summary`, `export_workbook` |
 | `ledgerr_ontology` | ontology query/export/write operations | `query_path`, `export_snapshot`, `upsert_entities`, `upsert_edges` |
 
-Input parsing and validation live in [crates/ledgerr-mcp/src/mcp_adapter.rs](crates/ledgerr-mcp/src/mcp_adapter.rs).
+The concrete parser, action enums, field aliases, and JSON Schemas all live in [crates/ledgerr-mcp/src/contract.rs](../crates/ledgerr-mcp/src/contract.rs).
+
+The transport adapter in [crates/ledgerr-mcp/src/mcp_adapter.rs](../crates/ledgerr-mcp/src/mcp_adapter.rs) consumes that contract rather than re-describing it by hand.
 
 ## Compatibility
 
@@ -25,17 +29,18 @@ The server still accepts older `l3dg3rr_*` and proxy-style call names as hidden 
 ## Internal Service API
 
 Canonical trait:
-[TurboLedgerTools in crates/ledgerr-mcp/src/lib.rs](crates/ledgerr-mcp/src/lib.rs#L289)
+[TurboLedgerTools in crates/ledgerr-mcp/src/lib.rs](../crates/ledgerr-mcp/src/lib.rs#L289)
 
 Important distinction:
-- The MCP surface is now the reduced 7-tool catalog.
+- The MCP surface is the reduced 7-tool catalog defined in Rust.
 - The internal service trait remains more granular and implementation-oriented.
 
 API layering:
 1. `ledgerr-mcp-server` (stdio transport)
-2. `mcp_adapter` (tool grouping, argument parsing, envelope shaping)
-3. `TurboLedgerService` (domain logic, guardrails, state/event/HSM ops)
-4. `ledger-core` (ingest, filename validation, classification primitives)
+2. `contract` (published tool families, action enums, generated schema/doc artifacts)
+3. `mcp_adapter` (dispatch + envelope shaping)
+4. `TurboLedgerService` (domain logic, guardrails, state/event/HSM ops)
+5. `ledger-core` (ingest, filename validation, classification primitives)
 
 ## Example Flow
 
@@ -51,27 +56,31 @@ API layering:
 
 ```json
 {
-  "jsonrpc":"2.0",
-  "id":3,
-  "method":"tools/call",
-  "params":{
-    "name":"ledgerr_documents",
-    "arguments":{
-      "action":"ingest_pdf",
-      "pdf_path":"WF--BH-CHK--2023-01--statement.pdf",
-      "journal_path":"/tmp/demo.beancount",
-      "workbook_path":"/tmp/demo.xlsx",
-      "raw_context_bytes":[99,116,120],
-      "extracted_rows":[
+  "id": 3,
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "arguments": {
+      "action": "ingest_pdf",
+      "extracted_rows": [
         {
-          "account_id":"WF-BH-CHK",
-          "date":"2023-01-05",
-          "amount":"-42.50",
-          "description":"Coffee Beans",
-          "source_ref":"wf-2023-01.rkyv"
+          "account_id": "WF-BH-CHK",
+          "amount": "-42.50",
+          "date": "2023-01-05",
+          "description": "Coffee Beans",
+          "source_ref": "wf-2023-01.rkyv"
         }
-      ]
-    }
+      ],
+      "journal_path": "/tmp/demo.beancount",
+      "pdf_path": "WF--BH-CHK--2023-01--statement.pdf",
+      "raw_context_bytes": [
+        99,
+        116,
+        120
+      ],
+      "workbook_path": "/tmp/demo.xlsx"
+    },
+    "name": "ledgerr_documents"
   }
 }
 ```
@@ -80,17 +89,20 @@ API layering:
 
 ```json
 {
-  "jsonrpc":"2.0",
-  "id":4,
-  "method":"tools/call",
-  "params":{
-    "name":"ledgerr_reconciliation",
-    "arguments":{
-      "action":"commit",
-      "source_total":"42.50",
-      "extracted_total":"42.50",
-      "posting_amounts":["-42.50","42.50"]
-    }
+  "id": 4,
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "arguments": {
+      "action": "commit",
+      "extracted_total": "42.50",
+      "posting_amounts": [
+        "-42.50",
+        "42.50"
+      ],
+      "source_total": "42.50"
+    },
+    "name": "ledgerr_reconciliation"
   }
 }
 ```
@@ -106,17 +118,17 @@ API layering:
 
 ```json
 {
-  "jsonrpc":"2.0",
-  "id":7,
-  "method":"tools/call",
-  "params":{
-    "name":"ledgerr_tax",
-    "arguments":{
-      "action":"evidence_chain",
-      "ontology_path":"/tmp/ontology.json",
-      "from_entity_id":"WF-BH-CHK",
-      "document_ref":"wf-2023-01.rkyv"
-    }
+  "id": 7,
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "arguments": {
+      "action": "evidence_chain",
+      "document_ref": "wf-2023-01.rkyv",
+      "from_entity_id": "WF-BH-CHK",
+      "ontology_path": "/tmp/ontology.json"
+    },
+    "name": "ledgerr_tax"
   }
 }
 ```

--- a/docs/mcp-capability-contract.md
+++ b/docs/mcp-capability-contract.md
@@ -1,102 +1,74 @@
 # MCP Capability Contract (Operator View)
 
-This document describes what is currently exposed through:
-- MCP transport (`ledgerr-mcp-server`)
-- local CLI/runtime entrypoints (`Justfile`, Python launcher)
-- internal Rust service API (`TurboLedgerTools`)
+This document describes the published MCP surface for `ledgerr-mcp-server`.
 
-It is intentionally concrete and code-aligned.
+The default catalog is intentionally small: 7 top-level `ledgerr_*` tools. Each tool uses a required `action` field so the major capability families stay visible while related operations are grouped under one top-level command.
 
-## 1) MCP Surface (What an Agent Can Call)
+## Published MCP Tools
 
-MCP boundary:
-- Methods: `initialize`, `tools/list`, `tools/call`
-- Server: [crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs](crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs#L8)
-- Tool catalog: [crates/ledgerr-mcp/src/mcp_adapter.rs](crates/ledgerr-mcp/src/mcp_adapter.rs#L30)
+| Tool | Purpose | Common actions |
+|---|---|---|
+| `ledgerr_documents` | document intake, routing, manifest/account discovery, raw context retrieval | `list_accounts`, `pipeline_status`, `validate_filename`, `ingest_pdf`, `ingest_rows`, `get_raw_context` |
+| `ledgerr_review` | classification and human-review workflows | `run_rule`, `classify_ingested`, `query_flags`, `classify_transaction`, `reconcile_excel_classification` |
+| `ledgerr_reconciliation` | staged totals/postings guardrails | `validate`, `reconcile`, `commit` |
+| `ledgerr_workflow` | lifecycle/HSM orchestration plus relocated plugin ops | `status`, `transition`, `resume`, `plugin_info` |
+| `ledgerr_audit` | append-only event and audit-log views | `event_history`, `event_replay`, `query_audit_log` |
+| `ledgerr_tax` | tax summaries, evidence, ambiguity review, workbook export | `assist`, `evidence_chain`, `ambiguity_review`, `schedule_summary`, `export_workbook` |
+| `ledgerr_ontology` | ontology query/export/write operations | `query_path`, `export_snapshot`, `upsert_entities`, `upsert_edges` |
 
-### Tool Matrix
+Input parsing and validation live in [crates/ledgerr-mcp/src/mcp_adapter.rs](crates/ledgerr-mcp/src/mcp_adapter.rs).
 
-| MCP tool name | Primary purpose | Required arguments | Backing service/API |
-|---|---|---|---|
-| `l3dg3rr_list_accounts` | enumerate manifest account ids for tool planning and routing | none | `TurboLedgerService::list_accounts_tool` |
-| `l3dg3rr_get_raw_context` | fetch stored raw context bytes by reference path | `rkyv_ref` | `TurboLedgerTools::get_raw_context` |
-| `l3dg3rr_get_pipeline_status` | readiness hint for workflow start | none | `get_pipeline_status` adapter helper |
-| `proxy_docling_ingest_pdf` | ingest rows extracted from PDF, persist raw bytes fallback, emit canonical rows + tx ids | `pdf_path`, `journal_path`, `workbook_path`, `extracted_rows` | `TurboLedgerTools::ingest_pdf` |
-| `proxy_rustledger_ingest_statement_rows` | ingest normalized rows through rustledger-compatible path | `journal_path`, `workbook_path`, `rows` | `TurboLedgerTools::ingest_statement_rows` |
-| `l3dg3rr_ontology_query_path` | query ontology path traversal | `ontology_path`, `from_entity_id` | `TurboLedgerService::ontology_query_path_tool` |
-| `l3dg3rr_ontology_export_snapshot` | export deterministic ontology snapshot | `ontology_path` | `OntologyStore::load` + snapshot |
-| `l3dg3rr_validate_reconciliation` | validation stage checks | `source_total`, `extracted_total`, `posting_amounts` | `validate_stage` |
-| `l3dg3rr_reconcile_postings` | reconcile stage checks | `source_total`, `extracted_total`, `posting_amounts` | `reconcile_stage` |
-| `l3dg3rr_commit_guarded` | commit gate for balanced/ready stage | `source_total`, `extracted_total`, `posting_amounts` | `commit_stage` |
-| `l3dg3rr_hsm_transition` | deterministic lifecycle transition | `target_state`, `target_substate` | `hsm_transition_tool` |
-| `l3dg3rr_hsm_status` | current state + concise hints | none | `hsm_status_tool` |
-| `l3dg3rr_hsm_resume` | resume from checkpoint marker | `state_marker` | `hsm_resume_tool` |
-| `l3dg3rr_event_history` | filtered append-only event query | optional `tx_id`, `document_ref`, `time_start`, `time_end` | `event_history` |
-| `l3dg3rr_event_replay` | reconstruct lifecycle state from events | optional `tx_id`, `document_ref` | `replay_lifecycle` |
-| `l3dg3rr_tax_assist` | tax summary/schedule guidance gated by reconciliation | `ontology_path`, `from_entity_id`, `reconciliation` | `tax_assist_tool` |
-| `l3dg3rr_tax_evidence_chain` | source->events->current_state chain | `ontology_path`, `from_entity_id` | `tax_evidence_chain_tool` |
-| `l3dg3rr_tax_ambiguity_review` | ambiguity review queue payload | `ontology_path`, `from_entity_id`, `reconciliation` | `tax_ambiguity_review_tool` |
+## Compatibility
 
-Input parsing and validation live in:
-[crates/ledgerr-mcp/src/mcp_adapter.rs](crates/ledgerr-mcp/src/mcp_adapter.rs#L160)
+The server still accepts older `l3dg3rr_*` and proxy-style call names as hidden compatibility aliases, but they are no longer advertised in `tools/list`. Agents should use the `ledgerr_*` tools above by default.
 
-## 2) Internal Rust Service API (Wider Than MCP)
+## Internal Service API
 
 Canonical trait:
-[TurboLedgerTools in crates/ledgerr-mcp/src/lib.rs](crates/ledgerr-mcp/src/lib.rs#L275)
+[TurboLedgerTools in crates/ledgerr-mcp/src/lib.rs](crates/ledgerr-mcp/src/lib.rs#L289)
 
 Important distinction:
-- Some service capabilities exist but are not exposed as MCP tools yet.
-- Examples currently service-only: `run_rhai_rule`, `classify_ingested`, `query_flags`, `classify_transaction`, `query_audit_log`, `export_cpa_workbook`, `get_schedule_summary`, ontology upserts.
+- The MCP surface is now the reduced 7-tool catalog.
+- The internal service trait remains more granular and implementation-oriented.
 
-This is the current API layering:
+API layering:
 1. `ledgerr-mcp-server` (stdio transport)
-2. `mcp_adapter` (argument parsing + envelope shaping)
+2. `mcp_adapter` (tool grouping, argument parsing, envelope shaping)
 3. `TurboLedgerService` (domain logic, guardrails, state/event/HSM ops)
 4. `ledger-core` (ingest, filename validation, classification primitives)
 
-## 3) CLI / Runtime Entry Points
+## Example Flow
 
-Operational CLI helpers are lifecycle-oriented, not business-domain verbs:
-- [Justfile](Justfile#L3)
-  - `just mcp-build`
-  - `just mcp-start`
-  - `just mcp-start-release`
-  - `just mcp-stop`
-  - `just mcp-e2e`
-- Python launcher:
-  [plugins/l3dg3rr-plugin-create/python/src/l3dg3rr_mcp_launcher/__main__.py](plugins/l3dg3rr-plugin-create/python/src/l3dg3rr_mcp_launcher/__main__.py#L35)
-  - `--mode cargo|binary|docker`
+### Step A: initialize and list tools
 
-## 4) Functional Relationships (Contrived Sample)
-
-Scenario: an MCP client ingests one synthetic statement row, validates reconciliation, checks lifecycle state, then asks for tax evidence.
-
-### Step A: initialize and discover tools
 ```json
 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"demo","version":"0.1.0"}}}
 {"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
 {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
 ```
 
-### Step B: ingest a row through rustledger proxy
+### Step B: ingest a PDF through `ledgerr_documents`
+
 ```json
 {
   "jsonrpc":"2.0",
   "id":3,
   "method":"tools/call",
   "params":{
-    "name":"proxy_rustledger_ingest_statement_rows",
+    "name":"ledgerr_documents",
     "arguments":{
+      "action":"ingest_pdf",
+      "pdf_path":"WF--BH-CHK--2023-01--statement.pdf",
       "journal_path":"/tmp/demo.beancount",
       "workbook_path":"/tmp/demo.xlsx",
-      "rows":[
+      "raw_context_bytes":[99,116,120],
+      "extracted_rows":[
         {
           "account_id":"WF-BH-CHK",
           "date":"2023-01-05",
           "amount":"-42.50",
           "description":"Coffee Beans",
-          "source_ref":"/tmp/raw/wf-2023-01.rkyv"
+          "source_ref":"wf-2023-01.rkyv"
         }
       ]
     }
@@ -104,20 +76,17 @@ Scenario: an MCP client ingests one synthetic statement row, validates reconcili
 }
 ```
 
-Relationship here:
-- MCP tool -> adapter normalization/provenance (`provider=rustledger`) ->
-  `TurboLedgerService::ingest_statement_rows` ->
-  `ledger-core` ingest/idempotency.
+### Step C: run reconciliation commit gate
 
-### Step C: run reconciliation gate
 ```json
 {
   "jsonrpc":"2.0",
   "id":4,
   "method":"tools/call",
   "params":{
-    "name":"l3dg3rr_commit_guarded",
+    "name":"ledgerr_reconciliation",
     "arguments":{
+      "action":"commit",
       "source_total":"42.50",
       "extracted_total":"42.50",
       "posting_amounts":["-42.50","42.50"]
@@ -126,58 +95,39 @@ Relationship here:
 }
 ```
 
-Relationship here:
-- Reconciliation status gates downstream tax-oriented operations.
-- Blocked states return deterministic `isError` envelopes with typed reasons.
+### Step D: inspect workflow status and audit replay
 
-### Step D: inspect HSM status and event replay
 ```json
-{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"l3dg3rr_hsm_status","arguments":{}}}
-{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"l3dg3rr_event_replay","arguments":{"document_ref":"/tmp/raw/wf-2023-01.rkyv"}}}
+{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"ledgerr_workflow","arguments":{"action":"status"}}}
+{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"ledgerr_audit","arguments":{"action":"event_replay","document_ref":"wf-2023-01.rkyv"}}}
 ```
 
-Relationship here:
-- HSM provides concise lifecycle hints for small-model agent orchestration.
-- Event replay reconstructs deterministically computable lifecycle state from append-only history.
+### Step E: ask for tax evidence
 
-### Step E: ask for tax evidence chain
 ```json
 {
   "jsonrpc":"2.0",
   "id":7,
   "method":"tools/call",
   "params":{
-    "name":"l3dg3rr_tax_evidence_chain",
+    "name":"ledgerr_tax",
     "arguments":{
+      "action":"evidence_chain",
       "ontology_path":"/tmp/ontology.json",
       "from_entity_id":"WF-BH-CHK",
-      "document_ref":"/tmp/raw/wf-2023-01.rkyv"
+      "document_ref":"wf-2023-01.rkyv"
     }
   }
 }
 ```
 
-Relationship here:
-- Ontology path + event history + replay projection are merged into one evidence payload:
-  `source -> events -> current_state (+ ambiguity)`.
+## Current Gaps
 
-## 5) Practical Gaps To Keep In Mind
-
-1. Classification/audit/schedule methods are implemented in service API but not yet surfaced over MCP.
-2. Ontology upsert methods exist in service API but are not MCP-exposed (`ontology_upsert_entities_tool`, `ontology_upsert_edges_tool`).
-3. CLI is mostly runtime/start-stop orchestration; domain operations are MCP-first.
-
-## 6) Proposal: Next MCP Exposure Gaps (Mission-Aligned)
-
-The following are high-value MCP additions for an AI-first financial document knowledge workflow.
-
-| Priority | Proposed MCP tool | Existing backend method | Why it matters |
-|---|---|---|---|
-| P0 | `l3dg3rr_classify_ingested` | `classify_ingested` | turns ingestion output into review-queue-ready classifications without direct code execution |
-| P0 | `l3dg3rr_query_flags` | `query_flags` | gives agents deterministic open/resolved review queues by year |
-| P0 | `l3dg3rr_query_audit_log` | `query_audit_log` | provides explainability and mutation trace required for CPA/agent trust |
-| P1 | `l3dg3rr_classify_transaction` | `classify_transaction` | lets agents apply explicit corrections through guarded, auditable mutations |
-| P1 | `l3dg3rr_reconcile_excel_classification` | `reconcile_excel_classification` | syncs manual Excel edits back into deterministic audit/event chain |
-| P1 | `l3dg3rr_get_schedule_summary` | `get_schedule_summary` | provides compact tax summary materialization for downstream tax-agent orchestration |
-| P2 | `l3dg3rr_export_cpa_workbook` | `export_cpa_workbook` | gives a single MCP-triggered handoff artifact for CPA review cycles |
-| P2 | `l3dg3rr_ontology_upsert_entities` / `l3dg3rr_ontology_upsert_edges` | `ontology_upsert_entities_tool` / `ontology_upsert_edges_tool` | enables agent-driven ontology curation instead of read-only graph usage |
+Open design/roadmap gaps are tracked in:
+- `#20` persistent state across restart
+- `#21` workbook export completeness
+- `#22` schema/doc drift elimination
+- `#23` document inventory/queue
+- `#24` unified work queue
+- `#25` batch review actions
+- `#26` transaction query + preflight/rule preview

--- a/scripts/mcp_cli_demo.sh
+++ b/scripts/mcp_cli_demo.sh
@@ -1,20 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT_DIR"
+JOURNAL_PATH="${JOURNAL_PATH:-/tmp/demo.beancount}"
+WORKBOOK_PATH="${WORKBOOK_PATH:-/tmp/demo.xlsx}"
+SOURCE_REF="${SOURCE_REF:-wf-2023-01.rkyv}"
 
-MODE="${1:-basic}"
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
-
-SOURCE_REF="$TMP_DIR/WF--BH-CHK--2023-01--statement.rkyv"
-JOURNAL_PATH="$TMP_DIR/ledger.beancount"
-WORKBOOK_PATH="$TMP_DIR/tax-ledger.xlsx"
-
-run_basic() {
-  cat <<EOF | cargo run -q -p ledgerr-mcp --bin ledgerr-mcp-server
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"mcp-cli-basic","version":"0.1.0"}}}
+cargo run -q -p ledgerr-mcp --bin ledgerr-mcp-server <<EOF
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"demo","version":"0.1.0"}}}
 {"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
 {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
 {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"pipeline_status"}}}
@@ -22,27 +14,10 @@ run_basic() {
 {"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"ingest_pdf","pdf_path":"WF--BH-CHK--2023-01--statement.pdf","journal_path":"$JOURNAL_PATH","workbook_path":"$WORKBOOK_PATH","raw_context_bytes":[99,116,120],"extracted_rows":[{"account_id":"WF-BH-CHK","date":"2023-01-15","amount":"-42.11","description":"Coffee Shop","source_ref":"$SOURCE_REF"}]}}}
 {"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"get_raw_context","rkyv_ref":"$SOURCE_REF"}}}
 EOF
-}
 
-run_spinning_wheels() {
-  cat <<EOF | cargo run -q -p ledgerr-mcp --bin ledgerr-mcp-server
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"mcp-cli-spinning","version":"0.1.0"}}}
-{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
+# Troubleshooting path
+cat <<'EOF'
 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"ledgerr_workflow","arguments":{"action":"resume","state_marker":"invalid-checkpoint"}}}
 {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"ledgerr_reconciliation","arguments":{"action":"commit","source_total":"100.00","extracted_total":"95.00","posting_amounts":["-95.00","95.00"]}}}
 {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"ledgerr_audit","arguments":{"action":"event_history","time_start":"2026-12-31","time_end":"2026-01-01"}}}
 EOF
-}
-
-case "$MODE" in
-  basic)
-    run_basic
-    ;;
-  spinning-wheels)
-    run_spinning_wheels
-    ;;
-  *)
-    echo "usage: $0 [basic|spinning-wheels]" >&2
-    exit 2
-    ;;
-esac

--- a/scripts/mcp_cli_demo.sh
+++ b/scripts/mcp_cli_demo.sh
@@ -13,24 +13,24 @@ JOURNAL_PATH="$TMP_DIR/ledger.beancount"
 WORKBOOK_PATH="$TMP_DIR/tax-ledger.xlsx"
 
 run_basic() {
-  cat <<EOF | cargo run -q -p turbo-mcp --bin turbo-mcp-server
+  cat <<EOF | cargo run -q -p ledgerr-mcp --bin ledgerr-mcp-server
 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"mcp-cli-basic","version":"0.1.0"}}}
 {"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
 {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
-{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"l3dg3rr_get_pipeline_status","arguments":{}}}
-{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"l3dg3rr_list_accounts","arguments":{}}}
-{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"proxy_docling_ingest_pdf","arguments":{"pdf_path":"WF--BH-CHK--2023-01--statement.pdf","journal_path":"$JOURNAL_PATH","workbook_path":"$WORKBOOK_PATH","raw_context_bytes":[99,116,120],"extracted_rows":[{"account_id":"WF-BH-CHK","date":"2023-01-15","amount":"-42.11","description":"Coffee Shop","source_ref":"$SOURCE_REF"}]}}}
-{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"l3dg3rr_get_raw_context","arguments":{"rkyv_ref":"$SOURCE_REF"}}}
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"pipeline_status"}}}
+{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"list_accounts"}}}
+{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"ingest_pdf","pdf_path":"WF--BH-CHK--2023-01--statement.pdf","journal_path":"$JOURNAL_PATH","workbook_path":"$WORKBOOK_PATH","raw_context_bytes":[99,116,120],"extracted_rows":[{"account_id":"WF-BH-CHK","date":"2023-01-15","amount":"-42.11","description":"Coffee Shop","source_ref":"$SOURCE_REF"}]}}}
+{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"get_raw_context","rkyv_ref":"$SOURCE_REF"}}}
 EOF
 }
 
 run_spinning_wheels() {
-  cat <<EOF | cargo run -q -p turbo-mcp --bin turbo-mcp-server
+  cat <<EOF | cargo run -q -p ledgerr-mcp --bin ledgerr-mcp-server
 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"mcp-cli-spinning","version":"0.1.0"}}}
 {"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
-{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"l3dg3rr_hsm_resume","arguments":{"state_marker":"invalid-checkpoint"}}}
-{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"l3dg3rr_commit_guarded","arguments":{"source_total":"100.00","extracted_total":"95.00","posting_amounts":["-95.00","95.00"]}}}
-{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"l3dg3rr_event_history","arguments":{"time_start":"2026-12-31","time_end":"2026-01-01"}}}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"ledgerr_workflow","arguments":{"action":"resume","state_marker":"invalid-checkpoint"}}}
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"ledgerr_reconciliation","arguments":{"action":"commit","source_total":"100.00","extracted_total":"95.00","posting_amounts":["-95.00","95.00"]}}}
+{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"ledgerr_audit","arguments":{"action":"event_history","time_start":"2026-12-31","time_end":"2026-01-01"}}}
 EOF
 }
 

--- a/scripts/mcp_e2e.sh
+++ b/scripts/mcp_e2e.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-cargo test -p turbo-mcp --test mcp_stdio_e2e -- --nocapture
+cargo test -p ledgerr-mcp --test mcp_stdio_e2e -- --nocapture

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 hex = "0.4"
+ledgerr-mcp = { path = "../crates/ledgerr-mcp" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,13 +1,11 @@
+use std::fs;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
 use xtask_mcpb::{
     bundler::McpbBundler,
-    manifest::{
-        ManifestAuthor, ManifestServer, McpConfig, McpbManifest,
-        ServerType,
-    },
+    manifest::{ManifestAuthor, ManifestServer, McpConfig, McpbManifest, ServerType},
     publisher::{GitHubPublisher, McpRegistryPublisher},
     server_json::ServerJson,
     verify::verify_bundle,
@@ -63,9 +61,7 @@ enum Commands {
         server_name: String,
     },
     /// Validate a .mcpb bundle: ZIP structure, manifest, and entry_point presence
-    Verify {
-        path: PathBuf,
-    },
+    Verify { path: PathBuf },
     /// Update server.json version, mcpb identifier URL, and fileSha256 for a release.
     /// Run this before `mcp-publisher publish`.
     UpdateServerJson {
@@ -82,6 +78,8 @@ enum Commands {
         #[arg(long, default_value = "server.json")]
         path: PathBuf,
     },
+    /// Regenerate MCP contract docs and runnable examples from Rust.
+    GenerateMcpArtifacts,
 }
 
 fn main() {
@@ -94,7 +92,11 @@ fn main() {
 
 fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
-        Commands::Bundle { binary, output, version } => {
+        Commands::Bundle {
+            binary,
+            output,
+            version,
+        } => {
             let binary_name = binary
                 .file_name()
                 .and_then(|n| n.to_str())
@@ -113,7 +115,11 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             println!("{}", serde_json::to_string_pretty(&manifest)?);
         }
 
-        Commands::PublishGithub { release_tag, artifact, repo } => {
+        Commands::PublishGithub {
+            release_tag,
+            artifact,
+            repo,
+        } => {
             let mut publisher = GitHubPublisher::new(&release_tag);
             if let Some(r) = repo {
                 publisher = publisher.with_repo(r);
@@ -122,7 +128,12 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             println!("uploaded {} → release {}", artifact.display(), release_tag);
         }
 
-        Commands::PublishRegistry { release_tag, artifact_url, sha256, server_name } => {
+        Commands::PublishRegistry {
+            release_tag,
+            artifact_url,
+            sha256,
+            server_name,
+        } => {
             let manifest = ledgerr_manifest(&release_tag, "ledgerr-mcp-server");
             let publisher =
                 McpRegistryPublisher::new(&release_tag, &server_name, &manifest.description);
@@ -132,10 +143,20 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
         Commands::Verify { path } => {
             let manifest = verify_bundle(&path)?;
-            println!("ok: {} ({} {})", path.display(), manifest.name, manifest.version);
+            println!(
+                "ok: {} ({} {})",
+                path.display(),
+                manifest.name,
+                manifest.version
+            );
         }
 
-        Commands::UpdateServerJson { version, artifact_url, sha256, path } => {
+        Commands::UpdateServerJson {
+            version,
+            artifact_url,
+            sha256,
+            path,
+        } => {
             let mut server_json = ServerJson::load(&path)?;
             server_json.update_mcpb(&version, &artifact_url, &sha256)?;
             server_json.save(&path)?;
@@ -143,6 +164,24 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 "updated {}: version={version} sha256={sha256}",
                 path.display()
             );
+        }
+        Commands::GenerateMcpArtifacts => {
+            let capability_doc = ledgerr_mcp::contract::generated_capability_contract_markdown();
+            let runbook_doc = ledgerr_mcp::contract::generated_agent_runbook_markdown();
+            let demo_script = ledgerr_mcp::contract::generated_mcp_cli_demo_script();
+
+            fs::write("docs/mcp-capability-contract.md", capability_doc)?;
+            fs::write("docs/agent-mcp-runbook.md", runbook_doc)?;
+            fs::write("scripts/mcp_cli_demo.sh", demo_script)?;
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let perms = fs::Permissions::from_mode(0o755);
+                fs::set_permissions("scripts/mcp_cli_demo.sh", perms)?;
+            }
+
+            println!("generated MCP contract artifacts");
         }
     }
     Ok(())


### PR DESCRIPTION
Closes #22

## Summary
- add a Rust-owned MCP contract module for the published `ledgerr_*` surface
- generate `tools/list` schemas, operator docs, and runnable examples from that contract
- add drift tests so parser/schema/docs divergence fails in CI

## Validation
- `cargo test -p ledgerr-mcp`
- `just test`