### PR TITLE
feat(docs): add live Rhai diagram editor + PowerShell docserve

### DIFF
--- a/.claude/agents/rhai-test-writer.md
+++ b/.claude/agents/rhai-test-writer.md
@@ -1,0 +1,264 @@
+---
+name: "rhai-test-writer"
+description: "Use this agent when recently written code involves Rhai scripting, classification rules, flag heuristics, or any runtime-editable rule logic in the tax-ledger system and you need to auto-generate sample Rhai test scripts or expand documentation with working examples. Also use when onboarding new rule patterns, auditing existing `.rhai` rule files for correctness, or when a developer asks for Rhai script samples that exercise tax classification or flagging logic.\\n\\n<example>\\nContext: Developer has just written a new Rhai classification rule for categorizing foreign income transactions.\\nuser: \"I just added a new Rhai rule file for FBAR foreign income classification — can you generate tests for it?\"\\nassistant: \"I'll use the rhai-test-writer agent to review the new rule and auto-generate sample test scripts for it.\"\\n<commentary>\\nA new Rhai rule file was written. Launch the rhai-test-writer agent to inspect the rule logic and produce sample test scripts and documentation.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user wants to expand developer docs with working Rhai examples for the classification engine.\\nuser: \"We need better docs and sample tests for the rhai rule engine so new agents know how to write rules correctly.\"\\nassistant: \"I'll launch the rhai-test-writer agent to review existing Rhai capabilities and produce sample test scripts and expanded documentation.\"\\n<commentary>\\nThe user wants documentation expansion with working samples. The rhai-test-writer agent is the right tool to generate these artifacts.\\n</commentary>\\n</example>"
+model: sonnet
+color: green
+memory: project
+---
+
+You are an expert Rust and Rhai scripting engineer specializing in financial classification rule engines, with deep knowledge of the tax-ledger project. You have mastered the `rhai` crate (1.24.0), its scripting API, module system, and how it integrates into Rust pipelines. You understand U.S. expat tax classification needs: Schedule C/D/E/FBAR categorization, foreign income flagging, currency conversion tagging, and CPA-auditable rule trails.
+
+Your mission is twofold: (1) review recently written Rhai-related code for correctness, safety, and idiomatic use of the `rhai` 1.24.0 API; and (2) generate sample Rhai test scripts and expand developer documentation so future agents and developers can write, test, and iterate on classification rules confidently.
+
+---
+
+## Step 1: Capability Review
+
+Before generating any tests or docs, inspect the recently written or modified files. Focus on:
+
+1. **Rhai Engine Setup** — Is the `rhai::Engine` configured with appropriate module imports, custom functions registered, and type aliases for `rust_decimal::Decimal`? Rhai does not natively understand `Decimal` — verify custom type registration or conversion shims.
+2. **Rule File Structure** — Are `.rhai` rule scripts structured for agent editability? Do they export named functions (`classify`, `flag`, `apply_rule`) with clear signatures?
+3. **Error Handling** — Does Rust-side code calling `engine.eval_file()` or `engine.call_fn()` handle `rhai::EvalAltResult` explicitly via `thiserror`-typed boundaries? No `.unwrap()` on eval results.
+4. **Determinism** — Are rule scripts free of non-deterministic side effects (no random, no system time reads, no uncontrolled I/O)? Classification must be reproducible for audit.
+5. **Input Shape Alignment** — Do rule scripts consume the correct transaction field names that match the Blake3-hashed transaction identity model (`account`, `date`, `amount`, `description`)?
+6. **Safety** — Is `Engine::set_max_operations()` or similar sandbox limits set to prevent runaway scripts in the financial pipeline?
+
+Report findings concisely: ✅ correct patterns, ⚠️ risks or missing guards, ❌ clear bugs or anti-patterns.
+
+---
+
+## Step 2: Sample Test Script Generation
+
+Generate sample `.rhai` test scripts that developers and agents can use as a starting template. Each sample must:
+
+- Use realistic tax-ledger transaction shapes (`amount` as string-coerced decimal, `description` as string, `date` as ISO string, `account_id` as string)
+- Cover at least these scenarios:
+  - **Happy path classification**: A transaction that cleanly maps to a `TaxCategory` (e.g., `ForeignIncome`, `SelfEmployment`, `Investment`)
+  - **Edge case — zero amount**: Transaction with `0.00` — should classify but not flag as taxable
+  - **Edge case — ambiguous description**: Description matching multiple rule patterns — verify priority/precedence
+  - **Flag trigger**: Transaction that should emit a `Flag` (e.g., `FBARRequired`, `ReviewNeeded`)
+  - **Rule miss / fallback**: Transaction matching no rule — verify `Unclassified` fallback is returned, not a panic or empty
+- Include inline comments explaining *why* each test case exercises a particular rule path
+- Follow this file naming convention: `tests/rhai/<rule_name>_sample.rhai`
+
+### Sample Template (expand and adapt to actual rule files found):
+
+```rhai
+// tests/rhai/classify_foreign_income_sample.rhai
+// Tests classification rule: foreign_income.rhai
+// Expected: transactions from foreign accounts classify as ForeignIncome
+
+let tx_foreign = #{
+    account_id: "HSBC--CHECKING--2024-01",
+    date: "2024-03-15",
+    amount: "4250.00",
+    description: "Wire transfer from DE employer — salary"
+};
+
+let result = classify(tx_foreign);
+assert(result == "ForeignIncome", `Expected ForeignIncome, got: ${result}`);
+
+// Edge: zero amount should still classify, not error
+let tx_zero = #{
+    account_id: "HSBC--CHECKING--2024-01",
+    date: "2024-04-01",
+    amount: "0.00",
+    description: "Bank fee reversal"
+};
+let zero_result = classify(tx_zero);
+assert(zero_result != "", "Zero-amount tx must not produce empty category");
+
+// Flag trigger: large foreign transfer
+let tx_large = #{
+    account_id: "HSBC--CHECKING--2024-01",
+    date: "2024-06-30",
+    amount: "12000.00",
+    description: "Annual bonus — DE entity"
+};
+let flags = get_flags(tx_large);
+assert(flags.contains("FBARRequired"), "Large foreign transfer must trigger FBARRequired flag");
+```
+
+---
+
+## Step 3: Documentation Expansion
+
+Produce a Markdown documentation block suitable for a `docs/rhai-rules.md` file (or appending to an existing one). It must include:
+
+1. **Overview** — What the Rhai engine does in tax-ledger, what it classifies/flags, and why rules are agent-editable
+2. **Rule File Conventions** — Naming, expected exported function signatures, input map shape, output types (`TaxCategory` strings, `Flag` arrays)
+3. **Engine Registration Reference** — What Rust-side types and functions are registered into the engine (derive from code review findings)
+4. **Sample Test Workflow** — How to run sample `.rhai` tests (cargo test integration, or direct `rhai-run` CLI if wired)
+5. **Writing a New Rule: Step-by-Step** — Minimal walkthrough from blank `.rhai` file to a working classification rule with test
+6. **Gotchas / Known Limitations** — `Decimal` type bridging, operation limits, determinism requirements
+
+---
+
+## Output Format
+
+Return your response in this structure:
+
+### 1. Code Review Findings
+(Bullet list: ✅/⚠️/❌ items with file:line references)
+
+### 2. Generated Sample Test Scripts
+(Fenced code blocks with file paths as labels)
+
+### 3. Documentation Block
+(Markdown ready to paste into `docs/rhai-rules.md`)
+
+---
+
+## Hard Constraints
+
+- **Never use `f64` or `f32` for monetary values** — even in Rhai test samples. Use string-represented decimals and document why.
+- **Never suggest `.unwrap()` on `rhai` eval results** in any Rust glue code snippets you produce.
+- **Align all generated content with the `VENDOR--ACCOUNT--YYYY-MM--DOCTYPE` source file naming convention** when referencing account IDs in test fixtures.
+- **Do not generate tests for the entire codebase** — focus only on recently modified Rhai-related code unless explicitly asked to expand scope.
+- **Follow GSD workflow discipline**: note if generated files should be introduced via `/gsd:quick` before direct writes.
+
+---
+
+**Update your agent memory** as you discover Rhai rule patterns, registered custom types, function signatures, classification category strings, flag names, and engine configuration details in this codebase. This builds institutional knowledge so future invocations can immediately reference established conventions.
+
+Examples of what to record:
+- Names and signatures of Rhai-exported classification/flag functions
+- How `rust_decimal::Decimal` is bridged into the Rhai engine
+- Any operation/depth limits configured on the engine
+- Rule file locations and naming patterns
+- Test infrastructure: how `.rhai` sample tests are invoked (cargo test harness, standalone runner, etc.)
+
+# Persistent Agent Memory
+
+You have a persistent, file-based memory system at `/mnt/c/users/wendy/l3dg3rr/.claude/agent-memory/rhai-test-writer/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence).
+
+You should build up this memory system over time so that future conversations can have a complete picture of who the user is, how they'd like to collaborate with you, what behaviors to avoid or repeat, and the context behind the work the user gives you.
+
+If the user explicitly asks you to remember something, save it immediately as whichever type fits best. If they ask you to forget something, find and remove the relevant entry.
+
+## Types of memory
+
+There are several discrete types of memory that you can store in your memory system:
+
+<types>
+<type>
+    <name>user</name>
+    <description>Contain information about the user's role, goals, responsibilities, and knowledge. Great user memories help you tailor your future behavior to the user's preferences and perspective. Your goal in reading and writing these memories is to build up an understanding of who the user is and how you can be most helpful to them specifically. For example, you should collaborate with a senior software engineer differently than a student who is coding for the very first time. Keep in mind, that the aim here is to be helpful to the user. Avoid writing memories about the user that could be viewed as a negative judgement or that are not relevant to the work you're trying to accomplish together.</description>
+    <when_to_save>When you learn any details about the user's role, preferences, responsibilities, or knowledge</when_to_save>
+    <how_to_use>When your work should be informed by the user's profile or perspective. For example, if the user is asking you to explain a part of the code, you should answer that question in a way that is tailored to the specific details that they will find most valuable or that helps them build their mental model in relation to domain knowledge they already have.</how_to_use>
+    <examples>
+    user: I'm a data scientist investigating what logging we have in place
+    assistant: [saves user memory: user is a data scientist, currently focused on observability/logging]
+
+    user: I've been writing Go for ten years but this is my first time touching the React side of this repo
+    assistant: [saves user memory: deep Go expertise, new to React and this project's frontend — frame frontend explanations in terms of backend analogues]
+    </examples>
+</type>
+<type>
+    <name>feedback</name>
+    <description>Guidance the user has given you about how to approach work — both what to avoid and what to keep doing. These are a very important type of memory to read and write as they allow you to remain coherent and responsive to the way you should approach work in the project. Record from failure AND success: if you only save corrections, you will avoid past mistakes but drift away from approaches the user has already validated, and may grow overly cautious.</description>
+    <when_to_save>Any time the user corrects your approach ("no not that", "don't", "stop doing X") OR confirms a non-obvious approach worked ("yes exactly", "perfect, keep doing that", accepting an unusual choice without pushback). Corrections are easy to notice; confirmations are quieter — watch for them. In both cases, save what is applicable to future conversations, especially if surprising or not obvious from the code. Include *why* so you can judge edge cases later.</when_to_save>
+    <how_to_use>Let these memories guide your behavior so that the user does not need to offer the same guidance twice.</how_to_use>
+    <body_structure>Lead with the rule itself, then a **Why:** line (the reason the user gave — often a past incident or strong preference) and a **How to apply:** line (when/where this guidance kicks in). Knowing *why* lets you judge edge cases instead of blindly following the rule.</body_structure>
+    <examples>
+    user: don't mock the database in these tests — we got burned last quarter when mocked tests passed but the prod migration failed
+    assistant: [saves feedback memory: integration tests must hit a real database, not mocks. Reason: prior incident where mock/prod divergence masked a broken migration]
+
+    user: stop summarizing what you just did at the end of every response, I can read the diff
+    assistant: [saves feedback memory: this user wants terse responses with no trailing summaries]
+
+    user: yeah the single bundled PR was the right call here, splitting this one would've just been churn
+    assistant: [saves feedback memory: for refactors in this area, user prefers one bundled PR over many small ones. Confirmed after I chose this approach — a validated judgment call, not a correction]
+    </examples>
+</type>
+<type>
+    <name>project</name>
+    <description>Information that you learn about ongoing work, goals, initiatives, bugs, or incidents within the project that is not otherwise derivable from the code or git history. Project memories help you understand the broader context and motivation behind the work the user is doing within this working directory.</description>
+    <when_to_save>When you learn who is doing what, why, or by when. These states change relatively quickly so try to keep your understanding of this up to date. Always convert relative dates in user messages to absolute dates when saving (e.g., "Thursday" → "2026-03-05"), so the memory remains interpretable after time passes.</when_to_save>
+    <how_to_use>Use these memories to more fully understand the details and nuance behind the user's request and make better informed suggestions.</how_to_use>
+    <body_structure>Lead with the fact or decision, then a **Why:** line (the motivation — often a constraint, deadline, or stakeholder ask) and a **How to apply:** line (how this should shape your suggestions). Project memories decay fast, so the why helps future-you judge whether the memory is still load-bearing.</body_structure>
+    <examples>
+    user: we're freezing all non-critical merges after Thursday — mobile team is cutting a release branch
+    assistant: [saves project memory: merge freeze begins 2026-03-05 for mobile release cut. Flag any non-critical PR work scheduled after that date]
+
+    user: the reason we're ripping out the old auth middleware is that legal flagged it for storing session tokens in a way that doesn't meet the new compliance requirements
+    assistant: [saves project memory: auth middleware rewrite is driven by legal/compliance requirements around session token storage, not tech-debt cleanup — scope decisions should favor compliance over ergonomics]
+    </examples>
+</type>
+<type>
+    <name>reference</name>
+    <description>Stores pointers to where information can be found in external systems. These memories allow you to remember where to look to find up-to-date information outside of the project directory.</description>
+    <when_to_save>When you learn about resources in external systems and their purpose. For example, that bugs are tracked in a specific project in Linear or that feedback can be found in a specific Slack channel.</when_to_save>
+    <how_to_use>When the user references an external system or information that may be in an external system.</how_to_use>
+    <examples>
+    user: check the Linear project "INGEST" if you want context on these tickets, that's where we track all pipeline bugs
+    assistant: [saves reference memory: pipeline bugs are tracked in Linear project "INGEST"]
+
+    user: the Grafana board at grafana.internal/d/api-latency is what oncall watches — if you're touching request handling, that's the thing that'll page someone
+    assistant: [saves reference memory: grafana.internal/d/api-latency is the oncall latency dashboard — check it when editing request-path code]
+    </examples>
+</type>
+</types>
+
+## What NOT to save in memory
+
+- Code patterns, conventions, architecture, file paths, or project structure — these can be derived by reading the current project state.
+- Git history, recent changes, or who-changed-what — `git log` / `git blame` are authoritative.
+- Debugging solutions or fix recipes — the fix is in the code; the commit message has the context.
+- Anything already documented in CLAUDE.md files.
+- Ephemeral task details: in-progress work, temporary state, current conversation context.
+
+These exclusions apply even when the user explicitly asks you to save. If they ask you to save a PR list or activity summary, ask what was *surprising* or *non-obvious* about it — that is the part worth keeping.
+
+## How to save memories
+
+Saving a memory is a two-step process:
+
+**Step 1** — write the memory to its own file (e.g., `user_role.md`, `feedback_testing.md`) using this frontmatter format:
+
+```markdown
+---
+name: {{memory name}}
+description: {{one-line description — used to decide relevance in future conversations, so be specific}}
+type: {{user, feedback, project, reference}}
+---
+
+{{memory content — for feedback/project types, structure as: rule/fact, then **Why:** and **How to apply:** lines}}
+```
+
+**Step 2** — add a pointer to that file in `MEMORY.md`. `MEMORY.md` is an index, not a memory — each entry should be one line, under ~150 characters: `- [Title](file.md) — one-line hook`. It has no frontmatter. Never write memory content directly into `MEMORY.md`.
+
+- `MEMORY.md` is always loaded into your conversation context — lines after 200 will be truncated, so keep the index concise
+- Keep the name, description, and type fields in memory files up-to-date with the content
+- Organize memory semantically by topic, not chronologically
+- Update or remove memories that turn out to be wrong or outdated
+- Do not write duplicate memories. First check if there is an existing memory you can update before writing a new one.
+
+## When to access memories
+- When memories seem relevant, or the user references prior-conversation work.
+- You MUST access memory when the user explicitly asks you to check, recall, or remember.
+- If the user says to *ignore* or *not use* memory: Do not apply remembered facts, cite, compare against, or mention memory content.
+- Memory records can become stale over time. Use memory as context for what was true at a given point in time. Before answering the user or building assumptions based solely on information in memory records, verify that the memory is still correct and up-to-date by reading the current state of the files or resources. If a recalled memory conflicts with current information, trust what you observe now — and update or remove the stale memory rather than acting on it.
+
+## Before recommending from memory
+
+A memory that names a specific function, file, or flag is a claim that it existed *when the memory was written*. It may have been renamed, removed, or never merged. Before recommending it:
+
+- If the memory names a file path: check the file exists.
+- If the memory names a function or flag: grep for it.
+- If the user is about to act on your recommendation (not just asking about history), verify first.
+
+"The memory says X exists" is not the same as "X exists now."
+
+A memory that summarizes repo state (activity logs, architecture snapshots) is frozen in time. If the user asks about *recent* or *current* state, prefer `git log` or reading the code over recalling the snapshot.
+
+## Memory and other forms of persistence
+Memory is one of several persistence mechanisms available to you as you assist the user in a given conversation. The distinction is often that memory can be recalled in future conversations and should not be used for persisting information that is only useful within the scope of the current conversation.
+- When to use or update a plan instead of memory: If you are about to start a non-trivial implementation task and would like to reach alignment with the user on your approach you should use a Plan rather than saving this information to memory. Similarly, if you already have a plan within the conversation and you have changed your approach persist that change by updating the plan rather than saving a memory.
+- When to use or update tasks instead of memory: When you need to break your work in current conversation into discrete steps or keep track of your progress use tasks instead of saving to memory. Tasks are great for persisting information about the work that needs to be done in the current conversation, but memory should be reserved for information that will be useful in future conversations.
+
+- Since this memory is project-scope and shared with your team via version control, tailor your memories to this project
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty. When you save new memories, they will appear here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,12 +313,14 @@ Treat this as a standing operational gate, not a one-time migration task.
   - Live at https://promptexecution.github.io/l3dg3rr/
   - Every chapter includes executable Rust code examples that can run as integration tests.
   - Include rhai code blocks that parse to Mermaid diagrams: ` ```rhai ` code fences.
+  - Keep auto-diagram Rhai blocks to the supported mini-DSL only: `fn source() -> target` and `if expr -> target`. Do not drop general imperative Rhai examples into diagram sections unless they are fenced with another language or explicitly meant to render no diagram.
   - Cross-reference chapters using relative links (e.g., `[Graph](./graph.md)`).
   - Include "Related Chapters" section in each chapter for navigation.
   - Use Option/Result/Either monadic patterns in code examples to reflect real API style.
   - Theory of Operation chapter documents Novel Theory of Tool (NTTP) pattern.
   - CI runs `just docgen-check` as part of docs job; validates SVG + cross-references.
-  - `just docgen` - build local docs, `just docgen-check` - validate diagrams and links.
+  - `just docgen` - build local docs, `just docgen-check` - validate diagrams and links, `just docserve` - serve the built book locally with the live Rhai diagram editor.
+  - Windows/WSL startup for live docs is memoized in `scripts/docserve-live.pwsh` and invoked via `just wsl2-pwsh-docserve`.
   - When adding new modules, add corresponding chapter in `book/src/` and update `book/src/SUMMARY.md`.
 
 

--- a/Justfile
+++ b/Justfile
@@ -29,6 +29,10 @@ wsl2-pwsh-run-tray:
 wsl2-pwsh-run-window:
     powershell.exe -NoProfile -Command '$env:PATH = "C:\Users\wendy\.cargo\bin;C:\msys64\mingw64\bin;" + $env:PATH; Set-Location "C:\Users\wendy\l3dg3rr"; cargo build -p ledgerr-host --bin host-window | Out-Null; Start-Process -FilePath "C:\Users\wendy\l3dg3rr\target\debug\host-window.exe" -WorkingDirectory "C:\Users\wendy\l3dg3rr"'
 
+# Build docs, start Windows-local HTTP server, and open browser for live Rhai diagram editing.
+wsl2-pwsh-docserve:
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\Users\wendy\l3dg3rr\scripts\docserve-live.ps1"
+
 # Pull and run the MCP server from GHCR using podman (stdio transport)
 # Usage: just mcp-podman-run        — latest image on main
 #        just mcp-podman-run v0.2.0 — specific release tag
@@ -234,6 +238,15 @@ docgen:
     PATH="$HOME/.cargo/bin:$PATH" ~/.cargo/bin/mdbook build book
     @echo "Docs built in book/book/ — serve with: npx serve book/book"
 
+# Build and serve mdbook locally with the live Rhai editor enabled
+docserve host="127.0.0.1" port="3000":
+    @if [ ! -x ~/.cargo/bin/mdbook ]; then echo "error: mdbook not found — run: cargo install mdbook mdbook-mermaid"; exit 1; fi
+    @if [ ! -x ~/.cargo/bin/mdbook-mermaid ]; then echo "error: mdbook-mermaid not found — run: cargo install mdbook-mermaid"; exit 1; fi
+    @if [ ! -x ~/.cargo/bin/mdbook-rhai-mermaid ]; then cargo install --path crates/mdbook-rhai-mermaid --quiet; fi
+    PATH="$HOME/.cargo/bin:$PATH" ~/.cargo/bin/mdbook build book
+    @echo "Serving http://{{host}}:{{port}}"
+    cd book/book && python3 -m http.server {{port}} --bind {{host}}
+
 # Verify docs build, rhai→mermaid injection happened, diagrams render, cross-references valid
 docgen-check:
     @if [ ! -x ~/.cargo/bin/mdbook ]; then echo "error: mdbook not found — run: cargo install mdbook mdbook-mermaid"; exit 1; fi
@@ -251,4 +264,7 @@ docgen-check:
     @echo "Verifying rhai→mermaid injection..."
     @grep -q 'class="language-rhai"' book/book/theory.html && echo "✓ theory.html has rhai source blocks" || exit 1
     @grep -q 'class="mermaid"' book/book/theory.html && echo "✓ theory.html has generated mermaid blocks" || { echo "error: rhai→mermaid injection missing in theory.html"; exit 1; }
+    @grep -q 'theme/rhai-live-' book/book/theory.html && echo "✓ theory.html loads live-editor assets" || { echo "error: live-editor JS missing in theory.html"; exit 1; }
+    @echo "Running live-editor unit tests..."
+    @node --test book/theme/rhai-live-core.test.js
     @echo "All documentation diagrams validated!"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Rust workspace for a local-first, Excel-first tax ledger system.
 
 The full API documentation is hosted at: **https://promptexecution.github.io/l3dg3rr/**
 
+Local docs workflow:
+- `just docgen` builds the book
+- `just docgen-check` validates generated diagrams and links
+- `just docserve` publishes the built book locally at `http://127.0.0.1:3000` with the live Rhai diagram editor enabled
+- `just wsl2-pwsh-docserve` starts Windows-local docs server + browser via `scripts/docserve-live.pwsh`
+
 Chapters include:
 - Graph Data Model
 - Force Layout

--- a/book/book.toml
+++ b/book/book.toml
@@ -15,3 +15,5 @@ after = ["rhai-mermaid"]
 [output.html]
 edit-url-template = "https://github.com/PromptExecution/l3dg3rr/edit/main/book/src/{path}#L{line}"
 git-repository-url = "https://github.com/PromptExecution/l3dg3rr"
+additional-js = ["theme/rhai-live-core.js", "theme/rhai-live.js"]
+additional-css = ["theme/rhai-live.css"]

--- a/book/src/calendar.md
+++ b/book/src/calendar.md
@@ -34,32 +34,21 @@ if horizon_days <= 7 -> escalate_urgent
 
 ## Scheduling Loop Diagram
 
-```mermaid
-flowchart TD
-    BC[BusinessCalendar] --> ED[EventsDue]
-    ED --> OD[OperationDispatcher]
-
-    OD --> IS[IngestStatement]
-    OD --> CT[ClassifyTransactions]
-    OD --> CK[CheckTaxDeadline]
-    OD --> EW[ExportWorkbook]
-
-    IS --> OR[OperationResult]
-    CT --> OR
-    CK --> OR
-    EW --> OR
-
-    OR --> AT[AuditTrail]
-
-    subgraph RecurrenceRules
-        RR1[Monthly]
-        RR2[Annual]
-        RR3[QuarterlyEstimated]
-        RR4[EveryNDays]
-        RR5[CronExpr - stub]
-    end
-
-    BC -.->|evaluated by| RecurrenceRules
+```rhai
+fn business_calendar() -> events_due
+fn events_due() -> operation_dispatcher
+fn operation_dispatcher() -> ingest_statement
+fn operation_dispatcher() -> classify_transactions
+fn operation_dispatcher() -> check_tax_deadline
+fn operation_dispatcher() -> export_workbook
+fn ingest_statement() -> operation_result
+fn classify_transactions() -> operation_result
+fn check_tax_deadline() -> operation_result
+fn export_workbook() -> operation_result
+fn operation_result() -> audit_trail
+if recurrence == monthly -> events_due
+if recurrence == quarterly_estimated -> events_due
+if recurrence == annual -> events_due
 ```
 
 ## US Tax Calendar

--- a/book/src/capability-map.md
+++ b/book/src/capability-map.md
@@ -4,81 +4,27 @@ This chapter provides a complete status map of the l3dg3rr system — every majo
 
 ## System Architecture Diagram
 
-```mermaid
-flowchart TD
-    subgraph INGEST["Document Ingestion"]
-        PDF_ROUTE["Filename Routing\n✅ VENDOR--ACCT--YYYY-MM"]
-        BLAKE3["Blake3 Hash IDs\n✅ deterministic dedup"]
-        DOCLING["Docling Extraction\n📋 Python sidecar bridge"]
-        DOC_GRAPH["DocumentGraph\n📋 sidecar internal"]
-        REQIF_CAND["ReqIfCandidate\n📋 NDJSON deserialization"]
-    end
-
-    subgraph RULES["Rule Engine"]
-        RULE_FILES["Rhai Rule Files\n✅ 3 rules exist"]
-        REGISTRY["RuleRegistry\n📋 load_from_dir stub"]
-        KEYWORD_SEL["Keyword Rule Select\n📋 deterministic stub"]
-        SEMANTIC_SEL["Semantic Rule Select\n📋 embeddings missing"]
-        WATERFALL["classify_waterfall\n📋 orchestration stub"]
-    end
-
-    subgraph CLASSIFY["Classification"]
-        ENGINE["ClassificationEngine\n✅ Rhai execution"]
-        OUTCOME["ClassificationOutcome\n✅ category + confidence"]
-        FLAGS["ReviewFlag tracking\n✅ flag upsert + query"]
-    end
-
-    subgraph LEGAL["Legal Verification"]
-        JURISDICTION["Jurisdiction enum\n✅ US / AU / UK"]
-        LEGAL_RULE["LegalRule + Z3 formulas\n✅ formulas defined"]
-        SOLVER["LegalSolver\n⚠️ Z3 integration partial"]
-        VERIFY["Proposer/Reviewer LLM\n⚠️ pattern defined, not wired"]
-    end
-
-    subgraph VIZ["Visualization"]
-        SLINT["Slint Desktop UI\n⚠️ stub, not wired"]
-        MERMAID_GEN["Mermaid auto-generation\n✅ from rhai DSL blocks"]
-        WORKFLOW_VIZ["WorkflowToml → diagrams\n✅ DSL compiles to Mermaid"]
-    end
-
-    subgraph WORKBOOK["Workbook Output"]
-        XLSX_WRITE["rust_xlsxwriter write\n✅ tx projection"]
-        CALAMINE_READ["calamine read-back\n✅ round-trip"]
-        JOURNAL["NDJSON journal\n✅ append + replay"]
-        AUDIT["Audit trail\n✅ MetaCtx mutation log"]
-    end
-
-    subgraph AGENT["Agent Infrastructure"]
-        PIPELINE_HSM["Pipeline HSM\n✅ type-state + statig"]
-        ISSUE_SRC["IssueSource::RhaiRule\n✅ validation layer"]
-        REQIF_OPA["reqif-opa-mcp MCP\n📋 not wired"]
-        NOTIFY["File watcher\n📋 notify crate stub"]
-    end
-
-    PDF_ROUTE --> BLAKE3
-    PDF_ROUTE --> DOCLING
-    BLAKE3 --> WORKBOOK
-    DOCLING --> DOC_GRAPH
-    DOC_GRAPH --> REQIF_CAND
-    REQIF_CAND --> REGISTRY
-    RULE_FILES --> REGISTRY
-    REGISTRY --> KEYWORD_SEL
-    REGISTRY --> SEMANTIC_SEL
-    KEYWORD_SEL --> WATERFALL
-    SEMANTIC_SEL --> WATERFALL
-    WATERFALL --> ENGINE
-    ENGINE --> OUTCOME
-    OUTCOME --> FLAGS
-    OUTCOME --> LEGAL
-    LEGAL_RULE --> SOLVER
-    SOLVER --> VERIFY
-    VERIFY --> WORKBOOK
-    FLAGS --> WORKBOOK
-    WORKBOOK --> AUDIT
-    WORKFLOW_VIZ --> MERMAID_GEN
-    PIPELINE_HSM --> AGENT
-    ISSUE_SRC --> AGENT
-    REQIF_OPA --> AGENT
+```rhai
+fn filename_routing() -> blake3_ids
+fn filename_routing() -> docling_bridge
+fn docling_bridge() -> document_graph
+fn document_graph() -> reqif_candidates
+fn reqif_candidates() -> rule_registry
+fn rule_files() -> rule_registry
+fn rule_registry() -> keyword_selector
+fn rule_registry() -> semantic_selector
+fn keyword_selector() -> classify_waterfall
+fn semantic_selector() -> classify_waterfall
+fn classify_waterfall() -> classification_engine
+fn classification_engine() -> review_flags
+fn classification_engine() -> legal_solver
+fn legal_solver() -> workbook_output
+fn review_flags() -> workbook_output
+fn workbook_output() -> audit_trail
+fn workflow_toml() -> mermaid_generation
+fn pipeline_hsm() -> agent_runtime
+fn issue_source() -> agent_runtime
+fn reqif_opa_bridge() -> agent_runtime
 ```
 
 ## Component Status Table

--- a/book/src/constraints.md
+++ b/book/src/constraints.md
@@ -2,30 +2,16 @@
 
 The constraints module implements Kasuari-based data plausibility validation.
 
-```mermaid
-flowchart LR
-    subgraph Input["Transaction"]
-        A["amount"]
-        D["date"]
-        C["category"]
-    end
-    
-    subgraph Validate["Kasuari Constraint Solver"]
-        RA["AmountRange"]
-        RD["DateWindow"]
-        RC["CategoryPattern"]
-    end
-    
-    subgraph Output["Result"]
-        OK["✓ Valid"]
-        WARN["⚠ Warning"]
-        FAIL["✗ Invalid"]
-    end
-    
-    Input --> Validate
-    RA --> OK
-    RD --> WARN
-    RC --> FAIL
+```rhai
+fn transaction_input() -> amount_range
+fn transaction_input() -> date_window
+fn transaction_input() -> category_pattern
+fn amount_range() -> constraint_solver
+fn date_window() -> constraint_solver
+fn category_pattern() -> constraint_solver
+if strength == strong -> invalid_result
+if strength == medium -> warning_result
+if strength == weak -> advisory_result
 ```
 
 ## VendorConstraintSet

--- a/book/src/document-ingestion.md
+++ b/book/src/document-ingestion.md
@@ -10,39 +10,17 @@ Document ingestion converts raw PDF statements into structured, auditable transa
 
 ## Ingestion Pipeline Diagram
 
-```mermaid
-flowchart TD
-    subgraph SOURCE["Source Documents"]
-        PDF["PDF Statement\n✅ Blake3 hash-ID"]
-        NAME["Filename Routing\n✅ VENDOR--ACCT--YYYY-MM--DOCTYPE"]
-    end
-
-    subgraph SIDECAR["reqif-opa-mcp Python Sidecar\n📋 bridge not yet wired"]
-        DOCLING["extract_docling_document\n📋 Docling 2.78 call"]
-        GRAPH["build DocumentGraph\n📋 DocumentNode assembly"]
-        CANDIDATES["derive RequirementCandidates\n📋 heuristic extraction"]
-        OPA["OPA policy gate\n📋 policy evaluation"]
-        REQIF_OUT["emit_reqif_xml\n📋 ReqIF baseline output"]
-    end
-
-    subgraph RUST["Rust Core"]
-        DESERIALIZE["ReqIfCandidate deserialization\n📋 NDJSON from sidecar"]
-        REGISTRY["RuleRegistry population\n📋 load_from_dir stub"]
-        CLASSIFY["classify_waterfall\n📋 multi-rule orchestration stub"]
-        WORKBOOK["Workbook commit\n✅ rust_xlsxwriter"]
-    end
-
-    PDF --> NAME
-    NAME --> DOCLING
-    NAME --> WORKBOOK
-    DOCLING --> GRAPH
-    GRAPH --> CANDIDATES
-    CANDIDATES --> OPA
-    OPA --> REQIF_OUT
-    REQIF_OUT --> DESERIALIZE
-    DESERIALIZE --> REGISTRY
-    REGISTRY --> CLASSIFY
-    CLASSIFY --> WORKBOOK
+```rhai
+fn pdf_statement() -> filename_routing
+fn filename_routing() -> blake3_ingest
+fn filename_routing() -> docling_extract
+fn docling_extract() -> document_graph
+fn document_graph() -> requirement_candidates
+fn requirement_candidates() -> opa_gate
+fn opa_gate() -> reqif_baseline
+fn reqif_baseline() -> rule_registry
+fn rule_registry() -> classify_waterfall
+fn classify_waterfall() -> workbook_commit
 ```
 
 ## Ingestion Flow (Rhai DSL)

--- a/book/src/ledger-ops.md
+++ b/book/src/ledger-ops.md
@@ -30,28 +30,19 @@ if result_failure -> emit_issue
 
 ## Dispatcher Architecture
 
-```mermaid
-flowchart TD
-    OD[OperationDispatcher] --> CTX[OperationContext]
-
-    OD --> ISS[IngestStatementOp]
-    OD --> CTO[ClassifyTransactionsOp]
-    OD --> CTD[CheckTaxDeadlineOp]
-    OD --> EWO[ExportWorkbookOp]
-    OD --> GAT[GenerateAuditTrailOp]
-
-    ISS -->|idempotent: blake3 dedup| OR[OperationResult]
-    CTO --> OR
-    CTD --> OR
-    EWO --> OR
-    GAT --> OR
-
-    OR --> AT[AuditTrail]
-    CTX -.->|provides| ISS
-    CTX -.->|provides| CTO
-    CTX -.->|provides| CTD
-    CTX -.->|provides| EWO
-    CTX -.->|provides| GAT
+```rhai
+fn operation_dispatcher() -> operation_context
+fn operation_dispatcher() -> ingest_statement_op
+fn operation_dispatcher() -> classify_transactions_op
+fn operation_dispatcher() -> check_tax_deadline_op
+fn operation_dispatcher() -> export_workbook_op
+fn operation_dispatcher() -> generate_audit_trail_op
+fn ingest_statement_op() -> operation_result
+fn classify_transactions_op() -> operation_result
+fn check_tax_deadline_op() -> operation_result
+fn export_workbook_op() -> operation_result
+fn generate_audit_trail_op() -> operation_result
+fn operation_result() -> audit_trail
 ```
 
 `IngestStatementOp` is annotated as idempotent: re-ingesting the same source file produces the same Blake3 content-hash transaction IDs and the dispatcher skips duplicate writes.

--- a/book/src/legal.md
+++ b/book/src/legal.md
@@ -2,28 +2,14 @@
 
 The legal module provides tax rule verification across multiple jurisdictions.
 
-```mermaid
-flowchart LR
-    subgraph Jurisdictions["Supported Jurisdictions"]
-        direction TB
-        US["🇺🇸 US<br/>Schedule C, 1040"]
-        AU["🇦🇺 AU<br/>GST, BAS"]
-        UK["🇬🇧 UK<br/>VAT, CT"]
-    end
-    
-    subgraph Rules["Tax Rules"]
-        R1["Schedule C Expense"]
-        R2["GST Credit"]
-        R3["VAT Deductibility"]
-    end
-    
-    subgraph Result["Disposition"]
-        U["Unrecoverable"]
-        R["Recoverable"]
-        A["Advisory"]
-    end
-    
-    Jurisdictions --> Rules --> Result
+```rhai
+fn transaction() -> us_rules
+fn transaction() -> au_rules
+fn transaction() -> uk_rules
+fn us_rules() -> unrecoverable
+fn au_rules() -> recoverable
+fn uk_rules() -> advisory
+if requires_fbar_reporting == true -> advisory
 ```
 
 ## Jurisdiction

--- a/book/src/pipeline.md
+++ b/book/src/pipeline.md
@@ -11,17 +11,14 @@ The pipeline module implements a type-state pattern for the document processing 
 
 ## State Types
 
-```mermaid
-stateDiagram-v2
-    [*] --> Ingested
-    Ingested --> Validating: validate()
-    Validating --> Classifying: classify()
-    Classifying --> Reconciling: reconcile()
-    Reconciling --> Committed: commit()
-    Committed --> [*]
-    
-    Validating --> NeedsReview: confidence < 0.5
-    NeedsReview --> Classifying: human_approved
+```rhai
+fn ingested() -> validating
+fn validating() -> classifying
+fn classifying() -> reconciling
+fn reconciling() -> committed
+if confidence < 0.5 -> needs_review
+if human_approved == true -> classifying
+if fatal_error == true -> error
 ```
 
 - **Ingested**: Document has been parsed

--- a/book/src/rule-engine.md
+++ b/book/src/rule-engine.md
@@ -40,44 +40,20 @@ The thresholds are configurable per deployment. The `review` path creates a `Rev
 
 The diagram below shows the full classification pipeline from document ingestion through workbook commit. Each node is tagged with its current implementation status.
 
-```mermaid
-flowchart TD
-    subgraph INGEST["Document Ingestion"]
-        PDF["PDF Source\n✅ filename routing"]
-        DOCTYPE["DocType Detection\n✅ DocType enum"]
-        REQIF["ReqIF Sidecar\n📋 Python bridge missing"]
-    end
-
-    subgraph RULES["Rule Engine"]
-        REGISTRY["RuleRegistry\n📋 load_from_dir stub"]
-        SELECT["Rule Selection\n⚠️ deterministic only"]
-        WATERFALL["classify_waterfall\n📋 orchestration stub"]
-    end
-
-    subgraph CONFIDENCE["Confidence Gate"]
-        HIGH["confidence > 0.85\n✅ commit path"]
-        MED["confidence 0.60–0.85\n✅ review flag"]
-        LOW["confidence ≤ 0.60\n✅ escalate flag"]
-    end
-
-    subgraph OUTPUT["Workbook Output"]
-        COMMIT["Workbook Commit\n✅ rust_xlsxwriter"]
-        FLAG["ReviewFlag Sheet\n✅ flags tracked"]
-    end
-
-    PDF --> DOCTYPE
-    DOCTYPE --> REQIF
-    DOCTYPE --> REGISTRY
-    REQIF --> REGISTRY
-    REGISTRY --> SELECT
-    SELECT --> WATERFALL
-    WATERFALL --> HIGH
-    WATERFALL --> MED
-    WATERFALL --> LOW
-    HIGH --> COMMIT
-    MED --> FLAG
-    LOW --> FLAG
-    FLAG --> COMMIT
+```rhai
+fn pdf_source() -> doctype_detection
+fn doctype_detection() -> reqif_bridge
+fn doctype_detection() -> rule_registry
+fn reqif_bridge() -> rule_registry
+fn rule_registry() -> rule_selection
+fn rule_selection() -> classify_waterfall
+fn classify_waterfall() -> high_confidence
+fn classify_waterfall() -> medium_confidence
+fn classify_waterfall() -> low_confidence
+fn high_confidence() -> workbook_commit
+fn medium_confidence() -> review_flag
+fn low_confidence() -> review_flag
+fn review_flag() -> workbook_commit
 ```
 
 ## Rule Authoring

--- a/book/src/theory.md
+++ b/book/src/theory.md
@@ -77,73 +77,42 @@ for (idx, _) in nodes.iter().enumerate() {
 
 ## System Architecture Diagram
 
-```mermaid
-flowchart TB
-    subgraph OPERATOR["OPERATOR"]
-        H["Human Accountant"]
-    end
-
-    subgraph HOST["SLINT DESKTOP HOST"]
-        T["Tray Icon"]
-        W["Window UI"]
-        N["Toast Notifier"]
-        C["Credential Manager"]
-        G["SlintGraph View"]
-    end
-
-    subgraph CORE["LEDGER-CORE"]
-        P["Pipeline HSM"]
-        V["Validation"]
-        L["Legal Solver"]
-        K["Constraints"]
-    end
-
-    subgraph MCP["MCP ADAPTER"]
-        D["ledgerr_documents"]
-        R["ledgerr_review"]
-        Cc["ledgerr_reconciliation"]
-    end
-
-    H --> HOST
-    T --> G
-    W --> G
-    N --> G
-    C --> G
-    HOST --> CORE
-    CORE --> MCP
-    P --> V
-    P --> L
-    P --> K
+```rhai
+fn human_accountant() -> tray_icon
+fn human_accountant() -> window_ui
+fn tray_icon() -> slint_graph_view
+fn window_ui() -> slint_graph_view
+fn toast_notifier() -> slint_graph_view
+fn credential_manager() -> slint_graph_view
+fn slint_graph_view() -> pipeline_hsm
+fn pipeline_hsm() -> validation
+fn pipeline_hsm() -> legal_solver
+fn pipeline_hsm() -> constraints
+fn pipeline_hsm() -> ledgerr_documents
+fn pipeline_hsm() -> ledgerr_review
+fn pipeline_hsm() -> ledgerr_reconciliation
 ```
 
 ## Pipeline Flow Diagram
 
-```mermaid
-stateDiagram-v2
-    [*] --> Ingested
-    Ingested --> Validating: validate
-    Validating --> Classifying: classify
-    Classifying --> Reconciling: reconcile
-    Reconciling --> Committed: commit
-    Committed --> [*]
-
-    Validating --> NeedsReview: low_confidence
-    NeedsReview --> Classifying: approved
+```rhai
+fn ingested() -> validating
+fn validating() -> classifying
+fn classifying() -> reconciling
+fn reconciling() -> committed
+if low_confidence == true -> needs_review
+if approved == true -> classifying
 ```
 
 ## LLM Verification Pattern
 
-```mermaid
-sequenceDiagram
-    participant P as Proposer LLM
-    participant S as Decision Store
-    participant R as Reviewer LLM
-    
-    P->>S: propose(category, confidence)
-    S->>R: review(proposal)
-    R-->>S: verdict(agreed, evidence)
-    S-->>P: result(confidence, issues)
-
+```rhai
+fn proposer_llm() -> decision_store
+fn decision_store() -> reviewer_llm
+if reviewer_agreed == true -> accepted_result
+if reviewer_agreed == false -> human_review
+fn human_review() -> accepted_result
+```
 ## Executable LLM Pipeline Integration
 
 ### Proposer/Reviewer Pattern
@@ -202,29 +171,12 @@ fn run_pipeline(document_path: &str) -> Result<PipelineState<Committed>, Issue> 
 
 ### 3D Force Layout to 2D Screen
 
-```mermaid
-flowchart LR
-    subgraph Input["3D Force Layout"]
-        F1["Node A"]
-        F2["Node B"]
-        F3["Node C"]
-    end
-    
-    subgraph Transform["Isometric Projection"]
-        I["x' = (x-z) * 0.866<br/>y' = (x+z) * 0.5 - y"]
-    end
-    
-    subgraph Output["2D Screen"]
-        S1["(400, 300)"]
-        S2["(450, 280)"]
-        S3["(420, 320)"]
-    end
-    
-    F1 --> I --> S1
-    F2 --> I --> S2
-    F3 --> I --> S3
+```rhai
+fn node_a_3d() -> isometric_projection
+fn node_b_3d() -> isometric_projection
+fn node_c_3d() -> isometric_projection
+fn isometric_projection() -> screen_coordinates
 ```
-
 ### State Visualization Mapping
 
 ```rust
@@ -285,8 +237,8 @@ test-recipes:
     validates: isometric graph rendering
 
   - name: mdbook-build
-    command: mdbook build book
-    validates: documentation generation
+    command: just docgen-check
+    validates: documentation generation plus live Rhai editor assets
 
   - name: mcp-surface-contract
     command: cargo run -p xtask-mcpb -- generate-mcp-artifacts

--- a/book/src/verify.md.bak
+++ b/book/src/verify.md.bak
@@ -4,13 +4,6 @@ The verify module implements multi-model verification for quality assurance.
 
 ## Multi-Model Verification
 
-```rhai
-fn proposer_model() -> decision_store
-fn decision_store() -> reviewer_model
-if reviewer_agreed == true -> accepted_result
-if reviewer_agreed == false -> human_review
-fn human_review() -> accepted_result
-```
 ```mermaid
 sequenceDiagram
     participant T as Transaction

--- a/book/src/visualize.md
+++ b/book/src/visualize.md
@@ -61,6 +61,19 @@ let mermaid = graph.to_mermaid();
 // Generates stateDiagram-v2
 ```
 
+## Live Rhai Editor
+
+The rendered book now upgrades generated Rhai diagram blocks into a local editor + preview surface. Use `just docserve`, open the book in a browser, edit a supported ` ```rhai ` block, and click `Regenerate` to redraw the chart without changing the source markdown.
+
+The live editor uses the same narrow diagram DSL as the mdBook preprocessor:
+- `fn source() -> target`
+- `if expression -> target`
+
+Diagnostics now surface line-level parse feedback:
+- malformed DSL lines are marked as errors
+- ignored non-DSL lines are marked as informational notes
+- render failures include Mermaid load guidance when the global runtime is unavailable
+
 ## HTML Export
 
 ```rust

--- a/book/theme/rhai-live-core.js
+++ b/book/theme/rhai-live-core.js
@@ -1,0 +1,257 @@
+(function (root, factory) {
+    const api = factory();
+    if (typeof module !== "undefined" && module.exports) {
+        module.exports = api;
+    }
+    if (root) {
+        root.RhaiLiveCore = api;
+    }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+    function sanitizeId(raw) {
+        return raw.replace(/[^A-Za-z0-9_]/g, "_");
+    }
+
+    function escapeLabel(raw) {
+        return raw.replace(/"/g, "&quot;");
+    }
+
+    function parseRhaiDiagram(source) {
+        const graph = {
+            order: [],
+            nodes: new Map(),
+            edges: [],
+        };
+        const pipelineEdges = [];
+        const conditionals = [];
+        const diagnostics = [];
+
+        function addNode(id, label, kind) {
+            if (!graph.nodes.has(id)) {
+                graph.order.push(id);
+                graph.nodes.set(id, { id, label, kind });
+            }
+        }
+
+        function addEdge(from, to, label) {
+            graph.edges.push({ from, to, label: label || null });
+        }
+
+        function parseCondition(expr, target) {
+            const operators = [">=", "<=", "!=", ">", "<", "=="];
+            for (const op of operators) {
+                const index = expr.indexOf(op);
+                if (index !== -1) {
+                    const lhs = expr.slice(0, index).trim();
+                    const rhs = expr.slice(index + op.length).trim();
+                    if (lhs && rhs) {
+                        return { lhs, op, rhs, target };
+                    }
+                }
+            }
+            return null;
+        }
+
+        function emitThresholdChain(lhs, op, thresholds) {
+            const nodeIds = thresholds.map(([value]) =>
+                sanitizeId(`${lhs}_${opWord(op)}_${String(value).replace(/\./g, "_")}`)
+            );
+
+            thresholds.forEach(([value, target], index) => {
+                const nodeId = nodeIds[index];
+                addNode(nodeId, `${lhs} ${op} ${value}`, "decision");
+
+                const targetId = sanitizeId(target);
+                addNode(targetId, target, "step");
+                addEdge(nodeId, targetId, "true");
+
+                if (index + 1 < thresholds.length) {
+                    addEdge(nodeId, nodeIds[index + 1], "false");
+                }
+            });
+        }
+
+        function opWord(op) {
+            switch (op) {
+                case ">":
+                    return "gt";
+                case "<":
+                    return "lt";
+                case ">=":
+                    return "gte";
+                case "<=":
+                    return "lte";
+                case "==":
+                    return "eq";
+                case "!=":
+                    return "ne";
+                default:
+                    return "op";
+            }
+        }
+
+        source.split("\n").forEach((rawLine, index) => {
+            const commentIndex = rawLine.indexOf("//");
+            const line = (commentIndex === -1 ? rawLine : rawLine.slice(0, commentIndex)).trim();
+            if (!line) {
+                return;
+            }
+
+            if (line.startsWith("fn ")) {
+                const rest = line.slice(3);
+                const parts = rest.split("->");
+                if (parts.length === 2) {
+                    const name = parts[0].trim().replace(/\(\)\s*$/, "").trim();
+                    const target = parts[1].trim();
+                    if (name && target) {
+                        pipelineEdges.push([name, target]);
+                        return;
+                    }
+                }
+                diagnostics.push({
+                    line: index + 1,
+                    kind: "error",
+                    message: "Malformed fn edge; expected `fn source() -> target`.",
+                    source: rawLine.trim(),
+                });
+                return;
+            }
+
+            if (line.startsWith("if ")) {
+                const rest = line.slice(3);
+                const parts = rest.split("->");
+                if (parts.length === 2) {
+                    const expr = parts[0].trim();
+                    const target = parts[1].trim();
+                    if (expr && target) {
+                        const parsed = parseCondition(expr, target);
+                        if (parsed) {
+                            conditionals.push(parsed);
+                        } else {
+                            conditionals.push({
+                                lhs: sanitizeId(expr),
+                                op: "",
+                                rhs: "",
+                                target: sanitizeId(target),
+                            });
+                            diagnostics.push({
+                                line: index + 1,
+                                kind: "warning",
+                                message:
+                                    "Condition parsed as raw decision node; prefer operators like >, <, >=, <=, ==, !=",
+                                source: rawLine.trim(),
+                            });
+                        }
+                        return;
+                    }
+                }
+                diagnostics.push({
+                    line: index + 1,
+                    kind: "error",
+                    message: "Malformed if edge; expected `if expression -> target`.",
+                    source: rawLine.trim(),
+                });
+                return;
+            }
+
+            diagnostics.push({
+                line: index + 1,
+                kind: "info",
+                message:
+                    "Line ignored by diagram DSL. Supported forms are `fn source() -> target` and `if expression -> target`.",
+                source: rawLine.trim(),
+            });
+        });
+
+        pipelineEdges.forEach(([name, target]) => {
+            const nameId = sanitizeId(name);
+            const targetId = sanitizeId(target);
+            addNode(nameId, name, "step");
+            addNode(targetId, target, "step");
+            addEdge(nameId, targetId, null);
+        });
+
+        const gtGroups = new Map();
+        const ltGroups = new Map();
+        const plainConditions = [];
+
+        conditionals.forEach((cond) => {
+            if (cond.op === ">" && !Number.isNaN(Number(cond.rhs))) {
+                const list = gtGroups.get(cond.lhs) || [];
+                list.push([Number(cond.rhs), cond.target]);
+                gtGroups.set(cond.lhs, list);
+                return;
+            }
+
+            if (cond.op === "<" && !Number.isNaN(Number(cond.rhs))) {
+                const list = ltGroups.get(cond.lhs) || [];
+                list.push([Number(cond.rhs), cond.target]);
+                ltGroups.set(cond.lhs, list);
+                return;
+            }
+
+            plainConditions.push(cond);
+        });
+
+        gtGroups.forEach((thresholds, lhs) => {
+            thresholds.sort((left, right) => right[0] - left[0]);
+            emitThresholdChain(lhs, ">", thresholds);
+        });
+
+        ltGroups.forEach((thresholds, lhs) => {
+            thresholds.sort((left, right) => left[0] - right[0]);
+            emitThresholdChain(lhs, "<", thresholds);
+        });
+
+        plainConditions.forEach((cond) => {
+            if (!cond.op) {
+                const condId = cond.lhs;
+                const targetId = sanitizeId(cond.target);
+                addNode(condId, cond.lhs, "decision");
+                addNode(targetId, cond.target, "step");
+                addEdge(condId, targetId, null);
+                return;
+            }
+
+            const exprLabel = `${cond.lhs} ${cond.op} ${cond.rhs}`;
+            const condId = sanitizeId(exprLabel);
+            const targetId = sanitizeId(cond.target);
+            addNode(condId, exprLabel, "decision");
+            addNode(targetId, cond.target, "step");
+            addEdge(condId, targetId, "true");
+        });
+
+        return { graph, diagnostics };
+    }
+
+    function graphToMermaid(graph) {
+        const lines = ["flowchart TD"];
+
+        graph.order.forEach((id) => {
+            const node = graph.nodes.get(id);
+            if (!node) {
+                return;
+            }
+            if (node.kind === "decision") {
+                lines.push(`    ${node.id}{"${escapeLabel(node.label)}"}`);
+            } else {
+                lines.push(`    ${node.id}["${escapeLabel(node.label)}"]`);
+            }
+        });
+
+        graph.edges.forEach((edge) => {
+            if (edge.label) {
+                lines.push(`    ${edge.from} -->|"${edge.label}"|${edge.to}`);
+            } else {
+                lines.push(`    ${edge.from} --> ${edge.to}`);
+            }
+        });
+
+        return lines.join("\n");
+    }
+
+    return {
+        sanitizeId,
+        parseRhaiDiagram,
+        graphToMermaid,
+    };
+});

--- a/book/theme/rhai-live-core.test.js
+++ b/book/theme/rhai-live-core.test.js
@@ -1,0 +1,32 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const core = require("./rhai-live-core.js");
+
+test("parses simple fn pipeline", function () {
+    const result = core.parseRhaiDiagram("fn ingest() -> classify\nfn classify() -> commit\n");
+    assert.equal(result.graph.nodes.size, 3);
+    assert.equal(result.graph.edges.length, 2);
+    assert.equal(result.diagnostics.length, 0);
+});
+
+test("emits diagnostics for unsupported and malformed lines", function () {
+    const src = [
+        "let x = 1",
+        "fn bad_syntax() => nope",
+        "if confidence > 0.8 -> commit",
+    ].join("\n");
+    const result = core.parseRhaiDiagram(src);
+    assert.equal(result.graph.edges.length, 1);
+    assert.ok(result.diagnostics.length >= 2);
+    assert.ok(result.diagnostics.some((d) => d.kind === "info"));
+    assert.ok(result.diagnostics.some((d) => d.kind === "error"));
+});
+
+test("builds threshold chain with false branch", function () {
+    const src = "if confidence > 0.5 -> review\nif confidence > 0.8 -> commit\n";
+    const result = core.parseRhaiDiagram(src);
+    const mermaid = core.graphToMermaid(result.graph);
+    assert.ok(mermaid.includes('|"false"|'));
+    assert.ok(mermaid.includes("commit"));
+    assert.ok(mermaid.includes("review"));
+});

--- a/book/theme/rhai-live.css
+++ b/book/theme/rhai-live.css
@@ -1,0 +1,129 @@
+.rhai-diagram-shell {
+    border: 1px solid var(--searchbar-border-color, #d0d7de);
+    border-radius: 10px;
+    margin: 1rem 0 1.5rem;
+    overflow: hidden;
+    background: var(--bg, #ffffff);
+}
+
+.rhai-diagram-toolbar {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--searchbar-border-color, #d0d7de);
+    background: var(--table-header-bg, rgba(127, 127, 127, 0.08));
+}
+
+.rhai-diagram-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.rhai-diagram-button {
+    border: 1px solid var(--searchbar-border-color, #d0d7de);
+    border-radius: 6px;
+    padding: 0.35rem 0.7rem;
+    background: var(--sidebar-bg, #f6f8fa);
+    color: inherit;
+    cursor: pointer;
+}
+
+.rhai-diagram-button:hover {
+    filter: brightness(0.98);
+}
+
+.rhai-diagram-status {
+    font-size: 0.9rem;
+    opacity: 0.8;
+}
+
+.rhai-diagram-body {
+    display: grid;
+    grid-template-columns: minmax(18rem, 1fr) minmax(18rem, 1fr);
+}
+
+.rhai-diagram-editor {
+    min-height: 18rem;
+    padding: 1rem;
+    border: 0;
+    border-right: 1px solid var(--searchbar-border-color, #d0d7de);
+    resize: vertical;
+    font: 0.9rem/1.5 var(--code-font-family, monospace);
+    background: transparent;
+    color: inherit;
+}
+
+.rhai-diagram-preview {
+    padding: 1rem;
+    overflow: auto;
+}
+
+.rhai-diagram-preview svg {
+    max-width: 100%;
+    height: auto;
+}
+
+.rhai-diagram-error {
+    color: #b42318;
+    font-weight: 600;
+}
+
+.rhai-diagram-note {
+    font-size: 0.85rem;
+    opacity: 0.75;
+}
+
+.rhai-diag-panel {
+    margin-top: 0.75rem;
+    border-top: 1px solid var(--searchbar-border-color, #d0d7de);
+    padding-top: 0.6rem;
+}
+
+.rhai-diag-title {
+    font-weight: 600;
+    margin-bottom: 0.4rem;
+}
+
+.rhai-diag-panel ul {
+    margin: 0;
+    padding-left: 1.2rem;
+}
+
+.rhai-diag-panel li {
+    margin-bottom: 0.35rem;
+}
+
+.rhai-diag-error {
+    color: #b42318;
+}
+
+.rhai-diag-warning {
+    color: #b54708;
+}
+
+.rhai-diag-info {
+    color: #344054;
+}
+
+.rhai-diag-hint {
+    font-size: 0.85rem;
+    opacity: 0.8;
+}
+
+.rhai-diagram-original {
+    display: none;
+}
+
+@media (max-width: 900px) {
+    .rhai-diagram-body {
+        grid-template-columns: 1fr;
+    }
+
+    .rhai-diagram-editor {
+        border-right: 0;
+        border-bottom: 1px solid var(--searchbar-border-color, #d0d7de);
+    }
+}

--- a/book/theme/rhai-live.js
+++ b/book/theme/rhai-live.js
@@ -1,0 +1,212 @@
+(function () {
+    const ORIGINAL_CLASS = "rhai-diagram-original";
+    const MERMAID_CDN = "https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js";
+
+    function escapeHtml(raw) {
+        return raw
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
+    }
+
+    async function ensureMermaid() {
+        if (window.mermaid) {
+            return window.mermaid;
+        }
+
+        if (!window.__rhaiLiveMermaidLoadPromise) {
+            window.__rhaiLiveMermaidLoadPromise = new Promise(function (resolve, reject) {
+                const script = document.createElement("script");
+                script.src = MERMAID_CDN;
+                script.async = true;
+                script.onload = function () {
+                    if (window.mermaid) {
+                        resolve(window.mermaid);
+                    } else {
+                        reject(new Error("Mermaid script loaded but window.mermaid is still undefined."));
+                    }
+                };
+                script.onerror = function () {
+                    reject(
+                        new Error(
+                            "Mermaid failed to load from CDN. Check network access or include Mermaid in mdBook assets."
+                        )
+                    );
+                };
+                document.head.appendChild(script);
+            });
+        }
+
+        return window.__rhaiLiveMermaidLoadPromise;
+    }
+
+    async function renderMermaid(target, mermaidSource) {
+        const mermaid = await ensureMermaid();
+        if (!window.__rhaiLiveMermaidInitialized) {
+            mermaid.initialize({ startOnLoad: false });
+            window.__rhaiLiveMermaidInitialized = true;
+        }
+
+        const renderId = `rhai-live-${Math.random().toString(36).slice(2)}`;
+        const rendered = await mermaid.render(renderId, mermaidSource);
+        target.innerHTML = rendered.svg;
+        if (typeof rendered.bindFunctions === "function") {
+            rendered.bindFunctions(target);
+        }
+    }
+
+    function diagnosticsHtml(diagnostics) {
+        if (!diagnostics.length) {
+            return "";
+        }
+
+        const lines = diagnostics.map(function (diag) {
+            const cls =
+                diag.kind === "error"
+                    ? "rhai-diag-error"
+                    : diag.kind === "warning"
+                      ? "rhai-diag-warning"
+                      : "rhai-diag-info";
+            return `<li class="${cls}"><strong>L${diag.line}</strong> ${escapeHtml(diag.message)}<br><code>${escapeHtml(
+                diag.source
+            )}</code></li>`;
+        });
+
+        return `<div class="rhai-diag-panel"><div class="rhai-diag-title">Diagnostics</div><ul>${lines.join(
+            ""
+        )}</ul></div>`;
+    }
+
+    async function attachEditor(sourcePre) {
+        const sourceCode = sourcePre && sourcePre.querySelector("code.language-rhai");
+        const previewPre = sourcePre.nextElementSibling;
+        if (!sourceCode || !previewPre || !previewPre.classList.contains("mermaid")) {
+            return;
+        }
+
+        const core = window.RhaiLiveCore;
+        if (!core) {
+            return;
+        }
+
+        const shell = document.createElement("section");
+        shell.className = "rhai-diagram-shell";
+
+        const toolbar = document.createElement("div");
+        toolbar.className = "rhai-diagram-toolbar";
+
+        const status = document.createElement("div");
+        status.className = "rhai-diagram-status";
+        status.textContent = "Live Rhai diagram editor";
+
+        const actions = document.createElement("div");
+        actions.className = "rhai-diagram-actions";
+
+        const regenerate = document.createElement("button");
+        regenerate.type = "button";
+        regenerate.className = "rhai-diagram-button";
+        regenerate.textContent = "Regenerate";
+
+        const reset = document.createElement("button");
+        reset.type = "button";
+        reset.className = "rhai-diagram-button";
+        reset.textContent = "Reset";
+
+        actions.appendChild(regenerate);
+        actions.appendChild(reset);
+        toolbar.appendChild(status);
+        toolbar.appendChild(actions);
+
+        const body = document.createElement("div");
+        body.className = "rhai-diagram-body";
+
+        const editor = document.createElement("textarea");
+        editor.className = "rhai-diagram-editor";
+        editor.spellcheck = false;
+        editor.value = sourceCode.textContent || "";
+
+        const preview = document.createElement("div");
+        preview.className = "rhai-diagram-preview";
+
+        const note = document.createElement("div");
+        note.className = "rhai-diagram-note";
+        note.textContent = "Edit the supported Rhai diagram DSL (`fn ... -> ...`, `if ... -> ...`) and regenerate.";
+
+        body.appendChild(editor);
+        body.appendChild(preview);
+        shell.appendChild(toolbar);
+        shell.appendChild(body);
+        shell.appendChild(note);
+
+        sourcePre.classList.add(ORIGINAL_CLASS);
+        previewPre.classList.add(ORIGINAL_CLASS);
+        previewPre.insertAdjacentElement("afterend", shell);
+
+        const originalSource = editor.value;
+
+        async function update() {
+            try {
+                const result = core.parseRhaiDiagram(editor.value);
+                const graph = result.graph;
+                const diagnostics = result.diagnostics;
+
+                if (!graph.order.length && !graph.edges.length) {
+                    preview.innerHTML =
+                        '<p class="rhai-diagram-error">No diagramable Rhai DSL lines found in this block.</p>' +
+                        diagnosticsHtml(diagnostics);
+                    status.textContent = "No parseable diagram nodes";
+                    return;
+                }
+
+                const mermaidSource = core.graphToMermaid(graph);
+                await renderMermaid(preview, mermaidSource);
+                preview.insertAdjacentHTML("beforeend", diagnosticsHtml(diagnostics));
+                status.textContent = `Rendered ${graph.nodes.size} nodes and ${graph.edges.length} edges`;
+            } catch (error) {
+                preview.innerHTML =
+                    `<p class="rhai-diagram-error">${escapeHtml(error.message)}</p>` +
+                    '<p class="rhai-diag-hint">Try refreshing, or verify Mermaid network availability.</p>';
+                status.textContent = "Render failed";
+            }
+        }
+
+        regenerate.addEventListener("click", update);
+        reset.addEventListener("click", async function () {
+            editor.value = originalSource;
+            await update();
+        });
+        editor.addEventListener("keydown", async function (event) {
+            if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
+                event.preventDefault();
+                await update();
+            }
+        });
+
+        await update();
+    }
+
+    async function main() {
+        const sourceBlocks = Array.from(document.querySelectorAll("pre"));
+        for (const sourcePre of sourceBlocks) {
+            const code = sourcePre.querySelector("code.language-rhai");
+            if (!code) {
+                continue;
+            }
+
+            const previewPre = sourcePre.nextElementSibling;
+            if (!previewPre || !previewPre.classList.contains("mermaid")) {
+                continue;
+            }
+
+            await attachEditor(sourcePre);
+        }
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", function () {
+            main().catch((error) => console.error("rhai-live:", error));
+        });
+    } else {
+        main().catch((error) => console.error("rhai-live:", error));
+    }
+})();

--- a/scripts/docserve-live.ps1
+++ b/scripts/docserve-live.ps1
@@ -1,0 +1,4 @@
+$scriptPath = Join-Path $PSScriptRoot "docserve-live.pwsh"
+$scriptBody = Get-Content -LiteralPath $scriptPath -Raw
+$scriptBlock = [ScriptBlock]::Create($scriptBody)
+& $scriptBlock @args

--- a/scripts/docserve-live.pwsh
+++ b/scripts/docserve-live.pwsh
@@ -1,0 +1,101 @@
+param(
+    [string]$RepoPath = "C:\Users\wendy\l3dg3rr",
+    [string]$WslRepoPath = "/mnt/c/users/wendy/l3dg3rr",
+    [string]$BindHost = "127.0.0.1",
+    [int]$Port = 3000,
+    [switch]$SkipBuild,
+    [switch]$SkipBrowser
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-HttpServerProcesses {
+    param([int]$TargetPort)
+    Get-CimInstance Win32_Process |
+        Where-Object {
+            ($_.Name -match "python|py") -and
+            ($_.CommandLine -match "http\.server") -and
+            ($_.CommandLine -match "\s$TargetPort(\s|$)")
+        }
+}
+
+function Stop-HttpServerProcesses {
+    param([int]$TargetPort)
+    $procs = Get-HttpServerProcesses -TargetPort $TargetPort
+    foreach ($proc in $procs) {
+        try {
+            Stop-Process -Id $proc.ProcessId -Force -ErrorAction Stop
+        } catch {
+            Write-Warning "Failed to stop PID $($proc.ProcessId): $($_.Exception.Message)"
+        }
+    }
+}
+
+function Start-HttpServer {
+    param(
+        [string]$WorkingDir,
+        [string]$BindHost,
+        [int]$BindPort
+    )
+
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        return Start-Process `
+            -FilePath "py" `
+            -ArgumentList "-3 -m http.server $BindPort --bind $BindHost --directory book/book" `
+            -WorkingDirectory $WorkingDir `
+            -WindowStyle Hidden `
+            -PassThru
+    }
+
+    if (Get-Command python -ErrorAction SilentlyContinue) {
+        return Start-Process `
+            -FilePath "python" `
+            -ArgumentList "-m http.server $BindPort --bind $BindHost --directory book/book" `
+            -WorkingDirectory $WorkingDir `
+            -WindowStyle Hidden `
+            -PassThru
+    }
+
+    throw "No Python launcher found on Windows PATH (expected 'py' or 'python')."
+}
+
+if (-not (Test-Path -LiteralPath $RepoPath)) {
+    throw "Repo path not found: $RepoPath"
+}
+
+if (-not $SkipBuild) {
+    Write-Host "Building docs via WSL: just docgen"
+    & wsl.exe -e bash -lc "cd $WslRepoPath && just docgen"
+}
+
+Set-Location -LiteralPath $RepoPath
+
+Stop-HttpServerProcesses -TargetPort $Port
+
+$server = Start-HttpServer -WorkingDir $RepoPath -BindHost $BindHost -BindPort $Port
+$url = "http://$BindHost`:$Port/theory.html"
+
+$ready = $false
+for ($i = 0; $i -lt 20; $i++) {
+    Start-Sleep -Milliseconds 300
+    try {
+        $resp = Invoke-WebRequest -Uri $url -UseBasicParsing -TimeoutSec 2
+        if ($resp.StatusCode -eq 200) {
+            $ready = $true
+            break
+        }
+    } catch {
+        # Keep polling until timeout.
+    }
+}
+
+if (-not $ready) {
+    throw "Docs server did not become ready at $url"
+}
+
+if (-not $SkipBrowser) {
+    Start-Process $url | Out-Null
+}
+
+Write-Host "Docs server ready at $url (PID $($server.Id))"


### PR DESCRIPTION
## Summary
- restore mdBook Rhai diagram sections to the supported mini-DSL
- add a live docs editor/preview for Rhai -> Mermaid with runtime diagnostics
- lazy-load Mermaid in-browser when unavailable and improve render error messaging
- add unit tests for the live editor core parser/diagnostics
- add Windows/WSL docs startup scripts (docserve-live.pwsh + docserve-live.ps1) and just wsl2-pwsh-docserve
- update AGENTS/README/visualize docs for the new workflow

## Validation
- cargo test -p mdbook-rhai-mermaid
- just docgen-check
- just wsl2-pwsh-docserve
- PowerShell HTTP checks for http://127.0.0.1:3000/theory.html (200 + live assets present)
