### PR TITLE
feat: persist MCP operational state across restart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,10 @@ Treat this as a standing operational gate, not a one-time migration task.
   - Treat `ledger_core::workbook::REQUIRED_SHEETS` as the canonical base workbook contract for export paths.
   - `export_cpa_workbook` should rebuild the full workbook from canonical service state on each export, including `META.config`, `ACCT.registry`, schedule sheets, flag sheets, transaction sheets, and `AUDIT.log`.
   - Tests should assert representative workbook contents, not just that a file was written.
+- 2026-04-17: restart-visible MCP operational state now persists as a deterministic sidecar next to the manifest workbook path.
+  - Persist ingest idempotency state, transaction row cache, audit log, lifecycle event history, and HSM checkpoint together as one snapshot.
+  - Keep the workbook as the human/accountant artifact; do not overload it as the only machine recovery mechanism for agent queues and replay state.
+  - If the sidecar exists but cannot be parsed or its version is unsupported, fail closed instead of silently resetting state.
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 COPY xtask ./xtask
+COPY docs ./docs
+COPY scripts ./scripts
 
 RUN cargo test --workspace --all-features
 RUN cargo build -p ledgerr-mcp --release --bin ledgerr-mcp-server

--- a/crates/ledger-core/src/classify.rs
+++ b/crates/ledger-core/src/classify.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use crate::ingest::{deterministic_tx_id, TransactionInput};
 use rhai::{Dynamic, Engine, EvalAltResult, Map, Scope, AST};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ClassificationError {
@@ -46,13 +47,13 @@ pub struct ClassificationBatch {
     pub classifications: Vec<ClassifiedTransaction>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FlagStatus {
     Open,
     Resolved,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ReviewFlag {
     pub tx_id: String,
     pub year: i32,
@@ -62,7 +63,7 @@ pub struct ReviewFlag {
     pub confidence: f64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ClassificationEngine {
     flags: Vec<ReviewFlag>,
 }
@@ -200,10 +201,16 @@ fn run_classify_fn(
 fn sample_to_map(sample: &SampleTransaction) -> Map {
     let mut tx = Map::new();
     tx.insert("tx_id".into(), Dynamic::from(sample.tx_id.clone()));
-    tx.insert("account_id".into(), Dynamic::from(sample.account_id.clone()));
+    tx.insert(
+        "account_id".into(),
+        Dynamic::from(sample.account_id.clone()),
+    );
     tx.insert("date".into(), Dynamic::from(sample.date.clone()));
     tx.insert("amount".into(), Dynamic::from(sample.amount.clone()));
-    tx.insert("description".into(), Dynamic::from(sample.description.clone()));
+    tx.insert(
+        "description".into(),
+        Dynamic::from(sample.description.clone()),
+    );
     tx
 }
 

--- a/crates/ledger-core/src/ingest.rs
+++ b/crates/ledger-core/src/ingest.rs
@@ -3,8 +3,9 @@ use std::path::Path;
 
 use crate::journal::{append_entries, JournalTransaction};
 use crate::workbook::{materialize_tx_projection, TxProjectionRow};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TransactionInput {
     pub account_id: String,
     pub date: String,
@@ -13,13 +14,13 @@ pub struct TransactionInput {
     pub source_ref: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IngestedTransaction {
     pub tx_id: String,
     pub source_ref: String,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct IngestedLedger {
     seen: BTreeSet<String>,
     projection_rows: Vec<TxProjectionRow>,

--- a/crates/ledger-core/src/journal.rs
+++ b/crates/ledger-core/src/journal.rs
@@ -75,4 +75,3 @@ fn invert_amount(amount: &str) -> String {
         format!("-{}", trimmed)
     }
 }
-

--- a/crates/ledger-core/src/workbook.rs
+++ b/crates/ledger-core/src/workbook.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use rust_xlsxwriter::Workbook;
+use serde::{Deserialize, Serialize};
 
 pub const REQUIRED_SHEETS: &[&str] = &[
     "META.config",
@@ -23,7 +24,7 @@ pub fn initialize_workbook(path: &Path) -> Result<(), rust_xlsxwriter::XlsxError
     workbook.save(path)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TxProjectionRow {
     pub tx_id: String,
     pub account_id: String,

--- a/crates/ledgerr-mcp/Cargo.toml
+++ b/crates/ledgerr-mcp/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 blake3 = "1.8.3"
 ledger-core = { version = "=1.3.7", path = "../ledger-core" }
-rust_decimal = "1.41.0"
+rust_decimal = { version = "1.41.0", features = ["serde"] }
 rust_xlsxwriter = { workspace = true }
 schemars = { version = "0.8", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs
+++ b/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs
@@ -219,7 +219,12 @@ fn handle_request(request: Value) -> Option<Value> {
 fn global_service() -> &'static TurboLedgerService {
     static SERVICE: OnceLock<TurboLedgerService> = OnceLock::new();
     SERVICE.get_or_init(|| {
-        let manifest = "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n\n[accounts]\nWF-BH-CHK = { institution = \"Wells Fargo\", type = \"checking\", currency = \"USD\" }\n";
-        TurboLedgerService::from_manifest_str(manifest).expect("default manifest must parse")
+        // Allow test/process callers to inject an explicit manifest so the stdio
+        // transport can exercise restart persistence without sharing one global
+        // relative workbook path across unrelated test processes.
+        let manifest = std::env::var("LEDGERR_MCP_MANIFEST").unwrap_or_else(|_| {
+            "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n\n[accounts]\nWF-BH-CHK = { institution = \"Wells Fargo\", type = \"checking\", currency = \"USD\" }\n".to_string()
+        });
+        TurboLedgerService::from_manifest_str(&manifest).expect("default manifest must parse")
     })
 }

--- a/crates/ledgerr-mcp/src/contract.rs
+++ b/crates/ledgerr-mcp/src/contract.rs
@@ -600,23 +600,23 @@ Expected blocked outcomes:\n\n\
 
 pub fn generated_mcp_cli_demo_script() -> String {
     "#!/usr/bin/env bash\nset -euo pipefail\n\n\
-JOURNAL_PATH=\"${{JOURNAL_PATH:-/tmp/demo.beancount}}\"\n\
-WORKBOOK_PATH=\"${{WORKBOOK_PATH:-/tmp/demo.xlsx}}\"\n\
-SOURCE_REF=\"${{SOURCE_REF:-wf-2023-01.rkyv}}\"\n\n\
+JOURNAL_PATH=\"${JOURNAL_PATH:-/tmp/demo.beancount}\"\n\
+WORKBOOK_PATH=\"${WORKBOOK_PATH:-/tmp/demo.xlsx}\"\n\
+SOURCE_REF=\"${SOURCE_REF:-wf-2023-01.rkyv}\"\n\n\
 cargo run -q -p ledgerr-mcp --bin ledgerr-mcp-server <<EOF\n\
-{{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{{\"clientInfo\":{{\"name\":\"demo\",\"version\":\"0.1.0\"}}}}}}\n\
-{{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\",\"params\":{{}}}}\n\
-{{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{{}}}}\n\
-{{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{{\"name\":\"ledgerr_documents\",\"arguments\":{{\"action\":\"pipeline_status\"}}}}}}\n\
-{{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{{\"name\":\"ledgerr_documents\",\"arguments\":{{\"action\":\"list_accounts\"}}}}}}\n\
-{{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{{\"name\":\"ledgerr_documents\",\"arguments\":{{\"action\":\"ingest_pdf\",\"pdf_path\":\"WF--BH-CHK--2023-01--statement.pdf\",\"journal_path\":\"$JOURNAL_PATH\",\"workbook_path\":\"$WORKBOOK_PATH\",\"raw_context_bytes\":[99,116,120],\"extracted_rows\":[{{\"account_id\":\"WF-BH-CHK\",\"date\":\"2023-01-15\",\"amount\":\"-42.11\",\"description\":\"Coffee Shop\",\"source_ref\":\"$SOURCE_REF\"}}]}}}}}}\n\
-{{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"tools/call\",\"params\":{{\"name\":\"ledgerr_documents\",\"arguments\":{{\"action\":\"get_raw_context\",\"rkyv_ref\":\"$SOURCE_REF\"}}}}}}\n\
+{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"clientInfo\":{\"name\":\"demo\",\"version\":\"0.1.0\"}}}\n\
+{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\",\"params\":{}}\n\
+{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}\n\
+{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_documents\",\"arguments\":{\"action\":\"pipeline_status\"}}}\n\
+{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_documents\",\"arguments\":{\"action\":\"list_accounts\"}}}\n\
+{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_documents\",\"arguments\":{\"action\":\"ingest_pdf\",\"pdf_path\":\"WF--BH-CHK--2023-01--statement.pdf\",\"journal_path\":\"$JOURNAL_PATH\",\"workbook_path\":\"$WORKBOOK_PATH\",\"raw_context_bytes\":[99,116,120],\"extracted_rows\":[{\"account_id\":\"WF-BH-CHK\",\"date\":\"2023-01-15\",\"amount\":\"-42.11\",\"description\":\"Coffee Shop\",\"source_ref\":\"$SOURCE_REF\"}]}}}\n\
+{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_documents\",\"arguments\":{\"action\":\"get_raw_context\",\"rkyv_ref\":\"$SOURCE_REF\"}}}\n\
 EOF\n\n\
 # Troubleshooting path\n\
 cat <<'EOF'\n\
-{{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{{\"name\":\"ledgerr_workflow\",\"arguments\":{{\"action\":\"resume\",\"state_marker\":\"invalid-checkpoint\"}}}}}}\n\
-{{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{{\"name\":\"ledgerr_reconciliation\",\"arguments\":{{\"action\":\"commit\",\"source_total\":\"100.00\",\"extracted_total\":\"95.00\",\"posting_amounts\":[\"-95.00\",\"95.00\"]}}}}}}\n\
-{{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{{\"name\":\"ledgerr_audit\",\"arguments\":{{\"action\":\"event_history\",\"time_start\":\"2026-12-31\",\"time_end\":\"2026-01-01\"}}}}}}\n\
+{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_workflow\",\"arguments\":{\"action\":\"resume\",\"state_marker\":\"invalid-checkpoint\"}}}\n\
+{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_reconciliation\",\"arguments\":{\"action\":\"commit\",\"source_total\":\"100.00\",\"extracted_total\":\"95.00\",\"posting_amounts\":[\"-95.00\",\"95.00\"]}}}\n\
+{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_audit\",\"arguments\":{\"action\":\"event_history\",\"time_start\":\"2026-12-31\",\"time_end\":\"2026-01-01\"}}}\n\
 EOF\n"
         .to_string()
 }

--- a/crates/ledgerr-mcp/src/events.rs
+++ b/crates/ledgerr-mcp/src/events.rs
@@ -1,10 +1,11 @@
 use std::collections::BTreeMap;
 
 use crate::ToolError;
+use serde::{Deserialize, Serialize};
 
 const EVENT_TYPES: &[&str] = &["ingest", "classification", "reconciliation", "adjustment"];
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LifecycleEvent {
     pub event_id: String,
     pub sequence: u64,
@@ -22,7 +23,7 @@ pub struct AppendEventResult {
     pub sequence: u64,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EventHistoryFilter {
     pub tx_id: Option<String>,
     pub document_ref: Option<String>,
@@ -54,7 +55,7 @@ pub trait LifecycleEventStore {
     fn list_events(&self, filter: EventHistoryFilter) -> Result<EventHistoryResponse, ToolError>;
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct InMemoryLifecycleEventStore {
     events: Vec<LifecycleEvent>,
     next_sequence: u64,
@@ -233,10 +234,7 @@ pub fn reconstruct_lifecycle(events: &[LifecycleEvent]) -> ReplayProjection {
             expected_sequence = expected_sequence.saturating_add(1);
         }
 
-        let tx_id = event
-            .tx_id
-            .clone()
-            .unwrap_or_else(|| "_stream".to_string());
+        let tx_id = event.tx_id.clone().unwrap_or_else(|| "_stream".to_string());
         let current_stage = stage_by_tx.get(&tx_id).cloned();
         if current_stage.is_none() && event.event_type != "ingest" {
             diagnostics.push(format!(

--- a/crates/ledgerr-mcp/src/hsm.rs
+++ b/crates/ledgerr-mcp/src/hsm.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum LifecycleState {
     Ingest,
     Normalize,
@@ -33,7 +35,7 @@ impl LifecycleState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum LifecycleSubstate {
     Pending,
     Ready,
@@ -56,7 +58,7 @@ impl LifecycleSubstate {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct LifecycleNode {
     pub state: LifecycleState,
     pub substate: LifecycleSubstate,
@@ -110,7 +112,7 @@ pub struct HsmResumeResponse {
     pub blockers: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HsmMachine {
     pub current: LifecycleNode,
     pub last_valid_checkpoint: String,
@@ -130,7 +132,11 @@ impl Default for HsmMachine {
 }
 
 pub fn checkpoint_marker(node: LifecycleNode) -> String {
-    format!("{}:{}:advanced", node.state.as_str(), node.substate.as_str())
+    format!(
+        "{}:{}:advanced",
+        node.state.as_str(),
+        node.substate.as_str()
+    )
 }
 
 pub fn parse_checkpoint_marker(marker: &str) -> Option<LifecycleNode> {
@@ -144,7 +150,11 @@ pub fn parse_checkpoint_marker(marker: &str) -> Option<LifecycleNode> {
     parse_node(state, substate)
 }
 
-pub fn resume_response(node: LifecycleNode, resumed: bool, mut blockers: Vec<String>) -> HsmResumeResponse {
+pub fn resume_response(
+    node: LifecycleNode,
+    resumed: bool,
+    mut blockers: Vec<String>,
+) -> HsmResumeResponse {
     blockers.sort();
     blockers.dedup();
     HsmResumeResponse {
@@ -195,7 +205,10 @@ pub fn next_hint_for(node: LifecycleNode) -> String {
     .to_string()
 }
 
-pub fn transition_blocked_response(current: LifecycleNode, requested: LifecycleNode) -> HsmTransitionResponse {
+pub fn transition_blocked_response(
+    current: LifecycleNode,
+    requested: LifecycleNode,
+) -> HsmTransitionResponse {
     let mut transition_evidence = vec![
         format!("from={}", current.token()),
         format!("to={}", requested.token()),
@@ -212,7 +225,11 @@ pub fn transition_blocked_response(current: LifecycleNode, requested: LifecycleN
         status: "blocked".to_string(),
         guard_reason: Some("invalid_transition".to_string()),
         transition_evidence,
-        state_marker: format!("{}:{}:blocked", current.state.as_str(), current.substate.as_str()),
+        state_marker: format!(
+            "{}:{}:blocked",
+            current.state.as_str(),
+            current.substate.as_str()
+        ),
     }
 }
 

--- a/crates/ledgerr-mcp/src/lib.rs
+++ b/crates/ledgerr-mcp/src/lib.rs
@@ -10,6 +10,7 @@ use ledger_core::manifest::Manifest;
 use ledger_core::workbook::REQUIRED_SHEETS;
 use rust_decimal::Decimal;
 use rust_xlsxwriter::Workbook;
+use serde::{Deserialize, Serialize};
 
 pub mod contract;
 pub mod events;
@@ -327,13 +328,13 @@ pub trait TurboLedgerTools {
     ) -> Result<GetScheduleSummaryResponse, ToolError>;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct StoredClassification {
     category: String,
     confidence: Decimal,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct AuditEntry {
     timestamp: String,
     actor: String,
@@ -344,12 +345,35 @@ struct AuditEntry {
     note: Option<String>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct ClassificationState {
     tx_rows: BTreeMap<String, TransactionInput>,
     classifications: BTreeMap<String, StoredClassification>,
     audit_log: Vec<AuditEntry>,
     engine: ClassificationEngine,
+}
+
+const PERSISTED_STATE_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedServiceState {
+    version: u32,
+    ingest_state: IngestedLedger,
+    classification_state: ClassificationState,
+    lifecycle_events: InMemoryLifecycleEventStore,
+    hsm_state: HsmMachine,
+}
+
+impl Default for PersistedServiceState {
+    fn default() -> Self {
+        Self {
+            version: PERSISTED_STATE_VERSION,
+            ingest_state: IngestedLedger::default(),
+            classification_state: ClassificationState::default(),
+            lifecycle_events: InMemoryLifecycleEventStore::default(),
+            hsm_state: HsmMachine::default(),
+        }
+    }
 }
 
 pub struct TurboLedgerService {
@@ -363,17 +387,61 @@ pub struct TurboLedgerService {
 impl TurboLedgerService {
     pub fn from_manifest_str(src: &str) -> Result<Self, ToolError> {
         let manifest = Manifest::parse(src).map_err(|e| ToolError::InvalidInput(e.to_string()))?;
+        let persisted =
+            load_persisted_state(std::path::Path::new(&manifest.session.workbook_path))?;
         Ok(Self {
             manifest,
-            ingest_state: Mutex::new(IngestedLedger::default()),
-            classification_state: Mutex::new(ClassificationState::default()),
-            lifecycle_events: Mutex::new(InMemoryLifecycleEventStore::default()),
-            hsm_state: Mutex::new(HsmMachine::default()),
+            ingest_state: Mutex::new(persisted.ingest_state),
+            classification_state: Mutex::new(persisted.classification_state),
+            lifecycle_events: Mutex::new(persisted.lifecycle_events),
+            hsm_state: Mutex::new(persisted.hsm_state),
         })
     }
 
     pub fn workbook_path(&self) -> &std::path::Path {
         std::path::Path::new(&self.manifest.session.workbook_path)
+    }
+
+    fn state_sidecar_path(&self) -> PathBuf {
+        persisted_state_path(self.workbook_path())
+    }
+
+    fn snapshot_persisted_state(&self) -> Result<PersistedServiceState, ToolError> {
+        // Persist all restart-visible state as one snapshot so idempotency, audit,
+        // lifecycle replay, and HSM resume move together. Partial silent resets would
+        // be worse than a hard failure in this accountant-facing workflow.
+        let ingest_state = self
+            .ingest_state
+            .lock()
+            .map_err(|_| ToolError::Internal("ingest lock poisoned".to_string()))?
+            .clone();
+        let classification_state = self
+            .classification_state
+            .lock()
+            .map_err(|_| ToolError::Internal("classification lock poisoned".to_string()))?
+            .clone();
+        let lifecycle_events = self
+            .lifecycle_events
+            .lock()
+            .map_err(|_| ToolError::Internal("events lock poisoned".to_string()))?
+            .clone();
+        let hsm_state = self
+            .hsm_state
+            .lock()
+            .map_err(|_| ToolError::Internal("hsm lock poisoned".to_string()))?
+            .clone();
+        Ok(PersistedServiceState {
+            version: PERSISTED_STATE_VERSION,
+            ingest_state,
+            classification_state,
+            lifecycle_events,
+            hsm_state,
+        })
+    }
+
+    fn persist_state(&self) -> Result<(), ToolError> {
+        let snapshot = self.snapshot_persisted_state()?;
+        persist_state_to_path(&self.state_sidecar_path(), &snapshot)
     }
 
     pub fn list_accounts_tool(
@@ -487,7 +555,10 @@ impl TurboLedgerService {
         if hsm::allowed_next_node(current) == Some(requested) {
             hsm.current = requested;
             hsm.last_valid_checkpoint = hsm::checkpoint_marker(requested);
-            return Ok(hsm::transition_advanced_response(requested));
+            let response = hsm::transition_advanced_response(requested);
+            drop(hsm);
+            self.persist_state()?;
+            return Ok(response);
         }
 
         Ok(hsm::transition_blocked_response(current, requested))
@@ -529,7 +600,10 @@ impl TurboLedgerService {
         }
 
         hsm.current = resume_node;
-        Ok(hsm::resume_response(hsm.current, true, Vec::new()))
+        let response = hsm::resume_response(hsm.current, true, Vec::new());
+        drop(hsm);
+        self.persist_state()?;
+        Ok(response)
     }
 
     pub fn adjust_transaction(
@@ -849,6 +923,7 @@ impl TurboLedgerService {
             Some(tx_row.source_ref.clone()),
             payload,
         )?;
+        self.persist_state()?;
 
         Ok(response)
     }
@@ -920,6 +995,7 @@ impl TurboLedgerTools for TurboLedgerService {
                 payload,
             )?;
         }
+        self.persist_state()?;
 
         let tx_ids = inserted
             .iter()
@@ -1128,6 +1204,8 @@ impl TurboLedgerTools for TurboLedgerService {
                 reason: c.reason,
             });
         }
+        drop(classification);
+        self.persist_state()?;
 
         Ok(ClassifyIngestedResponse {
             classifications: results,
@@ -1528,6 +1606,65 @@ fn now_timestamp() -> String {
         Ok(d) => format!("{}", d.as_secs()),
         Err(_) => "0".to_string(),
     }
+}
+
+fn persisted_state_path(workbook_path: &std::path::Path) -> PathBuf {
+    PathBuf::from(format!("{}.ledgerr-state.json", workbook_path.display()))
+}
+
+fn load_persisted_state(
+    workbook_path: &std::path::Path,
+) -> Result<PersistedServiceState, ToolError> {
+    let sidecar_path = persisted_state_path(workbook_path);
+    if !sidecar_path.exists() {
+        return Ok(PersistedServiceState::default());
+    }
+
+    let bytes = std::fs::read(&sidecar_path).map_err(|e| {
+        ToolError::Internal(format!(
+            "failed to read persisted state '{}': {e}",
+            sidecar_path.display()
+        ))
+    })?;
+    let state: PersistedServiceState = serde_json::from_slice(&bytes).map_err(|e| {
+        ToolError::Internal(format!(
+            "failed to parse persisted state '{}': {e}",
+            sidecar_path.display()
+        ))
+    })?;
+    if state.version != PERSISTED_STATE_VERSION {
+        return Err(ToolError::Internal(format!(
+            "unsupported persisted state version {} in '{}'",
+            state.version,
+            sidecar_path.display()
+        )));
+    }
+    Ok(state)
+}
+
+fn persist_state_to_path(
+    sidecar_path: &std::path::Path,
+    state: &PersistedServiceState,
+) -> Result<(), ToolError> {
+    if let Some(parent) = sidecar_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            ToolError::Internal(format!(
+                "failed to create persisted state directory '{}': {e}",
+                parent.display()
+            ))
+        })?;
+    }
+    let bytes = serde_json::to_vec_pretty(state)
+        .map_err(|e| ToolError::Internal(format!("failed to serialize persisted state: {e}")))?;
+    std::fs::write(sidecar_path, bytes).map_err(|e| {
+        ToolError::Internal(format!(
+            "failed to write persisted state '{}': {e}",
+            sidecar_path.display()
+        ))
+    })
 }
 
 fn to_audit_response(entry: AuditEntry) -> AuditEntryResponse {

--- a/crates/ledgerr-mcp/src/lib.rs
+++ b/crates/ledgerr-mcp/src/lib.rs
@@ -1659,9 +1659,23 @@ fn persist_state_to_path(
     }
     let bytes = serde_json::to_vec_pretty(state)
         .map_err(|e| ToolError::Internal(format!("failed to serialize persisted state: {e}")))?;
-    std::fs::write(sidecar_path, bytes).map_err(|e| {
+    // Write to a sibling temp file first, then rename atomically so a mid-write
+    // crash never leaves a truncated/corrupt sidecar that causes startup to fail closed.
+    let tmp_path: std::path::PathBuf = {
+        let mut tmp_os_string = sidecar_path.as_os_str().to_os_string();
+        tmp_os_string.push(".tmp");
+        tmp_os_string.into()
+    };
+    std::fs::write(&tmp_path, &bytes).map_err(|e| {
         ToolError::Internal(format!(
-            "failed to write persisted state '{}': {e}",
+            "failed to write persisted state temp file '{}': {e}",
+            tmp_path.display()
+        ))
+    })?;
+    std::fs::rename(&tmp_path, sidecar_path).map_err(|e| {
+        ToolError::Internal(format!(
+            "failed to rename persisted state '{}' to '{}': {e}",
+            tmp_path.display(),
             sidecar_path.display()
         ))
     })

--- a/crates/ledgerr-mcp/tests/common/mod.rs
+++ b/crates/ledgerr-mcp/tests/common/mod.rs
@@ -1,0 +1,27 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static COUNTER: AtomicU64 = AtomicU64::new(1);
+
+pub fn unique_workbook_path(label: &str) -> PathBuf {
+    let suffix = COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "ledgerr-{label}-{}-{suffix}.xlsx",
+        std::process::id()
+    ))
+}
+
+pub fn manifest_for_workbook(workbook_path: &Path, active_year: i32) -> String {
+    format!(
+        "[session]\nworkbook_path=\"{}\"\nactive_year={active_year}\n",
+        workbook_path.display()
+    )
+}
+
+#[allow(dead_code)]
+pub fn stdio_test_manifest(label: &str) -> String {
+    format!(
+        "{}\n[accounts]\nWF-BH-CHK = {{ institution = \"Wells Fargo\", type = \"checking\", currency = \"USD\" }}\n",
+        manifest_for_workbook(&unique_workbook_path(label), 2023)
+    )
+}

--- a/crates/ledgerr-mcp/tests/e2e_bdd.rs
+++ b/crates/ledgerr-mcp/tests/e2e_bdd.rs
@@ -1,12 +1,13 @@
+mod common;
+
 use calamine::Reader;
 use ledger_core::ingest::TransactionInput;
 use ledgerr_mcp::{GetRawContextRequest, IngestPdfRequest, TurboLedgerService, TurboLedgerTools};
 
 fn service() -> TurboLedgerService {
-    TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n",
-    )
-    .expect("manifest should parse")
+    let workbook_path = common::unique_workbook_path("e2e-bdd");
+    TurboLedgerService::from_manifest_str(&common::manifest_for_workbook(&workbook_path, 2023))
+        .expect("manifest should parse")
 }
 
 #[test]

--- a/crates/ledgerr-mcp/tests/e2e_mvp_flow.rs
+++ b/crates/ledgerr-mcp/tests/e2e_mvp_flow.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use ledger_core::ingest::TransactionInput;
 use ledgerr_mcp::{
     ClassifyTransactionRequest, FlagStatusRequest, GetScheduleSummaryRequest, IngestPdfRequest,
@@ -6,10 +8,9 @@ use ledgerr_mcp::{
 };
 
 fn service() -> TurboLedgerService {
-    TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n",
-    )
-    .expect("manifest")
+    let workbook_path = common::unique_workbook_path("e2e-mvp");
+    TurboLedgerService::from_manifest_str(&common::manifest_for_workbook(&workbook_path, 2023))
+        .expect("manifest")
 }
 
 #[test]

--- a/crates/ledgerr-mcp/tests/events_contract.rs
+++ b/crates/ledgerr-mcp/tests/events_contract.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::collections::BTreeSet;
 
 use ledger_core::ingest::TransactionInput;
@@ -7,10 +9,9 @@ use ledgerr_mcp::{
 };
 
 fn service() -> TurboLedgerService {
-    TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n",
-    )
-    .expect("manifest")
+    let workbook_path = common::unique_workbook_path("events-contract");
+    TurboLedgerService::from_manifest_str(&common::manifest_for_workbook(&workbook_path, 2023))
+        .expect("manifest")
 }
 
 fn sample_row(description: &str, amount: &str) -> TransactionInput {

--- a/crates/ledgerr-mcp/tests/events_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/events_mcp_e2e.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 
@@ -8,7 +10,6 @@ fn parse_response_payload(response: &Value) -> Value {
     serde_json::from_str(text).unwrap_or(Value::Null)
 }
 
-const EVENT_REPLAY_TOOL: &str = "l3dg3rr_event_replay";
 const EVENT_HISTORY_TOOL: &str = "l3dg3rr_event_history";
 
 struct McpStdioClient {
@@ -22,6 +23,10 @@ impl McpStdioClient {
     fn spawn() -> Self {
         let server_bin = env!("CARGO_BIN_EXE_ledgerr-mcp-server");
         let mut child = Command::new(server_bin)
+            .env(
+                "LEDGERR_MCP_MANIFEST",
+                common::stdio_test_manifest("events-mcp"),
+            )
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())

--- a/crates/ledgerr-mcp/tests/events_replay_contract.rs
+++ b/crates/ledgerr-mcp/tests/events_replay_contract.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::collections::BTreeMap;
 
 use ledger_core::ingest::TransactionInput;
@@ -8,10 +10,9 @@ use ledgerr_mcp::{
 };
 
 fn service() -> TurboLedgerService {
-    TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n",
-    )
-    .expect("manifest")
+    let workbook_path = common::unique_workbook_path("events-replay");
+    TurboLedgerService::from_manifest_str(&common::manifest_for_workbook(&workbook_path, 2023))
+        .expect("manifest")
 }
 
 fn sample_row(date: &str, description: &str, source_ref: &str) -> TransactionInput {

--- a/crates/ledgerr-mcp/tests/hsm_contract.rs
+++ b/crates/ledgerr-mcp/tests/hsm_contract.rs
@@ -1,10 +1,11 @@
+mod common;
+
 use ledgerr_mcp::{HsmStatusRequest, HsmTransitionRequest, TurboLedgerService};
 
 fn service() -> TurboLedgerService {
-    TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n",
-    )
-    .expect("manifest")
+    let workbook_path = common::unique_workbook_path("hsm-contract");
+    TurboLedgerService::from_manifest_str(&common::manifest_for_workbook(&workbook_path, 2023))
+        .expect("manifest")
 }
 
 #[test]

--- a/crates/ledgerr-mcp/tests/hsm_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/hsm_mcp_e2e.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 
@@ -18,6 +20,10 @@ impl McpStdioClient {
     fn spawn() -> Self {
         let server_bin = env!("CARGO_BIN_EXE_ledgerr-mcp-server");
         let mut child = Command::new(server_bin)
+            .env(
+                "LEDGERR_MCP_MANIFEST",
+                common::stdio_test_manifest("hsm-mcp"),
+            )
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -92,7 +98,6 @@ fn initialize_client(client: &mut McpStdioClient) {
     );
     client.send_notification_initialized();
 }
-
 
 fn parse_response_payload(response: &serde_json::Value) -> serde_json::Value {
     let text = response["content"][0]["text"].as_str().unwrap_or("null");

--- a/crates/ledgerr-mcp/tests/hsm_resume_contract.rs
+++ b/crates/ledgerr-mcp/tests/hsm_resume_contract.rs
@@ -1,10 +1,11 @@
+mod common;
+
 use ledgerr_mcp::{HsmResumeRequest, HsmStatusRequest, HsmTransitionRequest, TurboLedgerService};
 
 fn service() -> TurboLedgerService {
-    TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n",
-    )
-    .expect("manifest")
+    let workbook_path = common::unique_workbook_path("hsm-resume");
+    TurboLedgerService::from_manifest_str(&common::manifest_for_workbook(&workbook_path, 2023))
+        .expect("manifest")
 }
 
 #[test]

--- a/crates/ledgerr-mcp/tests/interface.rs
+++ b/crates/ledgerr-mcp/tests/interface.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use ledger_core::ingest::TransactionInput;
 use ledgerr_mcp::{
     GetRawContextRequest, IngestPdfRequest, IngestStatementRowsRequest, ListAccountsRequest,
@@ -6,17 +8,12 @@ use ledgerr_mcp::{
 
 #[test]
 fn list_accounts_is_stable_and_obvious() {
-    let manifest = r#"
-[session]
-workbook_path = "tax-ledger.xlsx"
-active_year = 2023
+    let manifest = format!(
+        "{}\n[accounts]\nWF-BH-CHK = {{ institution = \"Wells Fargo\", type = \"checking\", currency = \"USD\" }}\nCB-BTC = {{ institution = \"Coinbase\", type = \"exchange\", currency = \"USD\" }}\n",
+        common::manifest_for_workbook(&common::unique_workbook_path("interface-accounts"), 2023)
+    );
 
-[accounts]
-WF-BH-CHK = { institution = "Wells Fargo", type = "checking", currency = "USD" }
-CB-BTC = { institution = "Coinbase", type = "exchange", currency = "USD" }
-"#;
-
-    let service = TurboLedgerService::from_manifest_str(manifest).unwrap();
+    let service = TurboLedgerService::from_manifest_str(&manifest).unwrap();
     let mut accounts = service.list_accounts().unwrap();
     accounts.sort_by(|a, b| a.account_id.cmp(&b.account_id));
 
@@ -26,16 +23,15 @@ CB-BTC = { institution = "Coinbase", type = "exchange", currency = "USD" }
 
 #[test]
 fn list_accounts_tool_contract_is_explicit() {
-    let manifest = r#"
-[session]
-workbook_path = "tax-ledger.xlsx"
-active_year = 2023
+    let manifest = format!(
+        "{}\n[accounts]\nWF-BH-CHK = {{ institution = \"Wells Fargo\", type = \"checking\", currency = \"USD\" }}\n",
+        common::manifest_for_workbook(
+            &common::unique_workbook_path("interface-accounts-tool"),
+            2023
+        )
+    );
 
-[accounts]
-WF-BH-CHK = { institution = "Wells Fargo", type = "checking", currency = "USD" }
-"#;
-
-    let service = TurboLedgerService::from_manifest_str(manifest).unwrap();
+    let service = TurboLedgerService::from_manifest_str(&manifest).unwrap();
     let response = service.list_accounts_tool(ListAccountsRequest).unwrap();
 
     assert_eq!(response.accounts.len(), 1);
@@ -44,13 +40,10 @@ WF-BH-CHK = { institution = "Wells Fargo", type = "checking", currency = "USD" }
 
 #[test]
 fn preflight_rejects_non_contract_filename() {
-    let manifest = r#"
-[session]
-workbook_path = "tax-ledger.xlsx"
-active_year = 2023
-"#;
+    let manifest =
+        common::manifest_for_workbook(&common::unique_workbook_path("interface-preflight"), 2023);
 
-    let service = TurboLedgerService::from_manifest_str(manifest).unwrap();
+    let service = TurboLedgerService::from_manifest_str(&manifest).unwrap();
     let err = service
         .validate_source_filename("bad-name.pdf")
         .unwrap_err();
@@ -60,12 +53,9 @@ active_year = 2023
 
 #[test]
 fn ingest_statement_rows_writes_git_friendly_journal_once() {
-    let manifest = r#"
-[session]
-workbook_path = "tax-ledger.xlsx"
-active_year = 2023
-"#;
-    let service = TurboLedgerService::from_manifest_str(manifest).unwrap();
+    let manifest =
+        common::manifest_for_workbook(&common::unique_workbook_path("interface-ingest"), 2023);
+    let service = TurboLedgerService::from_manifest_str(&manifest).unwrap();
     let tmp = tempfile::tempdir().unwrap();
     let journal_path = tmp.path().join("ledger.beancount");
     let workbook_path = tmp.path().join("tax-ledger.xlsx");
@@ -102,12 +92,9 @@ active_year = 2023
 
 #[test]
 fn ingest_pdf_validates_filename_and_ingests_rows() {
-    let manifest = r#"
-[session]
-workbook_path = "tax-ledger.xlsx"
-active_year = 2023
-"#;
-    let service = TurboLedgerService::from_manifest_str(manifest).unwrap();
+    let manifest =
+        common::manifest_for_workbook(&common::unique_workbook_path("interface-ingest-pdf"), 2023);
+    let service = TurboLedgerService::from_manifest_str(&manifest).unwrap();
     let tmp = tempfile::tempdir().unwrap();
     let journal_path = tmp.path().join("ledger.beancount");
     let workbook_path = tmp.path().join("tax-ledger.xlsx");
@@ -134,12 +121,9 @@ active_year = 2023
 
 #[test]
 fn get_raw_context_reads_rkyv_reference_bytes() {
-    let manifest = r#"
-[session]
-workbook_path = "tax-ledger.xlsx"
-active_year = 2023
-"#;
-    let service = TurboLedgerService::from_manifest_str(manifest).unwrap();
+    let manifest =
+        common::manifest_for_workbook(&common::unique_workbook_path("interface-raw-context"), 2023);
+    let service = TurboLedgerService::from_manifest_str(&manifest).unwrap();
     let tmp = tempfile::tempdir().unwrap();
     let rkyv_ref = tmp.path().join("sample.rkyv");
     std::fs::write(&rkyv_ref, b"rkyv-bytes").unwrap();

--- a/crates/ledgerr-mcp/tests/mcp_stdio_e2e.rs
+++ b/crates/ledgerr-mcp/tests/mcp_stdio_e2e.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 
@@ -14,6 +16,10 @@ impl McpStdioClient {
     fn spawn() -> Self {
         let server_bin = env!("CARGO_BIN_EXE_ledgerr-mcp-server");
         let mut child = Command::new(server_bin)
+            .env(
+                "LEDGERR_MCP_MANIFEST",
+                common::stdio_test_manifest("mcp-stdio-e2e"),
+            )
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())

--- a/crates/ledgerr-mcp/tests/ontology_contract.rs
+++ b/crates/ledgerr-mcp/tests/ontology_contract.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::collections::BTreeMap;
 
 use ledgerr_mcp::{
@@ -7,13 +9,10 @@ use ledgerr_mcp::{
 use tempfile::tempdir;
 
 fn service() -> TurboLedgerService {
-    let manifest = r#"
-[session]
-workbook_path = "tax-ledger.xlsx"
-active_year = 2023
-"#;
+    let manifest =
+        common::manifest_for_workbook(&common::unique_workbook_path("ontology-contract"), 2023);
 
-    TurboLedgerService::from_manifest_str(manifest).expect("manifest should parse")
+    TurboLedgerService::from_manifest_str(&manifest).expect("manifest should parse")
 }
 
 // ONTO-01 (D-02, D-03, D-04): valid ontology entities and edges persist with stable content-hash IDs.

--- a/crates/ledgerr-mcp/tests/ontology_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/ontology_mcp_e2e.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
@@ -22,6 +24,10 @@ impl McpStdioClient {
     fn spawn() -> Self {
         let server_bin = env!("CARGO_BIN_EXE_ledgerr-mcp-server");
         let mut child = Command::new(server_bin)
+            .env(
+                "LEDGERR_MCP_MANIFEST",
+                common::stdio_test_manifest("ontology-mcp"),
+            )
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -314,10 +320,12 @@ fn onto_03_export_snapshot_stable_json_serialization_over_transport() {
 // ONTO-03 (D-03): ontology_export_snapshot routes through TurboLedgerService, not OntologyStore directly.
 #[test]
 fn onto_03_export_snapshot_routes_through_service() {
-    const TEST_MANIFEST: &str = "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n\n[accounts]\nWF-BH-CHK = { institution = \"Wells Fargo\", type = \"checking\", currency = \"USD\" }\n";
-
+    let test_manifest = format!(
+        "{}\n[accounts]\nWF-BH-CHK = {{ institution = \"Wells Fargo\", type = \"checking\", currency = \"USD\" }}\n",
+        common::manifest_for_workbook(&common::unique_workbook_path("ontology-mcp"), 2023)
+    );
     let service =
-        TurboLedgerService::from_manifest_str(TEST_MANIFEST).expect("manifest must parse");
+        TurboLedgerService::from_manifest_str(&test_manifest).expect("manifest must parse");
 
     let tempdir = tempfile::tempdir().expect("tempdir");
     let ontology_path = tempdir.path().join("ontology.json");

--- a/crates/ledgerr-mcp/tests/phase2_mcp_contract_remaining.rs
+++ b/crates/ledgerr-mcp/tests/phase2_mcp_contract_remaining.rs
@@ -1,12 +1,14 @@
+mod common;
+
 use ledger_core::ingest::TransactionInput;
 use ledgerr_mcp::{GetRawContextRequest, IngestPdfRequest, TurboLedgerService, TurboLedgerTools};
 
 #[test]
 fn mcp_01_ingest_pdf_returns_deterministic_tx_ids_from_real_ingest() {
-    let service = TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n",
-    )
-    .unwrap();
+    let workbook_path = common::unique_workbook_path("phase2-contract");
+    let service =
+        TurboLedgerService::from_manifest_str(&common::manifest_for_workbook(&workbook_path, 2023))
+            .unwrap();
 
     let dir = tempfile::tempdir().unwrap();
     let response = service
@@ -31,10 +33,10 @@ fn mcp_01_ingest_pdf_returns_deterministic_tx_ids_from_real_ingest() {
 
 #[test]
 fn mcp_05_get_raw_context_returns_stored_rkyv_bytes() {
-    let service = TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n",
-    )
-    .unwrap();
+    let workbook_path = common::unique_workbook_path("phase2-raw-context");
+    let service =
+        TurboLedgerService::from_manifest_str(&common::manifest_for_workbook(&workbook_path, 2023))
+            .unwrap();
 
     let dir = tempfile::tempdir().unwrap();
     let rkyv = dir.path().join("ctx.rkyv");

--- a/crates/ledgerr-mcp/tests/phase3_mcp_classification.rs
+++ b/crates/ledgerr-mcp/tests/phase3_mcp_classification.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use ledger_core::ingest::TransactionInput;
 use ledgerr_mcp::{
     ClassifyIngestedRequest, FlagStatusRequest, IngestPdfRequest, QueryFlagsRequest,
@@ -5,10 +7,9 @@ use ledgerr_mcp::{
 };
 
 fn service() -> TurboLedgerService {
-    TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n",
-    )
-    .expect("manifest")
+    let workbook_path = common::unique_workbook_path("phase3-classification");
+    TurboLedgerService::from_manifest_str(&common::manifest_for_workbook(&workbook_path, 2023))
+        .expect("manifest")
 }
 
 fn write_rule_file(dir: &tempfile::TempDir) -> std::path::PathBuf {

--- a/crates/ledgerr-mcp/tests/phase4_audit_integrity.rs
+++ b/crates/ledgerr-mcp/tests/phase4_audit_integrity.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use ledger_core::ingest::TransactionInput;
 use ledgerr_mcp::{
     ClassifyTransactionRequest, FlagStatusRequest, IngestPdfRequest, QueryAuditLogRequest,
@@ -5,10 +7,9 @@ use ledgerr_mcp::{
 };
 
 fn service() -> TurboLedgerService {
-    TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n",
-    )
-    .expect("manifest")
+    let workbook_path = common::unique_workbook_path("phase4-audit");
+    TurboLedgerService::from_manifest_str(&common::manifest_for_workbook(&workbook_path, 2023))
+        .expect("manifest")
 }
 
 fn ingest_one(svc: &TurboLedgerService, description: &str, amount: &str) -> String {

--- a/crates/ledgerr-mcp/tests/phase5_cpa_outputs.rs
+++ b/crates/ledgerr-mcp/tests/phase5_cpa_outputs.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use calamine::Reader;
 use ledger_core::ingest::TransactionInput;
 use ledger_core::workbook::REQUIRED_SHEETS;
@@ -7,9 +9,11 @@ use ledgerr_mcp::{
 };
 
 fn service() -> TurboLedgerService {
-    TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n\n[accounts.WF-BH-CHK]\ninstitution=\"Wise\"\ntype=\"checking\"\ncurrency=\"USD\"\n",
-    )
+    let workbook_path = common::unique_workbook_path("phase5-cpa");
+    TurboLedgerService::from_manifest_str(&format!(
+        "{}\n[accounts.WF-BH-CHK]\ninstitution=\"Wise\"\ntype=\"checking\"\ncurrency=\"USD\"\n",
+        common::manifest_for_workbook(&workbook_path, 2023)
+    ))
     .expect("manifest")
 }
 
@@ -81,7 +85,10 @@ fn wb_01_02_03_export_cpa_workbook_honors_canonical_contract_and_materializes_co
     assert!(wb.sheet_names().iter().any(|s| s == "TX.WF-BH-CHK"));
 
     let meta = wb.worksheet_range("META.config").expect("META.config");
-    assert_eq!(cell_text(&meta, 1, 0), Some("tax-ledger.xlsx".to_string()));
+    assert_eq!(
+        cell_text(&meta, 1, 0),
+        Some(svc.workbook_path().display().to_string())
+    );
     assert_eq!(cell_text(&meta, 1, 1), Some("2023".to_string()));
 
     let registry = wb.worksheet_range("ACCT.registry").expect("ACCT.registry");

--- a/crates/ledgerr-mcp/tests/phase6_mcp_exposure_gaps.rs
+++ b/crates/ledgerr-mcp/tests/phase6_mcp_exposure_gaps.rs
@@ -1,6 +1,8 @@
 #![allow(unexpected_cfgs)]
 #![cfg(phase6_gap_tests)]
 
+mod common;
+
 /// Phase 6: MCP Exposure Gaps — Failing Test Suite
 ///
 /// These tests document capabilities that exist in the `TurboLedgerTools` service API
@@ -34,6 +36,10 @@ impl McpClient {
     fn spawn() -> Self {
         let server_bin = env!("CARGO_BIN_EXE_ledgerr-mcp-server");
         let mut child = Command::new(server_bin)
+            .env(
+                "LEDGERR_MCP_MANIFEST",
+                common::stdio_test_manifest("phase6-gaps"),
+            )
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -723,10 +729,10 @@ fn invariant_classify_ingested_confidence_is_decimal_exact() {
         ClassifyIngestedRequest, IngestPdfRequest, TurboLedgerService, TurboLedgerTools,
     };
 
-    let svc = TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n",
-    )
-    .expect("manifest");
+    let workbook_path = common::unique_workbook_path("phase6-classify-ingested");
+    let svc =
+        TurboLedgerService::from_manifest_str(&common::manifest_for_workbook(&workbook_path, 2023))
+            .expect("manifest");
 
     let dir = tempfile::tempdir().expect("tempdir");
     svc.ingest_pdf(IngestPdfRequest {
@@ -769,8 +775,7 @@ fn invariant_classify_ingested_confidence_is_decimal_exact() {
     // value — Decimal::from_f64(0.92_f64) != Decimal::from_str("0.92") because the
     // IEEE 754 representation of 0.92 is 0.91999999999999993..., exposing the violation.
     use rust_decimal::prelude::*;
-    let conf_as_decimal = Decimal::from_f64(conf)
-        .expect("confidence must be a finite number");
+    let conf_as_decimal = Decimal::from_f64(conf).expect("confidence must be a finite number");
     let expected = Decimal::from_str("0.92").expect("parse exact decimal");
     assert_eq!(
         conf_as_decimal, expected,
@@ -789,10 +794,10 @@ fn invariant_query_flags_confidence_is_decimal_exact() {
         TurboLedgerService, TurboLedgerTools,
     };
 
-    let svc = TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n",
-    )
-    .expect("manifest");
+    let workbook_path = common::unique_workbook_path("phase6-query-flags");
+    let svc =
+        TurboLedgerService::from_manifest_str(&common::manifest_for_workbook(&workbook_path, 2023))
+            .expect("manifest");
 
     let dir = tempfile::tempdir().expect("tempdir");
     svc.ingest_pdf(IngestPdfRequest {
@@ -838,8 +843,7 @@ fn invariant_query_flags_confidence_is_decimal_exact() {
     // Same reasoning as the classify_ingested invariant: Ryu Display hides f64
     // imprecision for 0.33. Use Decimal conversion to reliably detect the violation.
     use rust_decimal::prelude::*;
-    let conf_as_decimal = Decimal::from_f64(conf)
-        .expect("confidence must be a finite number");
+    let conf_as_decimal = Decimal::from_f64(conf).expect("confidence must be a finite number");
     let expected = Decimal::from_str("0.33").expect("parse exact decimal");
     assert_eq!(
         conf_as_decimal, expected,
@@ -848,3 +852,4 @@ fn invariant_query_flags_confidence_is_decimal_exact() {
          Fix: change FlagRecordResponse.confidence to rust_decimal::Decimal."
     );
 }
+mod common;

--- a/crates/ledgerr-mcp/tests/plugin_info_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/plugin_info_mcp_e2e.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 
@@ -21,6 +23,10 @@ impl McpStdioClient {
     fn spawn() -> Self {
         let server_bin = env!("CARGO_BIN_EXE_ledgerr-mcp-server");
         let mut child = Command::new(server_bin)
+            .env(
+                "LEDGERR_MCP_MANIFEST",
+                common::stdio_test_manifest("plugin-info-mcp"),
+            )
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())

--- a/crates/ledgerr-mcp/tests/reconciliation_contract.rs
+++ b/crates/ledgerr-mcp/tests/reconciliation_contract.rs
@@ -1,10 +1,11 @@
+mod common;
+
 use ledgerr_mcp::{ReconciliationStageRequest, TurboLedgerService};
 
 fn service() -> TurboLedgerService {
-    TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n",
-    )
-    .expect("manifest")
+    let workbook_path = common::unique_workbook_path("reconciliation");
+    TurboLedgerService::from_manifest_str(&common::manifest_for_workbook(&workbook_path, 2023))
+        .expect("manifest")
 }
 
 #[test]

--- a/crates/ledgerr-mcp/tests/reconciliation_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/reconciliation_mcp_e2e.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 
@@ -18,6 +20,10 @@ impl McpStdioClient {
     fn spawn() -> Self {
         let server_bin = env!("CARGO_BIN_EXE_ledgerr-mcp-server");
         let mut child = Command::new(server_bin)
+            .env(
+                "LEDGERR_MCP_MANIFEST",
+                common::stdio_test_manifest("reconciliation-mcp"),
+            )
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -108,7 +114,6 @@ fn imbalanced_request() -> Value {
         "posting_amounts": ["-100.00", "90.00"]
     })
 }
-
 
 fn parse_response_payload(response: &serde_json::Value) -> serde_json::Value {
     let text = response["content"][0]["text"].as_str().unwrap_or("null");

--- a/crates/ledgerr-mcp/tests/restart_persistence.rs
+++ b/crates/ledgerr-mcp/tests/restart_persistence.rs
@@ -1,0 +1,186 @@
+use ledger_core::ingest::TransactionInput;
+use ledgerr_mcp::{
+    ClassifyTransactionRequest, EventHistoryFilter, FlagStatusRequest, HsmResumeRequest,
+    HsmStatusRequest, HsmTransitionRequest, IngestStatementRowsRequest, QueryAuditLogRequest,
+    QueryFlagsRequest, ReplayLifecycleRequest, TurboLedgerService, TurboLedgerTools,
+};
+
+fn manifest_for(workbook_path: &std::path::Path) -> String {
+    format!(
+        "[session]\nworkbook_path=\"{}\"\nactive_year=2023\n",
+        workbook_path.display()
+    )
+}
+
+fn sample_row(source_ref: &std::path::Path) -> TransactionInput {
+    TransactionInput {
+        account_id: "WF-BH-CHK".to_string(),
+        date: "2023-01-15".to_string(),
+        amount: "-42.11".to_string(),
+        description: "Coffee Shop".to_string(),
+        source_ref: source_ref.display().to_string(),
+    }
+}
+
+#[test]
+fn restart_01_persists_ingest_review_audit_state_and_idempotency() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workbook_path = temp.path().join("tax-ledger.xlsx");
+    let journal_path = temp.path().join("ledger.beancount");
+    let source_ref = temp.path().join("source").join("ctx.rkyv");
+    std::fs::create_dir_all(source_ref.parent().expect("source parent")).expect("mkdir");
+    std::fs::write(&source_ref, b"ctx").expect("write source");
+    let manifest = manifest_for(&workbook_path);
+    let row = sample_row(&source_ref);
+
+    let tx_id = {
+        let service = TurboLedgerService::from_manifest_str(&manifest).expect("manifest");
+        let ingest = service
+            .ingest_statement_rows(IngestStatementRowsRequest {
+                journal_path: journal_path.clone(),
+                workbook_path: workbook_path.clone(),
+                rows: vec![row.clone()],
+            })
+            .expect("ingest");
+        let tx_id = ingest.tx_ids[0].clone();
+        service
+            .classify_transaction(ClassifyTransactionRequest {
+                tx_id: tx_id.clone(),
+                category: "Uncategorized".to_string(),
+                confidence: "0.40".to_string(),
+                note: Some("restart durability".to_string()),
+                actor: "agent".to_string(),
+            })
+            .expect("classify");
+        tx_id
+    };
+
+    let reloaded = TurboLedgerService::from_manifest_str(&manifest).expect("reload manifest");
+    let second_ingest = reloaded
+        .ingest_statement_rows(IngestStatementRowsRequest {
+            journal_path: journal_path.clone(),
+            workbook_path: workbook_path.clone(),
+            rows: vec![row],
+        })
+        .expect("reingest after restart");
+    assert_eq!(second_ingest.inserted_count, 0);
+
+    let flags = reloaded
+        .query_flags(QueryFlagsRequest {
+            year: 2023,
+            status: FlagStatusRequest::Open,
+        })
+        .expect("flags after restart");
+    assert_eq!(flags.flags.len(), 1);
+    assert_eq!(flags.flags[0].tx_id, tx_id);
+
+    let audit = reloaded
+        .query_audit_log(QueryAuditLogRequest)
+        .expect("audit after restart");
+    assert_eq!(audit.entries.len(), 2);
+    assert!(audit
+        .entries
+        .iter()
+        .all(|entry| entry.tx_id == tx_id && entry.actor == "agent"));
+
+    let reconciled = reloaded
+        .classify_transaction(ClassifyTransactionRequest {
+            tx_id: tx_id.clone(),
+            category: "Meals".to_string(),
+            confidence: "0.91".to_string(),
+            note: Some("post-restart edit".to_string()),
+            actor: "agent".to_string(),
+        })
+        .expect("classification after restart");
+    assert_eq!(reconciled.tx_id, tx_id);
+    assert_eq!(reconciled.category, "Meals");
+}
+
+#[test]
+fn restart_02_persists_event_history_and_replay_state() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workbook_path = temp.path().join("tax-ledger.xlsx");
+    let journal_path = temp.path().join("ledger.beancount");
+    let source_ref = temp.path().join("source").join("ctx.rkyv");
+    std::fs::create_dir_all(source_ref.parent().expect("source parent")).expect("mkdir");
+    std::fs::write(&source_ref, b"ctx").expect("write source");
+    let manifest = manifest_for(&workbook_path);
+    let row = sample_row(&source_ref);
+
+    let tx_id = {
+        let service = TurboLedgerService::from_manifest_str(&manifest).expect("manifest");
+        let ingest = service
+            .ingest_statement_rows(IngestStatementRowsRequest {
+                journal_path: journal_path.clone(),
+                workbook_path: workbook_path.clone(),
+                rows: vec![row.clone()],
+            })
+            .expect("ingest");
+        let tx_id = ingest.tx_ids[0].clone();
+        service
+            .classify_transaction(ClassifyTransactionRequest {
+                tx_id: tx_id.clone(),
+                category: "Meals".to_string(),
+                confidence: "0.91".to_string(),
+                note: Some("classify".to_string()),
+                actor: "agent".to_string(),
+            })
+            .expect("classify");
+        tx_id
+    };
+
+    let reloaded = TurboLedgerService::from_manifest_str(&manifest).expect("reload manifest");
+    let history = reloaded
+        .event_history(EventHistoryFilter {
+            tx_id: Some(tx_id.clone()),
+            document_ref: Some(source_ref.display().to_string()),
+            time_start: None,
+            time_end: None,
+        })
+        .expect("history after restart");
+    assert_eq!(history.events.len(), 2);
+    assert_eq!(history.events[0].event_type, "ingest");
+    assert_eq!(history.events[1].event_type, "classification");
+
+    let replay = reloaded
+        .replay_lifecycle(ReplayLifecycleRequest {
+            tx_id: Some(tx_id),
+            document_ref: Some(source_ref.display().to_string()),
+        })
+        .expect("replay after restart");
+    assert!(replay.reconstructed_state.contains("stage=classification"));
+    assert!(replay.reconstructed_state.contains("category=Meals"));
+    assert_eq!(replay.event_count, 2);
+    assert!(replay.diagnostics.is_empty());
+}
+
+#[test]
+fn restart_03_persists_hsm_checkpoint_across_reload() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workbook_path = temp.path().join("tax-ledger.xlsx");
+    let manifest = manifest_for(&workbook_path);
+
+    {
+        let service = TurboLedgerService::from_manifest_str(&manifest).expect("manifest");
+        let response = service
+            .hsm_transition_tool(HsmTransitionRequest {
+                target_state: "normalize".to_string(),
+                target_substate: "ready".to_string(),
+            })
+            .expect("transition");
+        assert_eq!(response.state_marker, "normalize:ready:advanced");
+    }
+
+    let reloaded = TurboLedgerService::from_manifest_str(&manifest).expect("reload manifest");
+    let status = reloaded.hsm_status_tool(HsmStatusRequest).expect("status");
+    assert_eq!(status.display_state, "normalize.ready");
+    assert_eq!(status.next_hint, "advance_to_validate");
+
+    let resumed = reloaded
+        .hsm_resume_tool(HsmResumeRequest {
+            state_marker: "normalize:ready:advanced".to_string(),
+        })
+        .expect("resume");
+    assert!(resumed.resumed);
+    assert_eq!(resumed.resume_from, "normalize:ready:advanced");
+}

--- a/crates/ledgerr-mcp/tests/tax_assist_contract.rs
+++ b/crates/ledgerr-mcp/tests/tax_assist_contract.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::collections::BTreeMap;
 
 use ledgerr_mcp::{
@@ -7,10 +9,9 @@ use ledgerr_mcp::{
 };
 
 fn service() -> TurboLedgerService {
-    TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n",
-    )
-    .expect("manifest")
+    let workbook_path = common::unique_workbook_path("tax-assist");
+    TurboLedgerService::from_manifest_str(&common::manifest_for_workbook(&workbook_path, 2023))
+        .expect("manifest")
 }
 
 fn seed_tax_ontology(

--- a/crates/ledgerr-mcp/tests/tax_assist_mcp_e2e.rs
+++ b/crates/ledgerr-mcp/tests/tax_assist_mcp_e2e.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
@@ -21,6 +23,10 @@ impl McpStdioClient {
     fn spawn() -> Self {
         let server_bin = env!("CARGO_BIN_EXE_ledgerr-mcp-server");
         let mut child = Command::new(server_bin)
+            .env(
+                "LEDGERR_MCP_MANIFEST",
+                common::stdio_test_manifest("tax-assist-mcp"),
+            )
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -192,7 +198,6 @@ fn ingest_one_row(client: &mut McpStdioClient) {
     );
     assert_eq!(ingest["result"]["isError"], Value::Bool(false));
 }
-
 
 fn parse_response_payload(response: &serde_json::Value) -> serde_json::Value {
     let text = response["content"][0]["text"].as_str().unwrap_or("null");

--- a/crates/ledgerr-mcp/tests/tax_evidence_chain_contract.rs
+++ b/crates/ledgerr-mcp/tests/tax_evidence_chain_contract.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::collections::BTreeMap;
 
 use ledger_core::ingest::TransactionInput;
@@ -9,10 +11,9 @@ use ledgerr_mcp::{
 };
 
 fn service() -> TurboLedgerService {
-    TurboLedgerService::from_manifest_str(
-        "[session]\nworkbook_path=\"tax-ledger.xlsx\"\nactive_year=2023\n",
-    )
-    .expect("manifest")
+    let workbook_path = common::unique_workbook_path("tax-evidence");
+    TurboLedgerService::from_manifest_str(&common::manifest_for_workbook(&workbook_path, 2023))
+        .expect("manifest")
 }
 
 fn seed_chain_fixture(

--- a/docs/claude-cowork-plugin-marketplace.md
+++ b/docs/claude-cowork-plugin-marketplace.md
@@ -9,14 +9,14 @@ This repo now includes a Claude plugin marketplace and a plugin entry intended f
 
 ## Key files
 
-- Marketplace catalog: [marketplace.json](/home/brianh/promptexecution/mbse/l3dg3rr/.claude-plugin/marketplace.json)
-- Plugin manifest: [plugin.json](/home/brianh/promptexecution/mbse/l3dg3rr/plugins/l3dg3rr-plugin-create/.claude-plugin/plugin.json)
-- Plugin skill: [SKILL.md](/home/brianh/promptexecution/mbse/l3dg3rr/plugins/l3dg3rr-plugin-create/skills/plugin-create-for-l3dg3rr/SKILL.md)
-- MCP server entrypoint: [ledgerr-mcp-server.rs](/mnt/c/users/wendy/l3dg3rr/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs)
-- Runtime helper commands: [Justfile](/home/brianh/promptexecution/mbse/l3dg3rr/Justfile)
-- MCP regression script: [mcp_e2e.sh](/home/brianh/promptexecution/mbse/l3dg3rr/scripts/mcp_e2e.sh)
-- Container build: [Dockerfile](/home/brianh/promptexecution/mbse/l3dg3rr/Dockerfile)
-- Python launcher package: [pyproject.toml](/home/brianh/promptexecution/mbse/l3dg3rr/plugins/l3dg3rr-plugin-create/python/pyproject.toml)
+- Marketplace catalog: [marketplace.json](.claude-plugin/marketplace.json)
+- Plugin manifest: [plugin.json](plugins/l3dg3rr-plugin-create/.claude-plugin/plugin.json)
+- Plugin skill: [SKILL.md](plugins/l3dg3rr-plugin-create/skills/plugin-create-for-l3dg3rr/SKILL.md)
+- MCP server entrypoint: [ledgerr-mcp-server.rs](crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs)
+- Runtime helper commands: [Justfile](Justfile)
+- MCP regression script: [mcp_e2e.sh](scripts/mcp_e2e.sh)
+- Container build: [Dockerfile](Dockerfile)
+- Python launcher package: [pyproject.toml](plugins/l3dg3rr-plugin-create/python/pyproject.toml)
 
 ## Install in Cowork
 

--- a/scripts/mcp_cli_demo.sh
+++ b/scripts/mcp_cli_demo.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-JOURNAL_PATH="${{JOURNAL_PATH:-/tmp/demo.beancount}}"
-WORKBOOK_PATH="${{WORKBOOK_PATH:-/tmp/demo.xlsx}}"
-SOURCE_REF="${{SOURCE_REF:-wf-2023-01.rkyv}}"
+JOURNAL_PATH="${JOURNAL_PATH:-/tmp/demo.beancount}"
+WORKBOOK_PATH="${WORKBOOK_PATH:-/tmp/demo.xlsx}"
+SOURCE_REF="${SOURCE_REF:-wf-2023-01.rkyv}"
 
 cargo run -q -p ledgerr-mcp --bin ledgerr-mcp-server <<EOF
-{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"clientInfo":{{"name":"demo","version":"0.1.0"}}}}}}
-{{"jsonrpc":"2.0","method":"notifications/initialized","params":{{}}}}
-{{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{{}}}}
-{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"ledgerr_documents","arguments":{{"action":"pipeline_status"}}}}}}
-{{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{{"name":"ledgerr_documents","arguments":{{"action":"list_accounts"}}}}}}
-{{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{{"name":"ledgerr_documents","arguments":{{"action":"ingest_pdf","pdf_path":"WF--BH-CHK--2023-01--statement.pdf","journal_path":"$JOURNAL_PATH","workbook_path":"$WORKBOOK_PATH","raw_context_bytes":[99,116,120],"extracted_rows":[{{"account_id":"WF-BH-CHK","date":"2023-01-15","amount":"-42.11","description":"Coffee Shop","source_ref":"$SOURCE_REF"}}]}}}}}}
-{{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{{"name":"ledgerr_documents","arguments":{{"action":"get_raw_context","rkyv_ref":"$SOURCE_REF"}}}}}}
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"demo","version":"0.1.0"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"pipeline_status"}}}
+{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"list_accounts"}}}
+{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"ingest_pdf","pdf_path":"WF--BH-CHK--2023-01--statement.pdf","journal_path":"$JOURNAL_PATH","workbook_path":"$WORKBOOK_PATH","raw_context_bytes":[99,116,120],"extracted_rows":[{"account_id":"WF-BH-CHK","date":"2023-01-15","amount":"-42.11","description":"Coffee Shop","source_ref":"$SOURCE_REF"}]}}}
+{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"get_raw_context","rkyv_ref":"$SOURCE_REF"}}}
 EOF
 
 # Troubleshooting path
 cat <<'EOF'
-{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"ledgerr_workflow","arguments":{{"action":"resume","state_marker":"invalid-checkpoint"}}}}}}
-{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"ledgerr_reconciliation","arguments":{{"action":"commit","source_total":"100.00","extracted_total":"95.00","posting_amounts":["-95.00","95.00"]}}}}}}
-{{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{{"name":"ledgerr_audit","arguments":{{"action":"event_history","time_start":"2026-12-31","time_end":"2026-01-01"}}}}}}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"ledgerr_workflow","arguments":{"action":"resume","state_marker":"invalid-checkpoint"}}}
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"ledgerr_reconciliation","arguments":{"action":"commit","source_total":"100.00","extracted_total":"95.00","posting_amounts":["-95.00","95.00"]}}}
+{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"ledgerr_audit","arguments":{"action":"event_history","time_start":"2026-12-31","time_end":"2026-01-01"}}}
 EOF


### PR DESCRIPTION
Closes #20

## Summary
- persist restart-visible MCP service state in a deterministic sidecar adjacent to the manifest workbook path
- reload ingest, classification/audit, lifecycle event, and HSM checkpoint state in `TurboLedgerService::from_manifest_str`
- add restart persistence coverage and isolate stateful tests/stdio server processes with unique manifest workbook paths

## Validation
- `cargo test -p ledgerr-mcp`
- `just test`