### PR TITLE
[codex] Implement PRD-4 ontology and Phi-4 integration plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,6 +338,15 @@ Treat this as a standing operational gate, not a one-time migration task.
   - Prefer worked sample blocks in visualization-heavy chapters over abstract prose. At minimum, include one happy-path sample and one branch-heavy sample that can be pasted into the live editor.
   - The future `match` operator contract is documented in `book/src/match-visualization-plan.md`; keep Mermaid and isometric semantics aligned to that plan instead of inventing per-view behavior.
   - When adding new modules, add corresponding chapter in `book/src/` and update `book/src/SUMMARY.md`.
+- 2026-04-27: PRD-4 Phase 1 established `ledger-core::ontology` as the canonical ontology primitive layer while preserving MCP legacy storage shape.
+  - Keep `ledgerr-mcp` ontology files backward-compatible with `{ entities, edges }` and legacy `entity|...` / `edge|...` Blake3 ID prefixes unless a deliberate migration is planned.
+  - PRD-4 Phase 2 ingest ontology emission is opt-in through `ontology_path` on ingest requests; do not write ontology sidecars implicitly from workbook paths unless product policy changes.
+  - PRD-4 Phase 4 typed Phi-4 jobs start in `crates/ledgerr-host/src/agent_runtime.rs`; the local fallback in `internal_openai.rs` must satisfy the same JSON-only schema contract as a real model.
+  - PRD-4 Phase 5 proposal lifecycle lives in `ledger-core::proposal`; model proposals must be validated before commit and low-confidence or mutating relations require explicit operator approval.
+  - PRD-4 Phase 6 semantic retrieval starts as a deterministic local lexical index in `RuleRegistry`; future embedding backends must preserve stable candidate IDs and keep `classify_waterfall` authoritative.
+  - PRD-4 Phase 7 audit playbook must keep workbook rows, ontology facts, lifecycle events, and visual graph examples tied to the same deterministic transaction IDs.
+  - `book/src/SUMMARY.md` must not list the same chapter file twice; mdBook fails closed on duplicate paths before diagram checks run.
+  - Current validated docs toolchain is `mdbook 0.4.52`, `mdbook-mermaid 0.16.0`, and `mdbook-admonish 1.20.0` with admonish assets version `3.1.0`.
 - 2026-04-22: docs Rhai mutation playground is model-prompt-first.
   - The browser-side mdBook playground prepares constrained prompts and deterministic example drafts; it does not call an LLM directly from the browser.
   - Keep the prompt contract limited to supported Rhai diagram DSL lines (`fn`, `if`, `match`) plus concise explanation text.

--- a/PRD-4.md
+++ b/PRD-4.md
@@ -1,0 +1,461 @@
+# PRD-4: Ontological Traceability Graph and Phi-4 Internal Model Integration
+
+**Status**: Specification - not yet implemented  
+**Target capabilities**: deterministic artifact relationship graph, audit-first visual mapping, host-owned Phi-4 reasoning, typed model job contracts  
+**Author**: Codex  
+**Date**: 2026-04-27
+
+---
+
+## Problem
+
+`l3dg3rr` already has deterministic financial primitives, an MCP ontology surface, a visual workflow language, and a host-owned local Phi-4 direction. These pieces are not yet unified into one internal language for traceable relationships between data artifacts.
+
+Today, ontology facts can be upserted through MCP, but the ontology is not yet automatically produced from core ledger state. Model integration is also split across host runtime, MCP LLM extraction, verification stubs, and deterministic fallback endpoints. This makes it harder to audit why a workbook row exists, which document evidence supports it, which model call suggested a relationship, and which deterministic validator accepted or rejected that suggestion.
+
+The next product phase must make the ontology graph the system's internal audit language and make Phi-4 a supervised local proposer of typed relationship facts, not an authority that mutates financial truth.
+
+## Finished-State Description
+
+Every material artifact in the bookkeeping pipeline is represented as a typed node in a deterministic relationship graph:
+
+- source documents
+- extracted document chunks
+- normalized transaction rows
+- content-hash transaction IDs
+- classification outcomes
+- validation issues
+- evidence references
+- workflow states and tags
+- workbook projection rows
+- audit log events
+- Xero catalog/link entities
+- model job proposals and reviews
+
+Every relationship between those artifacts is represented as a typed edge with deterministic identity and provenance. The graph can be rebuilt from canonical state, exported through MCP, visualized in mdBook/Slint, and queried for evidence chains.
+
+Phi-4 runs through the `ledgerr-host` model boundary and produces typed JSON proposals for tasks such as relationship extraction, classification explanation, rule repair, and evidence-chain summarization. Rust validates every proposal before it becomes ontology state.
+
+Visual diagrams are not optional documentation. Each phase must ship with a diagram that shows the exact relationship flow it introduces, and tests must confirm the diagram source remains aligned with the implemented contract.
+
+---
+
+## North Star Visual
+
+```rhai
+fn source_document() -> document_record
+fn document_record() -> extracted_chunk
+fn extracted_chunk() -> normalized_row
+fn normalized_row() -> transaction_id
+fn transaction_id() -> classification_outcome
+fn classification_outcome() -> validation_issue
+fn validation_issue() -> evidence_reference
+fn evidence_reference() -> workbook_projection
+fn workbook_projection() -> audit_event
+fn transaction_id() -> xero_link_candidate
+fn xero_link_candidate() -> operator_review
+fn operator_review() -> committed_ontology_edge
+fn phi4_typed_job() -> proposed_ontology_edge
+fn proposed_ontology_edge() -> rust_validation_gate
+fn rust_validation_gate() -> committed_ontology_edge
+fn committed_ontology_edge() -> visual_audit_graph
+```
+
+The visual audit graph is the operator-facing proof surface. If an artifact cannot be traced visually back to source evidence and forward to workbook/audit output, the phase is not complete.
+
+---
+
+## Design Principles
+
+- Visual first: every new internal relationship must have a diagram representation before it is considered shippable.
+- Deterministic first: Rust-generated IDs, relation kinds, sort order, and snapshots must be stable across runs.
+- Model as proposer: Phi-4 can propose categories, edges, summaries, and repairs; Rust owns validation and mutation.
+- Host-owned model boundary: no core crate should directly depend on provider-specific clients or raw credentials.
+- Workbook remains CPA-facing truth: ontology and sidecar state explain and replay workbook output; they do not replace it.
+- Provenance is mandatory: every edge must carry evidence/source metadata or an explicit reason why provenance is unavailable.
+- MCP stays compact: expose ontology capabilities through `ledgerr_ontology` actions without expanding the advertised tool catalog.
+
+---
+
+## Phase 1 - Canonical Ontology Core
+
+### Goal
+
+Move the ontology language from an MCP-side implementation detail into a shared deterministic core contract.
+
+### Scope
+
+- Add canonical ontology types to `ledger-core`.
+- Define `ArtifactKind`, `RelationKind`, `ArtifactId`, `RelationId`, `ProvenanceRef`, and `OntologySnapshot`.
+- Preserve existing entity kinds: document, account, institution, transaction, tax category, evidence reference, Xero contact, Xero bank account, Xero invoice, workflow tag.
+- Add artifact kinds for model job, model proposal, workbook row, audit event, validation issue, document chunk, and classification outcome.
+- Replace free-form relation strings in new code with typed relation kinds.
+- Keep `ledgerr-mcp/src/ontology.rs` as transport/storage adapter until it can be fully migrated.
+
+### Required Visual
+
+```rhai
+fn ledger_core_types() -> artifact_kind
+fn ledger_core_types() -> relation_kind
+fn artifact_kind() -> ontology_snapshot
+fn relation_kind() -> ontology_snapshot
+fn ontology_snapshot() -> mcp_transport_adapter
+fn ontology_snapshot() -> visual_audit_graph
+```
+
+### Acceptance Criteria
+
+**AC-4.1.1** - `ledger-core` owns the canonical ontology type definitions and deterministic ID functions.
+
+**AC-4.1.2** - Existing MCP ontology actions continue to accept current payloads, but new internal code maps them into typed core structures.
+
+**AC-4.1.3** - Snapshot serialization is deterministic: repeated builds from equivalent inputs produce byte-identical JSON after formatting.
+
+**AC-4.1.4** - The phase diagram is included in mdBook and renders in both Mermaid and isometric views.
+
+### Required Tests
+
+- `cargo test -p ledger-core ontology_id_is_stable`
+- `cargo test -p ledger-core ontology_snapshot_sorting_is_deterministic`
+- `cargo test -p ledgerr-mcp ontology_legacy_payload_maps_to_core_types`
+- `just docgen-check`
+
+---
+
+## Phase 2 - Automatic Artifact Relationship Emission
+
+### Goal
+
+Make the graph emerge from normal pipeline work instead of relying on manual ontology upserts.
+
+### Scope
+
+- Emit ontology facts during document ingest, PDF ingest, image ingest, row ingest, classification, validation, reconciliation, workbook export, tag changes, and Xero linking.
+- Add a small `OntologyEmitter` trait that accepts typed artifact/edge facts without requiring callers to know storage details.
+- Keep a no-op emitter for tests and CLI paths that do not need ontology output.
+- Persist graph facts next to existing sidecar state where appropriate.
+
+### Required Visual
+
+```rhai
+fn ingest_pdf() -> document_artifact
+fn ingest_pdf() -> raw_context_artifact
+fn document_artifact() -> extracted_row_artifact
+fn extracted_row_artifact() -> transaction_artifact
+fn transaction_artifact() -> classification_artifact
+fn classification_artifact() -> validation_artifact
+fn validation_artifact() -> workbook_row_artifact
+fn workbook_row_artifact() -> audit_event_artifact
+```
+
+### Acceptance Criteria
+
+**AC-4.2.1** - Re-ingesting the same source data does not duplicate ontology nodes or edges.
+
+**AC-4.2.2** - Every inserted transaction has a path from source document or source reference to workbook projection row.
+
+**AC-4.2.3** - Classification and validation edges include confidence and issue metadata.
+
+**AC-4.2.4** - Xero link actions create both document registry links and ontology edges with shared provenance.
+
+**AC-4.2.5** - The operator can export a graph snapshot for a single transaction and inspect it visually.
+
+### Required Tests
+
+- `cargo test -p ledgerr-mcp ingest_pdf_emits_document_to_transaction_edges`
+- `cargo test -p ledgerr-mcp row_reingest_does_not_duplicate_ontology_edges`
+- `cargo test -p ledgerr-mcp classify_transaction_emits_classification_edge`
+- `cargo test -p ledgerr-mcp xero_link_entity_emits_registry_and_ontology_relation`
+- `cargo test -p ledgerr-mcp tax_evidence_chain_contract`
+- `just mcp-cli-basic`
+
+---
+
+## Phase 3 - Visual Audit Graph as a First-Class Product Surface
+
+### Goal
+
+Make relationship traceability inspectable through the existing visual workflow language and desktop host.
+
+### Scope
+
+- Add an ontology-to-diagram adapter that converts snapshots into the supported Rhai diagram DSL.
+- Add graph filters: by transaction ID, document ID, workbook row, tax category, Xero entity, validation issue, and model job.
+- Add visual badges for deterministic facts, model proposals, operator approvals, rejected proposals, and missing provenance.
+- Keep Mermaid as the canonical 2D reference and isometric view as the operator-friendly exploration surface.
+- Add at least one worked audit graph example to mdBook.
+
+### Required Visual
+
+```rhai
+fn ontology_snapshot() -> filter_graph
+match filter.kind => Transaction -> transaction_evidence_view
+match filter.kind => Document -> document_lineage_view
+match filter.kind => XeroEntity -> xero_reconciliation_view
+match filter.kind => ModelJob -> model_proposal_view
+match filter.kind => _ -> full_snapshot_view
+fn transaction_evidence_view() -> mermaid_2d
+fn transaction_evidence_view() -> isometric_3d
+```
+
+### Acceptance Criteria
+
+**AC-4.3.1** - A transaction evidence graph can be rendered from a snapshot without hand-written diagram source.
+
+**AC-4.3.2** - Visual output distinguishes deterministic Rust facts from Phi-4 proposals and operator-approved facts.
+
+**AC-4.3.3** - Missing provenance appears as an explicit warning node, not as absent UI.
+
+**AC-4.3.4** - The same parsed graph drives both Mermaid and isometric rendering.
+
+**AC-4.3.5** - The visual graph has stable node ordering across repeated renders.
+
+### Required Tests
+
+- `cargo test -p ledger-core ontology_snapshot_to_rhai_dsl_is_deterministic`
+- `cargo test -p mdbook-rhai-mermaid ontology_audit_graph_renders_match_nodes`
+- `npm test --prefix book/theme`
+- `just docgen-check`
+- Playwright or equivalent screenshot test for desktop-width and mobile-width graph rendering once the visual route is browser-served.
+
+---
+
+## Phase 4 - Host-Owned Phi-4 Typed Job Runtime
+
+### Goal
+
+Unify internal model calls behind the host runtime and make Phi-4 produce validated typed outputs.
+
+### Scope
+
+- Define typed model jobs:
+  - `ClassifyTransactionJob`
+  - `ProposeOntologyEdgesJob`
+  - `ExplainEvidenceChainJob`
+  - `RepairRuleCandidateJob`
+  - `SummarizeAuditPathJob`
+- Route these through `ledgerr-host/src/agent_runtime.rs`.
+- Prefer `phi-4-mini-reasoning` at `http://127.0.0.1:15115/v1/chat/completions` for local mode.
+- Keep deterministic fallback behavior for tests and no-model environments.
+- Record model-call metadata through `ModelAuditSink` without raw prompt or response body.
+- Migrate or wrap `ledgerr-llm` so extraction/classification uses the same audit and settings path.
+
+### Required Visual
+
+```rhai
+fn typed_model_job() -> host_agent_runtime
+fn host_agent_runtime() -> phi4_local_endpoint
+fn phi4_local_endpoint() -> structured_json_response
+fn structured_json_response() -> schema_validation
+fn schema_validation() -> invariant_validation
+fn invariant_validation() -> ontology_proposal
+fn ontology_proposal() -> operator_or_policy_gate
+fn operator_or_policy_gate() -> committed_ontology_edge
+```
+
+### Acceptance Criteria
+
+**AC-4.4.1** - Core pipeline code depends on a model trait, not a provider-specific HTTP client.
+
+**AC-4.4.2** - Every typed job has a JSON schema, a parser test, and a validator test.
+
+**AC-4.4.3** - Invalid model output fails closed and produces an audit event.
+
+**AC-4.4.4** - The local Phi-4 endpoint and deterministic fallback both satisfy the same typed job contract.
+
+**AC-4.4.5** - Prompt and response content are not written to audit logs by default.
+
+### Required Tests
+
+- `cargo test -p ledgerr-host agent_runtime_parses_typed_phi4_job`
+- `cargo test -p ledgerr-host model_audit_records_metadata_without_content`
+- `cargo test -p ledgerr-host internal_phi_endpoint_satisfies_typed_job_contract`
+- `cargo test -p ledger-core verify_phi4_profile_uses_local_model_defaults`
+- `just test-phi4` when model assets are available
+- `just test-phi4-mistral` when model assets and native build prerequisites are available
+
+---
+
+## Phase 5 - Proposal Review, Approval, and Deterministic Commit
+
+### Goal
+
+Let Phi-4 enrich the ontology without bypassing financial invariants, operator policy, or auditability.
+
+### Scope
+
+- Add proposal state: proposed, validated, rejected, approved, committed.
+- Require validation before an edge can be committed.
+- Require operator approval for ambiguous, low-confidence, credential-adjacent, Xero-mutating, or workbook-mutating proposals.
+- Add reviewer model support through the existing multi-model verification loop, with Phi-4 as the default local proposer.
+- Preserve rejected proposals as audit artifacts when useful for review, without polluting committed relationship paths.
+
+### Required Visual
+
+```rhai
+fn phi4_proposal() -> parse_typed_output
+fn parse_typed_output() -> rust_invariant_check
+if confidence >= 0.90 -> policy_gate
+if confidence < 0.90 -> operator_review
+fn policy_gate() -> committed_edge
+fn operator_review() -> approved_edge
+fn operator_review() -> rejected_proposal
+fn approved_edge() -> committed_edge
+fn rejected_proposal() -> audit_event
+```
+
+### Acceptance Criteria
+
+**AC-4.5.1** - No model proposal can directly mutate workbook, journal, credential, or Xero state.
+
+**AC-4.5.2** - Rejected proposals remain queryable by audit tools but are excluded from committed evidence chains by default.
+
+**AC-4.5.3** - Approved proposals include actor, timestamp, model metadata, validation result, and source artifact IDs.
+
+**AC-4.5.4** - Confidence thresholds are configurable but have safe defaults.
+
+**AC-4.5.5** - The approval path is visible in the graph.
+
+### Required Tests
+
+- `cargo test -p ledger-core model_proposal_cannot_commit_without_validation`
+- `cargo test -p ledgerr-mcp rejected_proposal_excluded_from_default_evidence_chain`
+- `cargo test -p ledgerr-mcp approved_proposal_preserves_model_and_actor_metadata`
+- `cargo test -p ledger-core low_confidence_proposal_requires_operator_review`
+- `just mcp-cli-spinning-wheels`
+
+---
+
+## Phase 6 - Semantic Retrieval and Rule Selection
+
+### Goal
+
+Use local model-powered retrieval to improve classification and evidence matching while keeping deterministic rules authoritative.
+
+### Scope
+
+- Add embeddings for transaction descriptions, document chunks, rule descriptions, prior classifications, and Xero catalog entities.
+- Build a local vector index for candidate retrieval.
+- Feed retrieved candidates into Phi-4 typed jobs as context.
+- Keep Rhai waterfall and Rust validators as final authority.
+- Record which retrieved candidates influenced a model proposal.
+
+### Required Visual
+
+```rhai
+fn document_chunk() -> embedding_record
+fn transaction_description() -> embedding_record
+fn rule_registry() -> embedding_record
+fn embedding_record() -> local_vector_index
+fn local_vector_index() -> candidate_context
+fn candidate_context() -> phi4_typed_job
+fn phi4_typed_job() -> validated_classification
+fn validated_classification() -> ontology_edge
+```
+
+### Acceptance Criteria
+
+**AC-4.6.1** - Retrieval is local-first and does not require cloud services.
+
+**AC-4.6.2** - The semantic selector never bypasses Rhai classification invariants or validation gates.
+
+**AC-4.6.3** - Candidate context is traceable: retrieved item IDs are attached to proposal provenance.
+
+**AC-4.6.4** - Rebuilding the index from the same inputs yields stable item IDs and stable top-k ordering for equal scores.
+
+### Required Tests
+
+- `cargo test -p ledger-core semantic_candidate_ids_are_stable`
+- `cargo test -p ledger-core semantic_selector_preserves_deterministic_fallback`
+- `cargo test -p ledgerr-mcp semantic_context_refs_are_added_to_model_provenance`
+- `cargo test -p ledger-core rule_registry_waterfall_remains_authoritative`
+
+---
+
+## Phase 7 - End-to-End Audit Playbook
+
+### Goal
+
+Ship a complete operator-facing audit path from document ingest to visual evidence graph to workbook export.
+
+### Scope
+
+- Add a sample dataset that exercises document ingest, row normalization, classification, validation issue, Xero candidate link, model proposal, approval/rejection, workbook projection, and audit graph export.
+- Add mdBook playbook chapter for the scenario.
+- Add MCP CLI flow for both happy path and blocked diagnostic path.
+- Add Slint host route or local docs route that opens the visual graph for the sample transaction.
+
+### Required Visual
+
+```rhai
+fn sample_statement() -> ingest_rows
+fn ingest_rows() -> classify_transactions
+fn classify_transactions() -> phi4_edge_proposals
+fn phi4_edge_proposals() -> operator_review
+fn operator_review() -> workbook_export
+fn workbook_export() -> evidence_chain
+fn evidence_chain() -> visual_audit_graph
+fn visual_audit_graph() -> cpa_review
+```
+
+### Acceptance Criteria
+
+**AC-4.7.1** - A fresh checkout can run the basic audit playbook without a real model by using deterministic fallback responses.
+
+**AC-4.7.2** - The same playbook can run with real Phi-4 when model assets are present.
+
+**AC-4.7.3** - The output workbook, audit log, ontology snapshot, and visual graph all refer to the same transaction IDs.
+
+**AC-4.7.4** - The blocked diagnostic path demonstrates a failed or low-confidence proposal and shows how the operator resolves it.
+
+**AC-4.7.5** - Documentation links the playbook to the MCP surface, ontology type mesh, workflow, and workbook audit chapters.
+
+### Required Tests
+
+- `just test`
+- `just mcp-cli-basic`
+- `just mcp-cli-spinning-wheels`
+- `just docgen-check`
+- `cargo test -p ledgerr-mcp audit_playbook_ids_match_across_workbook_ontology_and_events`
+- `cargo test -p ledgerr-host internal_phi_fallback_runs_audit_playbook_prompt`
+
+---
+
+## Cross-Phase Test Gates
+
+Every phase must complete these checks before being considered done:
+
+- Unit tests for newly introduced types and validators.
+- Integration test proving deterministic replay for the touched artifact path.
+- MCP contract test if any transport payload changes.
+- Visual diagram test or docgen test for every new relationship flow.
+- Audit test proving provenance is present or an explicit missing-provenance warning is emitted.
+- `just docgen-check` when docs or visual DSL examples change.
+- `just test` before merging implementation work.
+
+When model behavior is involved, both paths must be tested:
+
+- deterministic fallback path, always required in CI;
+- real Phi-4 path, required on machines with local model assets.
+
+---
+
+## Non-Goals
+
+- Replacing Excel as the CPA-facing artifact.
+- Giving Phi-4 direct write access to workbook, journal, credentials, or Xero.
+- Expanding the default MCP catalog beyond the collapsed `ledgerr_*` capability families.
+- Storing raw prompts or raw model responses in audit logs by default.
+- Requiring cloud services for the core audit path.
+- Building a generic knowledge graph product outside bookkeeping and audit traceability.
+
+---
+
+## Open Questions
+
+- Should the canonical ontology snapshot live beside the manifest workbook, inside the existing deterministic sidecar, or both?
+- Should model proposals be retained forever as audit artifacts, or pruned after workbook export with a digest retained?
+- Which local embedding backend should be preferred for Phase 6: fastembed/ONNX, Phi-derived embeddings, or a simpler lexical baseline first?
+- Should Slint show the graph through native Rust rendering, the existing docs browser route, or both?
+- Which ontology relations should be hard-coded typed enums immediately, and which should remain extension points for imported Xero/accounting concepts?
+

--- a/book/book.toml
+++ b/book/book.toml
@@ -6,7 +6,7 @@ title = "l3dg3rr Ledger Documentation"
 
 [preprocessor.admonish]
 command = "mdbook-admonish"
-assets_version = "2.0.0" # do not edit: managed by `mdbook-admonish install`
+assets_version = "3.1.0" # do not edit: managed by `mdbook-admonish install`
 
 [preprocessor.rhai-mermaid]
 command = "mdbook-rhai-mermaid"
@@ -20,4 +20,4 @@ after = ["rhai-mermaid", "admonish"]
 edit-url-template = "https://github.com/PromptExecution/l3dg3rr/edit/main/book/src/{path}#L{line}"
 git-repository-url = "https://github.com/PromptExecution/l3dg3rr"
 additional-js = ["theme/rhai-live-core.js", "theme/rhai-live.js", "theme/mdbook-nav-override.js"]
-additional-css = ["theme/rhai-live.css", "theme/mdbook-admonish.css"]
+additional-css = ["theme/rhai-live.css", "mdbook-admonish.css"]

--- a/book/mdbook-admonish.css
+++ b/book/mdbook-admonish.css
@@ -1,0 +1,356 @@
+@charset "UTF-8";
+:is(.admonition) {
+  display: flow-root;
+  margin: 1.5625em 0;
+  padding: 0 1.2rem;
+  color: var(--fg);
+  page-break-inside: avoid;
+  background-color: var(--bg);
+  border: 0 solid black;
+  border-inline-start-width: 0.4rem;
+  border-radius: 0.2rem;
+  box-shadow: 0 0.2rem 1rem rgba(0, 0, 0, 0.05), 0 0 0.1rem rgba(0, 0, 0, 0.1);
+}
+@media print {
+  :is(.admonition) {
+    box-shadow: none;
+  }
+}
+:is(.admonition) > * {
+  box-sizing: border-box;
+}
+:is(.admonition) :is(.admonition) {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+:is(.admonition) > .tabbed-set:only-child {
+  margin-top: 0;
+}
+html :is(.admonition) > :last-child {
+  margin-bottom: 1.2rem;
+}
+
+a.admonition-anchor-link {
+  display: none;
+  position: absolute;
+  left: -1.2rem;
+  padding-right: 1rem;
+}
+a.admonition-anchor-link:link, a.admonition-anchor-link:visited {
+  color: var(--fg);
+}
+a.admonition-anchor-link:link:hover, a.admonition-anchor-link:visited:hover {
+  text-decoration: none;
+}
+a.admonition-anchor-link::before {
+  content: "§";
+}
+
+:is(.admonition-title, summary.admonition-title) {
+  position: relative;
+  min-height: 4rem;
+  margin-block: 0;
+  margin-inline: -1.6rem -1.2rem;
+  padding-block: 0.8rem;
+  padding-inline: 4.4rem 1.2rem;
+  font-weight: 700;
+  background-color: rgba(68, 138, 255, 0.1);
+  print-color-adjust: exact;
+  -webkit-print-color-adjust: exact;
+  display: flex;
+}
+:is(.admonition-title, summary.admonition-title) p {
+  margin: 0;
+}
+html :is(.admonition-title, summary.admonition-title):last-child {
+  margin-bottom: 0;
+}
+:is(.admonition-title, summary.admonition-title)::before {
+  position: absolute;
+  top: 0.625em;
+  inset-inline-start: 1.6rem;
+  width: 2rem;
+  height: 2rem;
+  background-color: #448aff;
+  print-color-adjust: exact;
+  -webkit-print-color-adjust: exact;
+  mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"></svg>');
+  -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"></svg>');
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  content: "";
+}
+:is(.admonition-title, summary.admonition-title):hover a.admonition-anchor-link {
+  display: initial;
+}
+
+@media print {
+  details.admonition::details-content {
+    display: contents;
+  }
+}
+details.admonition > summary.admonition-title::after {
+  position: absolute;
+  top: 0.625em;
+  inset-inline-end: 1.6rem;
+  height: 2rem;
+  width: 2rem;
+  background-color: currentcolor;
+  mask-image: var(--md-details-icon);
+  -webkit-mask-image: var(--md-details-icon);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  content: "";
+  transform: rotate(0deg);
+  transition: transform 0.25s;
+}
+details[open].admonition > summary.admonition-title::after {
+  transform: rotate(90deg);
+}
+summary.admonition-title::-webkit-details-marker {
+  display: none;
+}
+
+:root {
+  --md-details-icon: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M8.59 16.58 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42Z'/></svg>");
+}
+
+:root {
+  --md-admonition-icon--admonish-note: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M20.71 7.04c.39-.39.39-1.04 0-1.41l-2.34-2.34c-.37-.39-1.02-.39-1.41 0l-1.84 1.83 3.75 3.75M3 17.25V21h3.75L17.81 9.93l-3.75-3.75L3 17.25z'/></svg>");
+  --md-admonition-icon--admonish-abstract: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M17 9H7V7h10m0 6H7v-2h10m-3 6H7v-2h7M12 3a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1m7 0h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2z'/></svg>");
+  --md-admonition-icon--admonish-info: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 9h-2V7h2m0 10h-2v-6h2m-1-9A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z'/></svg>");
+  --md-admonition-icon--admonish-tip: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M17.66 11.2c-.23-.3-.51-.56-.77-.82-.67-.6-1.43-1.03-2.07-1.66C13.33 7.26 13 4.85 13.95 3c-.95.23-1.78.75-2.49 1.32-2.59 2.08-3.61 5.75-2.39 8.9.04.1.08.2.08.33 0 .22-.15.42-.35.5-.23.1-.47.04-.66-.12a.58.58 0 0 1-.14-.17c-1.13-1.43-1.31-3.48-.55-5.12C5.78 10 4.87 12.3 5 14.47c.06.5.12 1 .29 1.5.14.6.41 1.2.71 1.73 1.08 1.73 2.95 2.97 4.96 3.22 2.14.27 4.43-.12 6.07-1.6 1.83-1.66 2.47-4.32 1.53-6.6l-.13-.26c-.21-.46-.77-1.26-.77-1.26m-3.16 6.3c-.28.24-.74.5-1.1.6-1.12.4-2.24-.16-2.9-.82 1.19-.28 1.9-1.16 2.11-2.05.17-.8-.15-1.46-.28-2.23-.12-.74-.1-1.37.17-2.06.19.38.39.76.63 1.06.77 1 1.98 1.44 2.24 2.8.04.14.06.28.06.43.03.82-.33 1.72-.93 2.27z'/></svg>");
+  --md-admonition-icon--admonish-success: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='m9 20.42-6.21-6.21 2.83-2.83L9 14.77l9.88-9.89 2.83 2.83L9 20.42z'/></svg>");
+  --md-admonition-icon--admonish-question: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='m15.07 11.25-.9.92C13.45 12.89 13 13.5 13 15h-2v-.5c0-1.11.45-2.11 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41a2 2 0 0 0-2-2 2 2 0 0 0-2 2H8a4 4 0 0 1 4-4 4 4 0 0 1 4 4 3.2 3.2 0 0 1-.93 2.25M13 19h-2v-2h2M12 2A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10c0-5.53-4.5-10-10-10z'/></svg>");
+  --md-admonition-icon--admonish-warning: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 14h-2V9h2m0 9h-2v-2h2M1 21h22L12 2 1 21z'/></svg>");
+  --md-admonition-icon--admonish-failure: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M20 6.91 17.09 4 12 9.09 6.91 4 4 6.91 9.09 12 4 17.09 6.91 20 12 14.91 17.09 20 20 17.09 14.91 12 20 6.91z'/></svg>");
+  --md-admonition-icon--admonish-danger: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M11 15H6l7-14v8h5l-7 14v-8z'/></svg>");
+  --md-admonition-icon--admonish-bug: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 12h-4v-2h4m0 6h-4v-2h4m6-6h-2.81a5.985 5.985 0 0 0-1.82-1.96L17 4.41 15.59 3l-2.17 2.17a6.002 6.002 0 0 0-2.83 0L8.41 3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05.33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21 5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8z'/></svg>");
+  --md-admonition-icon--admonish-example: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M7 13v-2h14v2H7m0 6v-2h14v2H7M7 7V5h14v2H7M3 8V5H2V4h2v4H3m-1 9v-1h3v4H2v-1h2v-.5H3v-1h1V17H2m2.25-7a.75.75 0 0 1 .75.75c0 .2-.08.39-.21.52L3.12 13H5v1H2v-.92L4 11H2v-1h2.25z'/></svg>");
+  --md-admonition-icon--admonish-quote: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 17h3l2-4V7h-6v6h3M6 17h3l2-4V7H5v6h3l-2 4z'/></svg>");
+}
+
+:is(.admonition):is(.admonish-note) {
+  border-color: #448aff;
+}
+
+:is(.admonish-note) > :is(.admonition-title, summary.admonition-title) {
+  background-color: rgba(68, 138, 255, 0.1);
+}
+:is(.admonish-note) > :is(.admonition-title, summary.admonition-title)::before {
+  background-color: #448aff;
+  mask-image: var(--md-admonition-icon--admonish-note);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-note);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.admonish-abstract, .admonish-summary, .admonish-tldr) {
+  border-color: #00b0ff;
+}
+
+:is(.admonish-abstract, .admonish-summary, .admonish-tldr) > :is(.admonition-title, summary.admonition-title) {
+  background-color: rgba(0, 176, 255, 0.1);
+}
+:is(.admonish-abstract, .admonish-summary, .admonish-tldr) > :is(.admonition-title, summary.admonition-title)::before {
+  background-color: #00b0ff;
+  mask-image: var(--md-admonition-icon--admonish-abstract);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-abstract);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.admonish-info, .admonish-todo) {
+  border-color: #00b8d4;
+}
+
+:is(.admonish-info, .admonish-todo) > :is(.admonition-title, summary.admonition-title) {
+  background-color: rgba(0, 184, 212, 0.1);
+}
+:is(.admonish-info, .admonish-todo) > :is(.admonition-title, summary.admonition-title)::before {
+  background-color: #00b8d4;
+  mask-image: var(--md-admonition-icon--admonish-info);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-info);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.admonish-tip, .admonish-hint, .admonish-important) {
+  border-color: #00bfa5;
+}
+
+:is(.admonish-tip, .admonish-hint, .admonish-important) > :is(.admonition-title, summary.admonition-title) {
+  background-color: rgba(0, 191, 165, 0.1);
+}
+:is(.admonish-tip, .admonish-hint, .admonish-important) > :is(.admonition-title, summary.admonition-title)::before {
+  background-color: #00bfa5;
+  mask-image: var(--md-admonition-icon--admonish-tip);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-tip);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.admonish-success, .admonish-check, .admonish-done) {
+  border-color: #00c853;
+}
+
+:is(.admonish-success, .admonish-check, .admonish-done) > :is(.admonition-title, summary.admonition-title) {
+  background-color: rgba(0, 200, 83, 0.1);
+}
+:is(.admonish-success, .admonish-check, .admonish-done) > :is(.admonition-title, summary.admonition-title)::before {
+  background-color: #00c853;
+  mask-image: var(--md-admonition-icon--admonish-success);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-success);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.admonish-question, .admonish-help, .admonish-faq) {
+  border-color: #64dd17;
+}
+
+:is(.admonish-question, .admonish-help, .admonish-faq) > :is(.admonition-title, summary.admonition-title) {
+  background-color: rgba(100, 221, 23, 0.1);
+}
+:is(.admonish-question, .admonish-help, .admonish-faq) > :is(.admonition-title, summary.admonition-title)::before {
+  background-color: #64dd17;
+  mask-image: var(--md-admonition-icon--admonish-question);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-question);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.admonish-warning, .admonish-caution, .admonish-attention) {
+  border-color: #ff9100;
+}
+
+:is(.admonish-warning, .admonish-caution, .admonish-attention) > :is(.admonition-title, summary.admonition-title) {
+  background-color: rgba(255, 145, 0, 0.1);
+}
+:is(.admonish-warning, .admonish-caution, .admonish-attention) > :is(.admonition-title, summary.admonition-title)::before {
+  background-color: #ff9100;
+  mask-image: var(--md-admonition-icon--admonish-warning);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-warning);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.admonish-failure, .admonish-fail, .admonish-missing) {
+  border-color: #ff5252;
+}
+
+:is(.admonish-failure, .admonish-fail, .admonish-missing) > :is(.admonition-title, summary.admonition-title) {
+  background-color: rgba(255, 82, 82, 0.1);
+}
+:is(.admonish-failure, .admonish-fail, .admonish-missing) > :is(.admonition-title, summary.admonition-title)::before {
+  background-color: #ff5252;
+  mask-image: var(--md-admonition-icon--admonish-failure);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-failure);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.admonish-danger, .admonish-error) {
+  border-color: #ff1744;
+}
+
+:is(.admonish-danger, .admonish-error) > :is(.admonition-title, summary.admonition-title) {
+  background-color: rgba(255, 23, 68, 0.1);
+}
+:is(.admonish-danger, .admonish-error) > :is(.admonition-title, summary.admonition-title)::before {
+  background-color: #ff1744;
+  mask-image: var(--md-admonition-icon--admonish-danger);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-danger);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.admonish-bug) {
+  border-color: #f50057;
+}
+
+:is(.admonish-bug) > :is(.admonition-title, summary.admonition-title) {
+  background-color: rgba(245, 0, 87, 0.1);
+}
+:is(.admonish-bug) > :is(.admonition-title, summary.admonition-title)::before {
+  background-color: #f50057;
+  mask-image: var(--md-admonition-icon--admonish-bug);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-bug);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.admonish-example) {
+  border-color: #7c4dff;
+}
+
+:is(.admonish-example) > :is(.admonition-title, summary.admonition-title) {
+  background-color: rgba(124, 77, 255, 0.1);
+}
+:is(.admonish-example) > :is(.admonition-title, summary.admonition-title)::before {
+  background-color: #7c4dff;
+  mask-image: var(--md-admonition-icon--admonish-example);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-example);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.admonish-quote, .admonish-cite) {
+  border-color: #9e9e9e;
+}
+
+:is(.admonish-quote, .admonish-cite) > :is(.admonition-title, summary.admonition-title) {
+  background-color: rgba(158, 158, 158, 0.1);
+}
+:is(.admonish-quote, .admonish-cite) > :is(.admonition-title, summary.admonition-title)::before {
+  background-color: #9e9e9e;
+  mask-image: var(--md-admonition-icon--admonish-quote);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-quote);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+.navy :is(.admonition) {
+  background-color: var(--sidebar-bg);
+}
+
+.ayu :is(.admonition),
+.coal :is(.admonition) {
+  background-color: var(--theme-hover);
+}
+
+.rust :is(.admonition) {
+  background-color: var(--sidebar-bg);
+  color: var(--sidebar-fg);
+}
+.rust .admonition-anchor-link:link, .rust .admonition-anchor-link:visited {
+  color: var(--sidebar-fg);
+}

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -5,6 +5,7 @@
 # Operator Capabilities
 
 - [Capability Map](./capability-map.md)
+- [Audit Playbook](./audit-playbook.md)
 - [Document Ingestion](./document-ingestion.md)
 - [Rule Engine](./rule-engine.md)
 - [Validation](./validation.md)
@@ -35,8 +36,3 @@
 - [Renderer](./render.md)
 - [Slint Visualization](./slint_viz.md)
 - [Match Visualization Plan](./match-visualization-plan.md)
-- [Business Calendar](./calendar.md)
-- [Ledger Operations](./ledger-ops.md)
-- [Capability Map](./capability-map.md)
-- [Type Compatibility](./type-compatibility.md)
-- [Concept Affinity](./concept-affinity.md)

--- a/book/src/audit-playbook.md
+++ b/book/src/audit-playbook.md
@@ -1,0 +1,50 @@
+# Audit Playbook
+
+This playbook is the PRD-4 end-to-end operator path. It proves that a sample
+statement row, workbook projection, ontology snapshot, audit events, and visual
+graph all carry the same transaction identity.
+
+```rhai
+fn sample_statement() -> ingest_rows
+fn ingest_rows() -> classify_transactions
+fn classify_transactions() -> phi4_edge_proposals
+fn phi4_edge_proposals() -> operator_review
+fn operator_review() -> workbook_export
+fn workbook_export() -> evidence_chain
+fn evidence_chain() -> visual_audit_graph
+fn visual_audit_graph() -> cpa_review
+```
+
+## Runnable Paths
+
+Basic deterministic path:
+
+```sh
+just mcp-cli-basic
+```
+
+Blocked diagnostic path:
+
+```sh
+just mcp-cli-spinning-wheels
+```
+
+Host playbook path with deterministic Phi-4 fallback:
+
+```sh
+just host-playbook-window
+```
+
+Host playbook path with local Phi-4 model assets:
+
+```sh
+just host-playbook-window-phi4
+```
+
+## Related Chapters
+
+- [Capability Map](./capability-map.md)
+- [MCP Surface](./mcp-surface.md)
+- [Ontology & Type Mesh](./ontology-type-mesh.md)
+- [Workbook & Audit](./workbook-audit.md)
+- [Visualization](./visualize.md)

--- a/book/src/capability-map.md
+++ b/book/src/capability-map.md
@@ -30,6 +30,128 @@ fn xero_catalog() -> reconciliation_candidates
 fn ledgerr_mcp_contract() -> agent_runtime
 ```
 
+## PRD-4 Phase 1: Canonical Ontology Core
+
+The first PRD-4 implementation slice makes `ledger-core` the canonical owner of
+ontology artifact and relation primitives while preserving the legacy MCP storage
+shape for compatibility.
+
+```rhai
+fn ledger_core_types() -> artifact_kind
+fn ledger_core_types() -> relation_kind
+fn artifact_kind() -> ontology_snapshot
+fn relation_kind() -> ontology_snapshot
+fn ontology_snapshot() -> mcp_transport_adapter
+fn ontology_snapshot() -> visual_audit_graph
+```
+
+## PRD-4 Phase 2: Automatic Artifact Relationship Emission
+
+The second PRD-4 implementation slice makes ontology facts emerge from normal
+pipeline work: ingest, classification, validation, workbook projection, audit
+events, and integration links emit typed artifact relationships instead of
+requiring manual ontology upserts.
+
+```rhai
+fn ingest_pdf() -> document_artifact
+fn ingest_pdf() -> raw_context_artifact
+fn document_artifact() -> extracted_row_artifact
+fn extracted_row_artifact() -> transaction_artifact
+fn transaction_artifact() -> classification_artifact
+fn classification_artifact() -> validation_artifact
+fn validation_artifact() -> workbook_row_artifact
+fn workbook_row_artifact() -> audit_event_artifact
+```
+
+## PRD-4 Phase 3: Visual Audit Graph
+
+The third PRD-4 implementation slice turns canonical ontology snapshots into the
+supported Rhai diagram DSL so the same graph can be rendered by Mermaid and the
+isometric live editor without hand-written diagram source.
+
+```rhai
+fn ontology_snapshot() -> filter_graph
+match filter.kind => Transaction -> transaction_evidence_view
+match filter.kind => Document -> document_lineage_view
+match filter.kind => XeroEntity -> xero_reconciliation_view
+match filter.kind => ModelJob -> model_proposal_view
+match filter.kind => _ -> full_snapshot_view
+fn transaction_evidence_view() -> mermaid_2d
+fn transaction_evidence_view() -> isometric_3d
+```
+
+## PRD-4 Phase 4: Typed Phi-4 Job Runtime
+
+The fourth PRD-4 implementation slice keeps model integration host-owned and
+schema-bound: Phi-4 receives a typed job request, returns only JSON, and the host
+validates the response before any ontology proposal can become an auditable fact.
+
+```rhai
+fn typed_model_job() -> host_agent_runtime
+fn host_agent_runtime() -> phi4_local_endpoint
+fn phi4_local_endpoint() -> structured_json_response
+fn structured_json_response() -> schema_validation
+fn schema_validation() -> invariant_validation
+fn invariant_validation() -> ontology_proposal
+fn ontology_proposal() -> operator_or_policy_gate
+fn operator_or_policy_gate() -> committed_ontology_edge
+```
+
+## PRD-4 Phase 5: Proposal Review and Commit
+
+The fifth PRD-4 implementation slice gives model-suggested ontology relations a
+deterministic lifecycle. Phi-4 can propose an edge, but Rust validation, policy
+thresholds, and operator approval decide whether that edge becomes committed
+ontology state.
+
+```rhai
+fn phi4_proposal() -> parse_typed_output
+fn parse_typed_output() -> rust_invariant_check
+if confidence >= 0.90 -> policy_gate
+if confidence < 0.90 -> operator_review
+fn policy_gate() -> committed_edge
+fn operator_review() -> approved_edge
+fn operator_review() -> rejected_proposal
+fn approved_edge() -> committed_edge
+fn rejected_proposal() -> audit_event
+```
+
+## PRD-4 Phase 6: Local Semantic Retrieval
+
+The sixth PRD-4 implementation slice introduces a local retrieval index for rule
+and evidence candidates. The first implementation uses deterministic lexical
+records as the fallback index so later model embeddings can improve ranking
+without changing candidate IDs, provenance, or Rhai authority.
+
+```rhai
+fn document_chunk() -> embedding_record
+fn transaction_description() -> embedding_record
+fn rule_registry() -> embedding_record
+fn embedding_record() -> local_vector_index
+fn local_vector_index() -> candidate_context
+fn candidate_context() -> phi4_typed_job
+fn phi4_typed_job() -> validated_classification
+fn validated_classification() -> ontology_edge
+```
+
+## PRD-4 Phase 7: End-to-End Audit Playbook
+
+The seventh PRD-4 implementation slice ties a sample statement flow to the
+operator-facing proof surface: ingest creates the transaction identity, workbook
+export and audit events preserve it, ontology explains it, and the visual graph
+shows the path for CPA review.
+
+```rhai
+fn sample_statement() -> ingest_rows
+fn ingest_rows() -> classify_transactions
+fn classify_transactions() -> phi4_edge_proposals
+fn phi4_edge_proposals() -> operator_review
+fn operator_review() -> workbook_export
+fn workbook_export() -> evidence_chain
+fn evidence_chain() -> visual_audit_graph
+fn visual_audit_graph() -> cpa_review
+```
+
 ## Component Status Table
 
 | Component | Module | Status | Notes |

--- a/crates/ledger-core/src/lib.rs
+++ b/crates/ledger-core/src/lib.rs
@@ -8,11 +8,13 @@ pub mod fs_meta;
 pub mod graph;
 pub mod ingest;
 pub mod journal;
+pub mod layout;
 pub mod ledger_ops;
 pub mod legal;
-pub mod layout;
 pub mod manifest;
+pub mod ontology;
 pub mod pipeline;
+pub mod proposal;
 pub mod render;
 pub mod rule_registry;
 pub mod slint_viz;
@@ -23,8 +25,8 @@ pub mod visualize;
 pub mod workbook;
 pub mod workflow;
 
-pub use graph::{NodeData, EdgeData, create_pipeline_nodes, create_pipeline_edges};
-pub use layout::{ForceLayout, iso_project};
+pub use graph::{create_pipeline_edges, create_pipeline_nodes, EdgeData, NodeData};
+pub use layout::{iso_project, ForceLayout};
 pub use render::GraphRenderer;
 pub use slint_viz::SlintGraphView;
 

--- a/crates/ledger-core/src/ontology.rs
+++ b/crates/ledger-core/src/ontology.rs
@@ -1,0 +1,423 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactKind {
+    Document,
+    Account,
+    Institution,
+    Transaction,
+    TaxCategory,
+    EvidenceReference,
+    XeroContact,
+    XeroBankAccount,
+    XeroInvoice,
+    WorkflowTag,
+    ModelJob,
+    ModelProposal,
+    WorkbookRow,
+    AuditEvent,
+    ValidationIssue,
+    DocumentChunk,
+    ClassificationOutcome,
+}
+
+impl ArtifactKind {
+    pub fn canonical_name(self) -> &'static str {
+        match self {
+            Self::Document => "document",
+            Self::Account => "account",
+            Self::Institution => "institution",
+            Self::Transaction => "transaction",
+            Self::TaxCategory => "tax_category",
+            Self::EvidenceReference => "evidence_reference",
+            Self::XeroContact => "xero_contact",
+            Self::XeroBankAccount => "xero_bank_account",
+            Self::XeroInvoice => "xero_invoice",
+            Self::WorkflowTag => "workflow_tag",
+            Self::ModelJob => "model_job",
+            Self::ModelProposal => "model_proposal",
+            Self::WorkbookRow => "workbook_row",
+            Self::AuditEvent => "audit_event",
+            Self::ValidationIssue => "validation_issue",
+            Self::DocumentChunk => "document_chunk",
+            Self::ClassificationOutcome => "classification_outcome",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RelationKind {
+    DocumentsTransaction,
+    LinksEvidence,
+    LinksTaxCategory,
+    DerivedFrom,
+    ClassifiedAs,
+    ValidatedBy,
+    ProjectsTo,
+    RecordedIn,
+    ProposedByModel,
+    ReviewedByOperator,
+    ApprovedAs,
+    RejectedAs,
+    LinkedToXero,
+    TaggedAs,
+    References,
+    RelatedTo,
+}
+
+impl RelationKind {
+    pub fn canonical_name(self) -> &'static str {
+        match self {
+            Self::DocumentsTransaction => "documents_transaction",
+            Self::LinksEvidence => "links_evidence",
+            Self::LinksTaxCategory => "links_tax_category",
+            Self::DerivedFrom => "derived_from",
+            Self::ClassifiedAs => "classified_as",
+            Self::ValidatedBy => "validated_by",
+            Self::ProjectsTo => "projects_to",
+            Self::RecordedIn => "recorded_in",
+            Self::ProposedByModel => "proposed_by_model",
+            Self::ReviewedByOperator => "reviewed_by_operator",
+            Self::ApprovedAs => "approved_as",
+            Self::RejectedAs => "rejected_as",
+            Self::LinkedToXero => "linked_to_xero",
+            Self::TaggedAs => "tagged_as",
+            Self::References => "references",
+            Self::RelatedTo => "related_to",
+        }
+    }
+}
+
+impl std::str::FromStr for RelationKind {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "documents_transaction" => Ok(Self::DocumentsTransaction),
+            "links_evidence" => Ok(Self::LinksEvidence),
+            "links_tax_category" => Ok(Self::LinksTaxCategory),
+            "derived_from" => Ok(Self::DerivedFrom),
+            "classified_as" => Ok(Self::ClassifiedAs),
+            "validated_by" => Ok(Self::ValidatedBy),
+            "projects_to" => Ok(Self::ProjectsTo),
+            "recorded_in" => Ok(Self::RecordedIn),
+            "proposed_by_model" => Ok(Self::ProposedByModel),
+            "reviewed_by_operator" => Ok(Self::ReviewedByOperator),
+            "approved_as" => Ok(Self::ApprovedAs),
+            "rejected_as" => Ok(Self::RejectedAs),
+            "linked_to_xero" => Ok(Self::LinkedToXero),
+            "tagged_as" => Ok(Self::TaggedAs),
+            "references" => Ok(Self::References),
+            "related_to" => Ok(Self::RelatedTo),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Artifact {
+    pub id: String,
+    pub kind: ArtifactKind,
+    pub attrs: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Relation {
+    pub id: String,
+    pub from: String,
+    pub to: String,
+    pub relation: String,
+    pub provenance: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProvenanceRef {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct OntologySnapshot {
+    pub artifacts: Vec<Artifact>,
+    pub relations: Vec<Relation>,
+}
+
+impl OntologySnapshot {
+    pub fn sort_deterministic(&mut self) {
+        self.artifacts
+            .sort_by(|a, b| (a.kind, &a.id).cmp(&(b.kind, &b.id)));
+        self.relations.sort_by(|a, b| {
+            (&a.relation, &a.from, &a.to, &a.id).cmp(&(&b.relation, &b.from, &b.to, &b.id))
+        });
+    }
+
+    pub fn to_pretty_json_stable(&self) -> Result<String, serde_json::Error> {
+        let mut snapshot = self.clone();
+        snapshot.sort_deterministic();
+        serde_json::to_string_pretty(&snapshot)
+    }
+
+    pub fn to_rhai_dsl(&self) -> String {
+        let mut snapshot = self.clone();
+        snapshot.sort_deterministic();
+        let artifacts = snapshot
+            .artifacts
+            .iter()
+            .map(|artifact| (artifact.id.as_str(), artifact))
+            .collect::<BTreeMap<_, _>>();
+        let mut lines = Vec::new();
+
+        for relation in &snapshot.relations {
+            let Some(from) = artifacts.get(relation.from.as_str()) else {
+                continue;
+            };
+            let Some(to) = artifacts.get(relation.to.as_str()) else {
+                continue;
+            };
+
+            let from_label = artifact_diagram_label(from);
+            let to_label = artifact_diagram_label(to);
+            let relation_label = relation_diagram_label(relation);
+            lines.push(format!("fn {from_label}() -> {relation_label}"));
+            lines.push(format!("fn {relation_label}() -> {to_label}"));
+
+            if relation.provenance.is_empty() {
+                let warning =
+                    diagram_token(&format!("missing_provenance_{}", short_id(&relation.id)));
+                lines.push(format!("fn {relation_label}() -> {warning}"));
+            }
+        }
+
+        lines.join("\n")
+    }
+}
+
+fn artifact_diagram_label(artifact: &Artifact) -> String {
+    let primary = artifact
+        .attrs
+        .get("tx_id")
+        .or_else(|| artifact.attrs.get("source_ref"))
+        .or_else(|| artifact.attrs.get("category"))
+        .or_else(|| artifact.attrs.get("id"))
+        .or_else(|| artifact.attrs.get("label"))
+        .map(String::as_str)
+        .unwrap_or_else(|| artifact.id.as_str());
+    diagram_token(&format!(
+        "{}_{}_{}",
+        artifact.kind.canonical_name(),
+        primary,
+        short_id(&artifact.id)
+    ))
+}
+
+fn relation_diagram_label(relation: &Relation) -> String {
+    diagram_token(&format!(
+        "relation_{}_{}",
+        relation.relation,
+        short_id(&relation.id)
+    ))
+}
+
+fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
+fn diagram_token(raw: &str) -> String {
+    let mut token = raw
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    while token.contains("__") {
+        token = token.replace("__", "_");
+    }
+    token.trim_matches('_').to_string()
+}
+
+pub fn artifact_content_hash(kind: ArtifactKind, attrs: &BTreeMap<String, String>) -> String {
+    let mut canonical = format!("entity|{}", kind.canonical_name());
+    for (key, value) in attrs {
+        canonical.push('|');
+        canonical.push_str(key);
+        canonical.push('=');
+        canonical.push_str(value);
+    }
+    content_hash(&canonical)
+}
+
+pub fn relation_content_hash(
+    from: &str,
+    to: &str,
+    relation: &str,
+    provenance: &BTreeMap<String, String>,
+) -> String {
+    let mut canonical = format!("edge|{}|{}|{}", from, to, relation);
+    for (key, value) in provenance {
+        canonical.push('|');
+        canonical.push_str(key);
+        canonical.push('=');
+        canonical.push_str(value);
+    }
+    content_hash(&canonical)
+}
+
+pub fn content_hash(canonical: &str) -> String {
+    blake3::hash(canonical.as_bytes()).to_hex().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ontology_id_is_stable() {
+        let mut attrs = BTreeMap::new();
+        attrs.insert("tx_id".to_string(), "tx-001".to_string());
+
+        let first = artifact_content_hash(ArtifactKind::Transaction, &attrs);
+        let second = artifact_content_hash(ArtifactKind::Transaction, &attrs);
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 64);
+    }
+
+    #[test]
+    fn ontology_snapshot_sorting_is_deterministic() {
+        let mut tx_attrs = BTreeMap::new();
+        tx_attrs.insert("tx_id".to_string(), "tx-001".to_string());
+        let mut doc_attrs = BTreeMap::new();
+        doc_attrs.insert("source_ref".to_string(), "statement.pdf".to_string());
+
+        let tx = Artifact {
+            id: artifact_content_hash(ArtifactKind::Transaction, &tx_attrs),
+            kind: ArtifactKind::Transaction,
+            attrs: tx_attrs,
+        };
+        let doc = Artifact {
+            id: artifact_content_hash(ArtifactKind::Document, &doc_attrs),
+            kind: ArtifactKind::Document,
+            attrs: doc_attrs,
+        };
+
+        let mut snapshot_a = OntologySnapshot {
+            artifacts: vec![tx.clone(), doc.clone()],
+            relations: vec![Relation {
+                id: relation_content_hash(
+                    &doc.id,
+                    &tx.id,
+                    "documents_transaction",
+                    &BTreeMap::new(),
+                ),
+                from: doc.id.clone(),
+                to: tx.id.clone(),
+                relation: "documents_transaction".to_string(),
+                provenance: BTreeMap::new(),
+            }],
+        };
+        let mut snapshot_b = OntologySnapshot {
+            artifacts: vec![doc, tx],
+            relations: snapshot_a.relations.clone(),
+        };
+
+        snapshot_a.sort_deterministic();
+        snapshot_b.sort_deterministic();
+
+        assert_eq!(snapshot_a, snapshot_b);
+        assert_eq!(
+            snapshot_a.to_pretty_json_stable().unwrap(),
+            snapshot_b.to_pretty_json_stable().unwrap()
+        );
+    }
+
+    #[test]
+    fn ontology_snapshot_to_rhai_dsl_is_deterministic() {
+        let mut tx_attrs = BTreeMap::new();
+        tx_attrs.insert("tx_id".to_string(), "tx-001".to_string());
+        let mut doc_attrs = BTreeMap::new();
+        doc_attrs.insert(
+            "source_ref".to_string(),
+            "2023/WF statement.pdf".to_string(),
+        );
+        let doc = Artifact {
+            id: artifact_content_hash(ArtifactKind::Document, &doc_attrs),
+            kind: ArtifactKind::Document,
+            attrs: doc_attrs,
+        };
+        let tx = Artifact {
+            id: artifact_content_hash(ArtifactKind::Transaction, &tx_attrs),
+            kind: ArtifactKind::Transaction,
+            attrs: tx_attrs,
+        };
+        let mut provenance = BTreeMap::new();
+        provenance.insert(
+            "source_ref".to_string(),
+            "2023/WF statement.pdf".to_string(),
+        );
+        let relation = Relation {
+            id: relation_content_hash(&doc.id, &tx.id, "documents_transaction", &provenance),
+            from: doc.id.clone(),
+            to: tx.id.clone(),
+            relation: "documents_transaction".to_string(),
+            provenance,
+        };
+        let snapshot_a = OntologySnapshot {
+            artifacts: vec![tx.clone(), doc.clone()],
+            relations: vec![relation.clone()],
+        };
+        let snapshot_b = OntologySnapshot {
+            artifacts: vec![doc, tx],
+            relations: vec![relation],
+        };
+
+        let expected = format!(
+            "fn document_2023_wf_statement_pdf_{}() -> relation_documents_transaction_{}\nfn relation_documents_transaction_{}() -> transaction_tx_001_{}",
+            short_id(&snapshot_b.artifacts[0].id),
+            short_id(&snapshot_b.relations[0].id),
+            short_id(&snapshot_b.relations[0].id),
+            short_id(&snapshot_b.artifacts[1].id),
+        );
+
+        assert_eq!(snapshot_a.to_rhai_dsl(), snapshot_b.to_rhai_dsl());
+        assert_eq!(snapshot_a.to_rhai_dsl(), expected);
+    }
+
+    #[test]
+    fn ontology_snapshot_to_rhai_dsl_marks_missing_provenance() {
+        let mut tx_attrs = BTreeMap::new();
+        tx_attrs.insert("tx_id".to_string(), "tx-001".to_string());
+        let mut doc_attrs = BTreeMap::new();
+        doc_attrs.insert("source_ref".to_string(), "statement.pdf".to_string());
+        let doc = Artifact {
+            id: artifact_content_hash(ArtifactKind::Document, &doc_attrs),
+            kind: ArtifactKind::Document,
+            attrs: doc_attrs,
+        };
+        let tx = Artifact {
+            id: artifact_content_hash(ArtifactKind::Transaction, &tx_attrs),
+            kind: ArtifactKind::Transaction,
+            attrs: tx_attrs,
+        };
+        let relation = Relation {
+            id: relation_content_hash(&doc.id, &tx.id, "documents_transaction", &BTreeMap::new()),
+            from: doc.id.clone(),
+            to: tx.id.clone(),
+            relation: "documents_transaction".to_string(),
+            provenance: BTreeMap::new(),
+        };
+        let snapshot = OntologySnapshot {
+            artifacts: vec![doc, tx],
+            relations: vec![relation],
+        };
+
+        assert!(snapshot.to_rhai_dsl().contains("missing_provenance_"));
+    }
+}

--- a/crates/ledger-core/src/proposal.rs
+++ b/crates/ledger-core/src/proposal.rs
@@ -1,0 +1,344 @@
+use std::collections::BTreeMap;
+
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::ontology::{relation_content_hash, Relation};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProposalState {
+    Proposed,
+    Validated,
+    Rejected,
+    Approved,
+    Committed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelMetadata {
+    pub provider: String,
+    pub model: String,
+    pub endpoint_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProposalValidation {
+    pub validator: String,
+    pub passed: bool,
+    pub checked_at: String,
+    pub notes: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProposalApproval {
+    pub actor: String,
+    pub decided_at: String,
+    pub approved: bool,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OntologyEdgeProposal {
+    pub proposal_id: String,
+    pub proposed_relation: Relation,
+    pub confidence: Decimal,
+    pub source_artifact_ids: Vec<String>,
+    #[serde(default)]
+    pub semantic_context_ids: Vec<String>,
+    pub model_metadata: ModelMetadata,
+    pub validation: Option<ProposalValidation>,
+    pub approval: Option<ProposalApproval>,
+    pub state: ProposalState,
+}
+
+impl OntologyEdgeProposal {
+    pub fn validate(mut self, validation: ProposalValidation) -> Self {
+        self.state = if validation.passed {
+            ProposalState::Validated
+        } else {
+            ProposalState::Rejected
+        };
+        self.validation = Some(validation);
+        self
+    }
+
+    pub fn record_approval(mut self, approval: ProposalApproval) -> Self {
+        self.state = if approval.approved {
+            ProposalState::Approved
+        } else {
+            ProposalState::Rejected
+        };
+        self.approval = Some(approval);
+        self
+    }
+
+    pub fn commit_relation(
+        &self,
+        policy: &ProposalPolicy,
+    ) -> Result<Relation, ProposalCommitError> {
+        let validation = self
+            .validation
+            .as_ref()
+            .ok_or(ProposalCommitError::MissingValidation)?;
+        if !validation.passed {
+            return Err(ProposalCommitError::ValidationFailed);
+        }
+
+        if let Some(reason) = policy.operator_review_reason(self) {
+            let approved = self
+                .approval
+                .as_ref()
+                .filter(|approval| approval.approved)
+                .ok_or(ProposalCommitError::OperatorReviewRequired(reason))?;
+            if approved.actor.trim().is_empty() {
+                return Err(ProposalCommitError::InvalidApproval(
+                    "approval actor must be non-empty".to_string(),
+                ));
+            }
+        }
+
+        let mut relation = self.proposed_relation.clone();
+        relation
+            .provenance
+            .insert("proposal_id".to_string(), self.proposal_id.clone());
+        relation
+            .provenance
+            .insert("proposal_state".to_string(), "committed".to_string());
+        relation.provenance.insert(
+            "proposal_confidence".to_string(),
+            self.confidence.normalize().to_string(),
+        );
+        relation.provenance.insert(
+            "model_provider".to_string(),
+            self.model_metadata.provider.clone(),
+        );
+        relation
+            .provenance
+            .insert("model_name".to_string(), self.model_metadata.model.clone());
+        relation.provenance.insert(
+            "validation_result".to_string(),
+            validation.passed.to_string(),
+        );
+        relation
+            .provenance
+            .insert("validated_by".to_string(), validation.validator.clone());
+        relation.provenance.insert(
+            "source_artifact_ids".to_string(),
+            self.source_artifact_ids.join(","),
+        );
+        if !self.semantic_context_ids.is_empty() {
+            relation.provenance.insert(
+                "semantic_context_ids".to_string(),
+                self.semantic_context_ids.join(","),
+            );
+        }
+        if let Some(approval) = self.approval.as_ref().filter(|approval| approval.approved) {
+            relation
+                .provenance
+                .insert("approval_actor".to_string(), approval.actor.clone());
+            relation
+                .provenance
+                .insert("approved_at".to_string(), approval.decided_at.clone());
+        }
+        relation.id = relation_content_hash(
+            &relation.from,
+            &relation.to,
+            &relation.relation,
+            &relation.provenance,
+        );
+        Ok(relation)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProposalPolicy {
+    pub auto_commit_min_confidence: Decimal,
+    pub review_relations: Vec<String>,
+}
+
+impl Default for ProposalPolicy {
+    fn default() -> Self {
+        Self {
+            auto_commit_min_confidence: Decimal::new(90, 2),
+            review_relations: vec!["linked_to_xero".to_string(), "projects_to".to_string()],
+        }
+    }
+}
+
+impl ProposalPolicy {
+    pub fn operator_review_reason(&self, proposal: &OntologyEdgeProposal) -> Option<String> {
+        if proposal.confidence < self.auto_commit_min_confidence {
+            return Some(format!(
+                "confidence {} is below auto-commit threshold {}",
+                proposal.confidence.normalize(),
+                self.auto_commit_min_confidence.normalize()
+            ));
+        }
+        if self
+            .review_relations
+            .iter()
+            .any(|relation| relation == &proposal.proposed_relation.relation)
+        {
+            return Some(format!(
+                "{} proposals require operator review",
+                proposal.proposed_relation.relation
+            ));
+        }
+        None
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ProposalCommitError {
+    #[error("model proposal must be validated before commit")]
+    MissingValidation,
+    #[error("model proposal validation failed")]
+    ValidationFailed,
+    #[error("operator review required: {0}")]
+    OperatorReviewRequired(String),
+    #[error("invalid approval: {0}")]
+    InvalidApproval(String),
+}
+
+pub fn rejected_proposal_audit_artifact(
+    proposal: &OntologyEdgeProposal,
+    rejected_at: impl Into<String>,
+) -> BTreeMap<String, String> {
+    let mut attrs = BTreeMap::new();
+    attrs.insert("proposal_id".to_string(), proposal.proposal_id.clone());
+    attrs.insert("state".to_string(), "rejected".to_string());
+    attrs.insert("rejected_at".to_string(), rejected_at.into());
+    attrs.insert(
+        "relation".to_string(),
+        proposal.proposed_relation.relation.clone(),
+    );
+    attrs.insert("from".to_string(), proposal.proposed_relation.from.clone());
+    attrs.insert("to".to_string(), proposal.proposed_relation.to.clone());
+    attrs.insert("model".to_string(), proposal.model_metadata.model.clone());
+    attrs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_proposal(confidence: Decimal, relation_name: &str) -> OntologyEdgeProposal {
+        OntologyEdgeProposal {
+            proposal_id: "proposal-001".to_string(),
+            proposed_relation: Relation {
+                id: "draft-edge".to_string(),
+                from: "artifact-a".to_string(),
+                to: "artifact-b".to_string(),
+                relation: relation_name.to_string(),
+                provenance: BTreeMap::new(),
+            },
+            confidence,
+            source_artifact_ids: vec!["artifact-a".to_string()],
+            semantic_context_ids: Vec::new(),
+            model_metadata: ModelMetadata {
+                provider: "internal".to_string(),
+                model: "phi-4-mini-reasoning".to_string(),
+                endpoint_url: "http://127.0.0.1:15115/v1/chat/completions".to_string(),
+            },
+            validation: None,
+            approval: None,
+            state: ProposalState::Proposed,
+        }
+    }
+
+    fn passing_validation() -> ProposalValidation {
+        ProposalValidation {
+            validator: "ledger-core".to_string(),
+            passed: true,
+            checked_at: "2026-04-27T00:00:00Z".to_string(),
+            notes: "relation endpoints exist".to_string(),
+        }
+    }
+
+    #[test]
+    fn model_proposal_cannot_commit_without_validation() {
+        let proposal = base_proposal(Decimal::new(95, 2), "references");
+
+        let error = proposal
+            .commit_relation(&ProposalPolicy::default())
+            .expect_err("unvalidated proposal must fail closed");
+
+        assert_eq!(error, ProposalCommitError::MissingValidation);
+    }
+
+    #[test]
+    fn low_confidence_proposal_requires_operator_review() {
+        let proposal =
+            base_proposal(Decimal::new(70, 2), "references").validate(passing_validation());
+
+        let error = proposal
+            .commit_relation(&ProposalPolicy::default())
+            .expect_err("low confidence proposal must require review");
+
+        assert!(matches!(
+            error,
+            ProposalCommitError::OperatorReviewRequired(_)
+        ));
+    }
+
+    #[test]
+    fn approved_proposal_commits_with_model_actor_and_validation_metadata() {
+        let proposal = base_proposal(Decimal::new(70, 2), "references")
+            .validate(passing_validation())
+            .record_approval(ProposalApproval {
+                actor: "operator".to_string(),
+                decided_at: "2026-04-27T00:01:00Z".to_string(),
+                approved: true,
+                reason: "source evidence matches".to_string(),
+            });
+
+        let relation = proposal
+            .commit_relation(&ProposalPolicy::default())
+            .expect("approved proposal should commit");
+
+        assert_eq!(relation.provenance["proposal_id"], "proposal-001");
+        assert_eq!(relation.provenance["proposal_state"], "committed");
+        assert_eq!(relation.provenance["model_name"], "phi-4-mini-reasoning");
+        assert_eq!(relation.provenance["approval_actor"], "operator");
+        assert_eq!(relation.provenance["validated_by"], "ledger-core");
+        assert_ne!(relation.id, "draft-edge");
+    }
+
+    #[test]
+    fn semantic_context_refs_are_added_to_model_provenance() {
+        let mut proposal = base_proposal(Decimal::new(95, 2), "references");
+        proposal.semantic_context_ids = vec!["semantic-a".to_string(), "semantic-b".to_string()];
+        let proposal = proposal.validate(passing_validation());
+
+        let relation = proposal
+            .commit_relation(&ProposalPolicy::default())
+            .expect("high confidence validated proposal should commit");
+
+        assert_eq!(
+            relation.provenance["semantic_context_ids"],
+            "semantic-a,semantic-b"
+        );
+    }
+
+    #[test]
+    fn rejected_proposal_is_audit_artifact_not_committed_relation() {
+        let proposal =
+            base_proposal(Decimal::new(95, 2), "references").validate(ProposalValidation {
+                validator: "ledger-core".to_string(),
+                passed: false,
+                checked_at: "2026-04-27T00:00:00Z".to_string(),
+                notes: "missing endpoint artifact".to_string(),
+            });
+
+        let error = proposal
+            .commit_relation(&ProposalPolicy::default())
+            .expect_err("failed validation cannot commit");
+        let audit_attrs = rejected_proposal_audit_artifact(&proposal, "2026-04-27T00:02:00Z");
+
+        assert_eq!(error, ProposalCommitError::ValidationFailed);
+        assert_eq!(audit_attrs["state"], "rejected");
+        assert_eq!(audit_attrs["proposal_id"], "proposal-001");
+    }
+}

--- a/crates/ledger-core/src/rule_registry.rs
+++ b/crates/ledger-core/src/rule_registry.rs
@@ -15,7 +15,10 @@
 //! The Python sidecar at <https://github.com/PromptExecution/reqif-opa-mcp> produces
 //! `RequirementCandidate` JSON objects that are deserialized into `ReqIfCandidate` here.
 
-use std::path::{Path, PathBuf};
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -41,6 +44,34 @@ fn is_transaction_rule(path: &Path) -> bool {
     };
 
     src.contains("fn classify(")
+}
+
+fn semantic_candidate_id(source_kind: &str, source_ref: &str, text: &str) -> String {
+    let canonical = format!(
+        "semantic_candidate|{}|{}|{}",
+        source_kind.trim(),
+        source_ref.trim(),
+        text.trim()
+    );
+    blake3::hash(canonical.as_bytes()).to_hex().to_string()
+}
+
+fn semantic_tokens(text: &str) -> BTreeSet<String> {
+    text.split(|c: char| !c.is_ascii_alphanumeric())
+        .filter_map(|token| {
+            let token = token.trim().to_ascii_lowercase();
+            (token.len() >= 3).then_some(token)
+        })
+        .collect()
+}
+
+fn lexical_similarity(query: &BTreeSet<String>, candidate: &BTreeSet<String>) -> f64 {
+    if query.is_empty() || candidate.is_empty() {
+        return 0.0;
+    }
+    let intersection = query.intersection(candidate).count() as f64;
+    let union = query.union(candidate).count() as f64;
+    intersection / union
 }
 
 // ============================================================================
@@ -100,6 +131,21 @@ pub struct DocumentChunk {
     pub semantic_id: String,
     /// Page anchors `[page_number, offset_chars]` into the source PDF.
     pub anchors: Vec<[u32; 2]>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SemanticCandidate {
+    pub id: String,
+    pub rule_path: PathBuf,
+    pub source_kind: String,
+    pub source_ref: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone)]
+struct SemanticIndexEntry {
+    candidate: SemanticCandidate,
+    tokens: BTreeSet<String>,
 }
 
 // ============================================================================
@@ -175,6 +221,8 @@ pub struct RuleRegistry {
     /// Optional `ReqIfCandidate` objects associated with each rule, indexed
     /// parallel to `rule_paths`. `None` if no sidecar JSON was found.
     candidates: Vec<Option<ReqIfCandidate>>,
+    /// Local deterministic lexical index used until model embeddings are wired.
+    semantic_index: Vec<SemanticIndexEntry>,
 }
 
 impl RuleRegistry {
@@ -226,6 +274,7 @@ impl RuleRegistry {
         Ok(Self {
             rule_paths,
             candidates,
+            semantic_index: Vec::new(),
         })
     }
 
@@ -370,20 +419,121 @@ impl RuleRegistry {
             .filter(|candidate| candidate.is_some())
             .count()
     }
+
+    /// Return stable semantic candidate identifiers in index order.
+    pub fn semantic_candidate_ids(&self) -> Vec<String> {
+        self.semantic_index
+            .iter()
+            .map(|entry| entry.candidate.id.clone())
+            .collect()
+    }
+
+    /// Return semantic candidates in index order.
+    pub fn semantic_candidates(&self) -> Vec<SemanticCandidate> {
+        self.semantic_index
+            .iter()
+            .map(|entry| entry.candidate.clone())
+            .collect()
+    }
 }
 
 impl SemanticRuleSelector for RuleRegistry {
-    fn select_rules_semantic(&self, _tx: &SampleTransaction, _top_k: usize) -> Vec<PathBuf> {
-        unimplemented!(
-            "SemanticRuleSelector::select_rules_semantic — requires embedding infrastructure \
-             (local ONNX / fastembed-rs / candle model); use select_rules_deterministic until available"
-        )
+    fn select_rules_semantic(&self, tx: &SampleTransaction, top_k: usize) -> Vec<PathBuf> {
+        if top_k == 0 || self.semantic_index.is_empty() {
+            return self.select_rules_deterministic(tx);
+        }
+
+        let query = semantic_tokens(&format!("{} {}", tx.account_id, tx.description));
+        let mut scored = self
+            .semantic_index
+            .iter()
+            .map(|entry| {
+                (
+                    lexical_similarity(&query, &entry.tokens),
+                    entry.candidate.id.as_str(),
+                    entry.candidate.rule_path.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        scored.sort_by(|a, b| {
+            b.0.total_cmp(&a.0)
+                .then_with(|| a.1.cmp(b.1))
+                .then_with(|| a.2.cmp(&b.2))
+        });
+
+        let mut selected = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        const MIN_LEXICAL_SIMILARITY: f64 = 0.05;
+        for (score, _id, path) in scored {
+            if score < MIN_LEXICAL_SIMILARITY {
+                continue;
+            }
+            if seen.insert(path.clone()) {
+                selected.push(path);
+            }
+            if selected.len() >= top_k {
+                break;
+            }
+        }
+
+        if selected.is_empty() {
+            self.select_rules_deterministic(tx)
+        } else {
+            selected
+        }
     }
 
     fn build_embedding_index(&mut self) -> Result<(), RuleRegistryError> {
-        unimplemented!(
-            "SemanticRuleSelector::build_embedding_index — requires embedding model; \
-             blocked until embedding infrastructure is wired"
-        )
+        let mut entries = Vec::new();
+        for (rule_path, candidate) in self.rule_paths.iter().zip(self.candidates.iter()) {
+            let source_ref = rule_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("unknown_rule")
+                .to_string();
+            let text = if let Some(candidate) = candidate {
+                format!(
+                    "{} {} {} {}",
+                    candidate.key, candidate.section, candidate.text, candidate.rationale
+                )
+            } else {
+                std::fs::read_to_string(rule_path)?
+            };
+            let id = semantic_candidate_id("rule", &source_ref, &text);
+            entries.push(SemanticIndexEntry {
+                tokens: semantic_tokens(&format!("{source_ref} {text}")),
+                candidate: SemanticCandidate {
+                    id,
+                    rule_path: rule_path.clone(),
+                    source_kind: "rule".to_string(),
+                    source_ref,
+                    text,
+                },
+            });
+        }
+        entries.sort_by(|a, b| {
+            a.candidate
+                .id
+                .cmp(&b.candidate.id)
+                .then_with(|| a.candidate.rule_path.cmp(&b.candidate.rule_path))
+        });
+        self.semantic_index = entries;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn semantic_candidate_ids_are_stable() {
+        let first = semantic_candidate_id("rule", "classify_schedule_c.rhai", "client invoice");
+        let second = semantic_candidate_id("rule", "classify_schedule_c.rhai", "client invoice");
+        let different = semantic_candidate_id("rule", "classify_schedule_e.rhai", "client invoice");
+
+        assert_eq!(first, second);
+        assert_ne!(first, different);
+        assert_eq!(first.len(), 64);
     }
 }

--- a/crates/ledger-core/tests/rule_registry.rs
+++ b/crates/ledger-core/tests/rule_registry.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use ledger_core::classify::{ClassificationEngine, SampleTransaction};
-use ledger_core::rule_registry::RuleRegistry;
+use ledger_core::rule_registry::{RuleRegistry, SemanticRuleSelector};
 
 fn rules_dir() -> PathBuf {
     let manifest =
@@ -107,4 +107,58 @@ fn classify_waterfall_preserves_fallback_unclassified_reason() {
     assert_eq!(outcome.confidence, 0.0);
     assert!(outcome.needs_review);
     assert!(outcome.reason.contains("Mystery payment"));
+}
+
+#[test]
+fn semantic_candidate_ids_are_stable_after_rebuild() {
+    let mut first = RuleRegistry::load_from_dir(&rules_dir()).expect("rules directory loads");
+    first
+        .build_embedding_index()
+        .expect("local lexical index builds");
+    let mut second = RuleRegistry::load_from_dir(&rules_dir()).expect("rules directory loads");
+    second
+        .build_embedding_index()
+        .expect("local lexical index builds");
+
+    assert_eq!(
+        first.semantic_candidate_ids(),
+        second.semantic_candidate_ids()
+    );
+    assert_eq!(first.semantic_candidate_ids().len(), first.rule_count());
+}
+
+#[test]
+fn semantic_selector_preserves_deterministic_fallback() {
+    let mut registry = RuleRegistry::load_from_dir(&rules_dir()).expect("rules directory loads");
+    registry
+        .build_embedding_index()
+        .expect("local lexical index builds");
+    let tx = sample("Mystery payment", "WF--BH-CHK--2024-02", "99.00");
+
+    let semantic = registry.select_rules_semantic(&tx, 5);
+    let deterministic = registry.select_rules_deterministic(&tx);
+
+    assert_eq!(file_names(&semantic), file_names(&deterministic));
+}
+
+#[test]
+fn rule_registry_waterfall_remains_authoritative_with_semantic_index() {
+    let mut registry = RuleRegistry::load_from_dir(&rules_dir()).expect("rules directory loads");
+    registry
+        .build_embedding_index()
+        .expect("local lexical index builds");
+    let mut engine = ClassificationEngine::default();
+    let tx = sample(
+        "Client invoice #INV-042 consulting services",
+        "WF--BH-CHK--2024-02",
+        "3500.00",
+    );
+
+    let selected = registry.select_rules_semantic(&tx, 3);
+    let outcome = registry
+        .classify_waterfall(&mut engine, &tx)
+        .expect("waterfall classifies");
+
+    assert!(!selected.is_empty());
+    assert_eq!(outcome.category, "SelfEmployment");
 }

--- a/crates/ledgerr-host/src/agent_runtime.rs
+++ b/crates/ledgerr-host/src/agent_runtime.rs
@@ -69,7 +69,7 @@ use rig::{
     completion::{AssistantContent, CompletionModel, Message},
     providers::openai,
 };
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::settings::ChatSettings;
@@ -234,8 +234,76 @@ pub enum AgentRuntimeError {
     MissingAssistantMessage,
     #[error("failed to parse structured model response: {0}")]
     Parse(#[from] serde_json::Error),
+    #[error("typed model output failed validation: {0}")]
+    InvalidTypedOutput(String),
     #[error("local llm error: {0}")]
     LocalLlm(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ClassifyTransactionJob {
+    pub tx_id: String,
+    pub account_id: String,
+    pub date: String,
+    pub amount: String,
+    pub description: String,
+}
+
+impl ClassifyTransactionJob {
+    pub fn to_model_request(&self) -> Result<ModelRequest, AgentRuntimeError> {
+        let payload = serde_json::to_string(&serde_json::json!({
+            "job": "classify_transaction",
+            "transaction": self,
+            "return_schema": {
+                "category": "non-empty string",
+                "confidence": "number in [0,1]",
+                "reason": "string or null",
+                "suggested_tags": ["string"]
+            }
+        }))?;
+
+        Ok(ModelRequest::text(payload)
+            .with_system_prompt(PHI4_TYPED_JOB_SYSTEM_PROMPT)
+            .with_max_tokens(256))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct TransactionClassificationOutput {
+    pub category: String,
+    pub confidence: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(default)]
+    pub suggested_tags: Vec<String>,
+}
+
+impl TransactionClassificationOutput {
+    pub fn validate(&self) -> Result<(), AgentRuntimeError> {
+        if self.category.trim().is_empty() {
+            return Err(AgentRuntimeError::InvalidTypedOutput(
+                "category must be non-empty".to_string(),
+            ));
+        }
+        if !self.confidence.is_finite() || !(0.0..=1.0).contains(&self.confidence) {
+            return Err(AgentRuntimeError::InvalidTypedOutput(
+                "confidence must be a finite number in [0,1]".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub const PHI4_TYPED_JOB_SYSTEM_PROMPT: &str = "\
+You are l3dg3rr's local Phi-4 typed-job worker. Return only valid JSON matching the requested schema. Do not include markdown.";
+
+pub fn run_classify_transaction_job<R: AgentRuntime>(
+    runtime: &R,
+    job: &ClassifyTransactionJob,
+) -> Result<TransactionClassificationOutput, AgentRuntimeError> {
+    let output: TransactionClassificationOutput = runtime.extract(job.to_model_request()?)?;
+    output.validate()?;
+    Ok(output)
 }
 
 #[derive(Debug, Clone)]
@@ -454,6 +522,24 @@ mod tests {
     use rig::{completion::AssistantContent, providers::openai};
     use serde::Deserialize;
 
+    #[derive(Debug)]
+    struct FixedJsonRuntime {
+        response: &'static str,
+    }
+
+    impl AgentRuntime for FixedJsonRuntime {
+        fn complete(&self, request: ModelRequest) -> Result<ModelResponse, AgentRuntimeError> {
+            assert_eq!(
+                request.system_prompt.as_deref(),
+                Some(PHI4_TYPED_JOB_SYSTEM_PROMPT)
+            );
+            assert_eq!(request.max_tokens, Some(256));
+            Ok(ModelResponse {
+                assistant_text: self.response.to_string(),
+            })
+        }
+    }
+
     fn test_settings() -> ChatSettings {
         ChatSettings {
             endpoint_url: "https://example.test/v1/chat/completions".to_string(),
@@ -557,6 +643,77 @@ mod tests {
                 answer: "yes".to_string()
             }
         );
+    }
+
+    #[test]
+    fn classify_transaction_job_builds_typed_request() {
+        let job = ClassifyTransactionJob {
+            tx_id: "tx_123".to_string(),
+            account_id: "WF-BH-CHK".to_string(),
+            date: "2024-01-31".to_string(),
+            amount: "-12.34".to_string(),
+            description: "Cafe lunch".to_string(),
+        };
+
+        let request = job.to_model_request().expect("model request");
+
+        assert_eq!(
+            request.system_prompt.as_deref(),
+            Some(PHI4_TYPED_JOB_SYSTEM_PROMPT)
+        );
+        assert_eq!(request.max_tokens, Some(256));
+        assert!(request
+            .user_message
+            .contains("\"job\":\"classify_transaction\""));
+        assert!(request.user_message.contains("\"tx_id\":\"tx_123\""));
+        assert!(request
+            .user_message
+            .contains("\"confidence\":\"number in [0,1]\""));
+    }
+
+    #[test]
+    fn typed_classification_output_validation_rejects_invalid_values() {
+        let empty_category = TransactionClassificationOutput {
+            category: " ".to_string(),
+            confidence: 0.5,
+            reason: None,
+            suggested_tags: Vec::new(),
+        };
+        assert!(matches!(
+            empty_category.validate(),
+            Err(AgentRuntimeError::InvalidTypedOutput(_))
+        ));
+
+        let bad_confidence = TransactionClassificationOutput {
+            category: "Meals".to_string(),
+            confidence: 1.5,
+            reason: None,
+            suggested_tags: Vec::new(),
+        };
+        assert!(matches!(
+            bad_confidence.validate(),
+            Err(AgentRuntimeError::InvalidTypedOutput(_))
+        ));
+    }
+
+    #[test]
+    fn run_classify_transaction_job_extracts_and_validates_json() {
+        let runtime = FixedJsonRuntime {
+            response: r##"{"category":"Meals","confidence":0.81,"reason":"lunch vendor","suggested_tags":["#meal"]}"##,
+        };
+        let job = ClassifyTransactionJob {
+            tx_id: "tx_123".to_string(),
+            account_id: "WF-BH-CHK".to_string(),
+            date: "2024-01-31".to_string(),
+            amount: "-12.34".to_string(),
+            description: "Cafe lunch".to_string(),
+        };
+
+        let output = run_classify_transaction_job(&runtime, &job).expect("typed output");
+
+        assert_eq!(output.category, "Meals");
+        assert_eq!(output.confidence, 0.81);
+        assert_eq!(output.suggested_tags, ["#meal"]);
     }
 
     #[test]

--- a/crates/ledgerr-host/src/chat.rs
+++ b/crates/ledgerr-host/src/chat.rs
@@ -115,6 +115,8 @@ pub enum ChatError {
     MissingAssistantMessage,
     #[error("failed to parse structured model response: {0}")]
     Parse(serde_json::Error),
+    #[error("typed model output failed validation: {0}")]
+    InvalidTypedOutput(String),
     #[error("local llm error: {0}")]
     LocalLlm(String),
 }
@@ -374,6 +376,7 @@ impl From<AgentRuntimeError> for ChatError {
             AgentRuntimeError::RigHttp(error) => Self::RigHttp(error),
             AgentRuntimeError::MissingAssistantMessage => Self::MissingAssistantMessage,
             AgentRuntimeError::Parse(error) => Self::Parse(error),
+            AgentRuntimeError::InvalidTypedOutput(msg) => Self::InvalidTypedOutput(msg),
             AgentRuntimeError::LocalLlm(msg) => Self::LocalLlm(msg),
         }
     }

--- a/crates/ledgerr-host/src/internal_openai.rs
+++ b/crates/ledgerr-host/src/internal_openai.rs
@@ -874,7 +874,7 @@ mod tests {
             stream: false,
         };
 
-        let response = Phi4LocalFallbackBackend::default()
+        let response = Phi4LocalFallbackBackend
             .complete(&request)
             .expect("fallback should respond");
         let output: TransactionClassificationOutput =
@@ -898,7 +898,7 @@ mod tests {
             stream: false,
         };
 
-        let response = Phi4LocalFallbackBackend::default()
+        let response = Phi4LocalFallbackBackend
             .complete(&request)
             .expect("fallback should respond");
         let payload: serde_json::Value = serde_json::from_str(&response).expect("json response");

--- a/crates/ledgerr-host/src/internal_openai.rs
+++ b/crates/ledgerr-host/src/internal_openai.rs
@@ -150,7 +150,36 @@ impl InternalChatBackend for Phi4LocalFallbackBackend {
             .map(|message| message.content_text())
             .unwrap_or_default();
 
-        let response = if user.contains("fn ") || user.contains("if ") || user.contains("match ") {
+        let response = if user.contains("audit_playbook")
+            || user.contains("audit playbook")
+            || user.contains("visual evidence graph")
+        {
+            serde_json::json!({
+                "playbook": "audit_playbook",
+                "mode": "deterministic_fallback",
+                "steps": [
+                    "ingest_rows",
+                    "classify_transactions",
+                    "phi4_edge_proposals",
+                    "operator_review",
+                    "workbook_export",
+                    "evidence_chain",
+                    "visual_audit_graph"
+                ],
+                "requires_model_assets": false
+            })
+            .to_string()
+        } else if user.contains("\"job\":\"classify_transaction\"")
+            || user.contains("classify_transaction") && user.contains("return_schema")
+        {
+            serde_json::json!({
+                "category": "Meals",
+                "confidence": 0.72,
+                "reason": "deterministic Phi-4 fallback classification",
+                "suggested_tags": ["#phi4-fallback"]
+            })
+            .to_string()
+        } else if user.contains("fn ") || user.contains("if ") || user.contains("match ") {
             [
                 "fn classify_rows() -> score_confidence",
                 "if confidence > 0.85 -> commit_workbook",
@@ -718,6 +747,9 @@ fn default_phi4_model_path() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent_runtime::{
+        ClassifyTransactionJob, TransactionClassificationOutput, PHI4_TYPED_JOB_SYSTEM_PROMPT,
+    };
 
     #[derive(Debug)]
     struct FixedBackend;
@@ -814,6 +846,71 @@ mod tests {
 
         assert!(response.contains("if confidence > 0.60 -> review_flag"));
         assert!(response.contains("review-safe"));
+    }
+
+    #[test]
+    fn fallback_backend_generates_valid_typed_classification_json() {
+        let job = ClassifyTransactionJob {
+            tx_id: "tx_123".to_string(),
+            account_id: "WF-BH-CHK".to_string(),
+            date: "2024-01-31".to_string(),
+            amount: "-12.34".to_string(),
+            description: "Cafe lunch".to_string(),
+        };
+        let model_request = job.to_model_request().expect("model request");
+        let request = OpenAiChatRequest {
+            model: INTERNAL_PHI_MODEL.to_string(),
+            messages: vec![
+                OpenAiChatMessage {
+                    role: "system".to_string(),
+                    content: PHI4_TYPED_JOB_SYSTEM_PROMPT.into(),
+                },
+                OpenAiChatMessage {
+                    role: "user".to_string(),
+                    content: model_request.user_message.into(),
+                },
+            ],
+            max_tokens: model_request.max_tokens,
+            stream: false,
+        };
+
+        let response = Phi4LocalFallbackBackend::default()
+            .complete(&request)
+            .expect("fallback should respond");
+        let output: TransactionClassificationOutput =
+            serde_json::from_str(&response).expect("typed json");
+
+        output.validate().expect("valid typed output");
+        assert_eq!(output.category, "Meals");
+        assert_eq!(output.suggested_tags, ["#phi4-fallback"]);
+    }
+
+    #[test]
+    fn internal_phi_fallback_runs_audit_playbook_prompt() {
+        let request = OpenAiChatRequest {
+            model: INTERNAL_PHI_MODEL.to_string(),
+            messages: vec![OpenAiChatMessage {
+                role: "user".to_string(),
+                content: "Run the audit playbook and return the visual evidence graph steps."
+                    .into(),
+            }],
+            max_tokens: Some(256),
+            stream: false,
+        };
+
+        let response = Phi4LocalFallbackBackend::default()
+            .complete(&request)
+            .expect("fallback should respond");
+        let payload: serde_json::Value = serde_json::from_str(&response).expect("json response");
+
+        assert_eq!(payload["playbook"], "audit_playbook");
+        assert_eq!(payload["mode"], "deterministic_fallback");
+        assert_eq!(payload["requires_model_assets"], false);
+        assert!(payload["steps"]
+            .as_array()
+            .expect("steps")
+            .iter()
+            .any(|step| step == "visual_audit_graph"));
     }
 
     #[test]

--- a/crates/ledgerr-mcp/src/contract.rs
+++ b/crates/ledgerr-mcp/src/contract.rs
@@ -748,24 +748,38 @@ Expected blocked outcomes:\n\n\
 
 pub fn generated_mcp_cli_demo_script() -> String {
     "#!/usr/bin/env bash\nset -euo pipefail\n\n\
-JOURNAL_PATH=\"${JOURNAL_PATH:-/tmp/demo.beancount}\"\n\
-WORKBOOK_PATH=\"${WORKBOOK_PATH:-/tmp/demo.xlsx}\"\n\
-SOURCE_REF=\"${SOURCE_REF:-wf-2023-01.rkyv}\"\n\n\
+DEMO_ROOT=\"${DEMO_ROOT:-/tmp/l3dg3rr-mcp-demo-$$}\"\n\
+JOURNAL_PATH=\"${JOURNAL_PATH:-$DEMO_ROOT/demo.beancount}\"\n\
+WORKBOOK_PATH=\"${WORKBOOK_PATH:-$DEMO_ROOT/demo.xlsx}\"\n\
+ONTOLOGY_PATH=\"${ONTOLOGY_PATH:-$DEMO_ROOT/demo.ontology.json}\"\n\
+SOURCE_REF=\"${SOURCE_REF:-wf-2023-01.rkyv}\"\n\
+MODE=\"${1:-basic}\"\n\n\
+mkdir -p \"$DEMO_ROOT\"\n\n\
+if [[ \"$MODE\" == \"basic\" ]]; then\n  \
 cargo run -q -p ledgerr-mcp --bin ledgerr-mcp-server <<EOF\n\
 {\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"clientInfo\":{\"name\":\"demo\",\"version\":\"0.1.0\"}}}\n\
 {\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\",\"params\":{}}\n\
 {\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}\n\
 {\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_documents\",\"arguments\":{\"action\":\"pipeline_status\"}}}\n\
 {\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_documents\",\"arguments\":{\"action\":\"list_accounts\"}}}\n\
-{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_documents\",\"arguments\":{\"action\":\"ingest_pdf\",\"pdf_path\":\"WF--BH-CHK--2023-01--statement.pdf\",\"journal_path\":\"$JOURNAL_PATH\",\"workbook_path\":\"$WORKBOOK_PATH\",\"raw_context_bytes\":[99,116,120],\"extracted_rows\":[{\"account_id\":\"WF-BH-CHK\",\"date\":\"2023-01-15\",\"amount\":\"-42.11\",\"description\":\"Coffee Shop\",\"source_ref\":\"$SOURCE_REF\"}]}}}\n\
-{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_documents\",\"arguments\":{\"action\":\"get_raw_context\",\"rkyv_ref\":\"$SOURCE_REF\"}}}\n\
-EOF\n\n\
-# Troubleshooting path\n\
-cat <<'EOF'\n\
+{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_documents\",\"arguments\":{\"action\":\"ingest_pdf\",\"pdf_path\":\"WF--BH-CHK--2023-01--statement.pdf\",\"journal_path\":\"$JOURNAL_PATH\",\"workbook_path\":\"$WORKBOOK_PATH\",\"ontology_path\":\"$ONTOLOGY_PATH\",\"raw_context_bytes\":[99,116,120],\"extracted_rows\":[{\"account_id\":\"WF-BH-CHK\",\"date\":\"2023-01-15\",\"amount\":\"-42.11\",\"description\":\"Coffee Shop\",\"source_ref\":\"$SOURCE_REF\"}]}}}\n\
+{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_audit\",\"arguments\":{\"action\":\"event_history\"}}}\n\
+{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_ontology\",\"arguments\":{\"action\":\"export_snapshot\",\"ontology_path\":\"$ONTOLOGY_PATH\"}}}\n\
+EOF\n  \
+exit 0\n\
+fi\n\n\
+if [[ \"$MODE\" == \"spinning-wheels\" ]]; then\n  \
+cargo run -q -p ledgerr-mcp --bin ledgerr-mcp-server <<'EOF'\n\
+{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"clientInfo\":{\"name\":\"demo\",\"version\":\"0.1.0\"}}}\n\
+{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\",\"params\":{}}\n\
 {\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_workflow\",\"arguments\":{\"action\":\"resume\",\"state_marker\":\"invalid-checkpoint\"}}}\n\
 {\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_reconciliation\",\"arguments\":{\"action\":\"commit\",\"source_total\":\"100.00\",\"extracted_total\":\"95.00\",\"posting_amounts\":[\"-95.00\",\"95.00\"]}}}\n\
 {\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"ledgerr_audit\",\"arguments\":{\"action\":\"event_history\",\"time_start\":\"2026-12-31\",\"time_end\":\"2026-01-01\"}}}\n\
-EOF\n"
+EOF\n  \
+exit 0\n\
+fi\n\n\
+echo \"usage: $0 [basic|spinning-wheels]\" >&2\n\
+exit 2\n"
         .to_string()
 }
 

--- a/crates/ledgerr-mcp/src/contract.rs
+++ b/crates/ledgerr-mcp/src/contract.rs
@@ -287,6 +287,8 @@ pub enum DocumentsArgs {
         journal_path: PathBuf,
         workbook_path: PathBuf,
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        ontology_path: Option<PathBuf>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         raw_context_bytes: Option<Vec<u8>>,
         #[serde(default)]
         extracted_rows: Vec<TransportRow>,
@@ -294,6 +296,8 @@ pub enum DocumentsArgs {
     IngestRows {
         journal_path: PathBuf,
         workbook_path: PathBuf,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ontology_path: Option<PathBuf>,
         rows: Vec<TransportRow>,
     },
     IngestImage {

--- a/crates/ledgerr-mcp/src/lib.rs
+++ b/crates/ledgerr-mcp/src/lib.rs
@@ -73,6 +73,7 @@ pub struct ListAccountsResponse {
 pub struct IngestStatementRowsRequest {
     pub journal_path: PathBuf,
     pub workbook_path: PathBuf,
+    pub ontology_path: Option<PathBuf>,
     pub rows: Vec<TransactionInput>,
 }
 
@@ -87,6 +88,7 @@ pub struct IngestPdfRequest {
     pub pdf_path: String,
     pub journal_path: PathBuf,
     pub workbook_path: PathBuf,
+    pub ontology_path: Option<PathBuf>,
     pub raw_context_bytes: Option<Vec<u8>>,
     pub extracted_rows: Vec<TransactionInput>,
 }
@@ -1123,6 +1125,10 @@ impl TurboLedgerTools for TurboLedgerService {
         }
         drop(classification);
 
+        if let Some(ontology_path) = request.ontology_path.as_deref() {
+            emit_ingest_ontology_edges(ontology_path, &request.rows)?;
+        }
+
         for row in &request.rows {
             let tx_id = deterministic_tx_id(row);
             let mut payload = BTreeMap::new();
@@ -1222,6 +1228,7 @@ impl TurboLedgerTools for TurboLedgerService {
         let response = self.ingest_statement_rows(IngestStatementRowsRequest {
             journal_path: request.journal_path,
             workbook_path: request.workbook_path,
+            ontology_path: request.ontology_path,
             rows: request.extracted_rows,
         })?;
         Ok(IngestPdfResponse {
@@ -2145,6 +2152,65 @@ fn save_document_registry(
     let json =
         serde_json::to_string_pretty(registry).map_err(|e| ToolError::Internal(e.to_string()))?;
     std::fs::write(path, json).map_err(|e| ToolError::Internal(e.to_string()))
+}
+
+pub fn default_ontology_path_for_workbook(workbook: &std::path::Path) -> PathBuf {
+    let file_name = workbook
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("ledger.xlsx");
+    workbook.with_file_name(format!("{file_name}.ontology.json"))
+}
+
+fn emit_ingest_ontology_edges(
+    ontology_path: &std::path::Path,
+    rows: &[TransactionInput],
+) -> Result<(), ToolError> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+
+    let mut store = OntologyStore::load(&ontology_path)?;
+
+    for row in rows {
+        let tx_id = deterministic_tx_id(row);
+        let mut doc_attrs = BTreeMap::new();
+        doc_attrs.insert("source_ref".to_string(), row.source_ref.clone());
+
+        let mut tx_attrs = BTreeMap::new();
+        tx_attrs.insert("tx_id".to_string(), tx_id.clone());
+        tx_attrs.insert("account_id".to_string(), row.account_id.clone());
+        tx_attrs.insert("date".to_string(), row.date.clone());
+        tx_attrs.insert("amount".to_string(), row.amount.clone());
+        tx_attrs.insert("description".to_string(), row.description.clone());
+
+        let entity_ids = store
+            .upsert_entities(vec![
+                OntologyEntityInput {
+                    kind: OntologyEntityKind::Document,
+                    attrs: doc_attrs,
+                },
+                OntologyEntityInput {
+                    kind: OntologyEntityKind::Transaction,
+                    attrs: tx_attrs,
+                },
+            ])?
+            .entity_ids;
+
+        let mut provenance = BTreeMap::new();
+        provenance.insert("emitter".to_string(), "ingest_statement_rows".to_string());
+        provenance.insert("source_ref".to_string(), row.source_ref.clone());
+        provenance.insert("tx_id".to_string(), tx_id);
+
+        store.upsert_edges(vec![OntologyEdgeInput {
+            from: entity_ids[0].clone(),
+            to: entity_ids[1].clone(),
+            relation: "documents_transaction".to_string(),
+            provenance,
+        }])?;
+    }
+
+    store.persist(ontology_path)
 }
 
 // ── New TurboLedgerService methods ────────────────────────────────────────────

--- a/crates/ledgerr-mcp/src/lib.rs
+++ b/crates/ledgerr-mcp/src/lib.rs
@@ -1125,8 +1125,37 @@ impl TurboLedgerTools for TurboLedgerService {
         }
         drop(classification);
 
-        if let Some(ontology_path) = request.ontology_path.as_deref() {
-            emit_ingest_ontology_edges(ontology_path, &request.rows)?;
+        if let Some(raw_ontology_path) = request.ontology_path.as_deref() {
+            let allowed_base = request
+                .workbook_path
+                .parent()
+                .ok_or_else(|| {
+                    ToolError::InvalidInput(
+                        "workbook_path must have a parent directory".to_string(),
+                    )
+                })?
+                .to_path_buf();
+            if raw_ontology_path
+                .components()
+                .any(|c| c == std::path::Component::ParentDir)
+            {
+                return Err(ToolError::InvalidInput(format!(
+                    "ontology_path '{}' contains path traversal components",
+                    raw_ontology_path.display()
+                )));
+            }
+            let resolved_ontology_path = if raw_ontology_path.is_absolute() {
+                if !raw_ontology_path.starts_with(&allowed_base) {
+                    return Err(ToolError::InvalidInput(format!(
+                        "ontology_path '{}' resolves outside the allowed directory",
+                        raw_ontology_path.display()
+                    )));
+                }
+                raw_ontology_path.to_path_buf()
+            } else {
+                allowed_base.join(raw_ontology_path)
+            };
+            emit_ingest_ontology_edges(&resolved_ontology_path, &request.rows)?;
         }
 
         for row in &request.rows {
@@ -2170,7 +2199,7 @@ fn emit_ingest_ontology_edges(
         return Ok(());
     }
 
-    let mut store = OntologyStore::load(&ontology_path)?;
+    let mut store = OntologyStore::load(ontology_path)?;
 
     for row in rows {
         let tx_id = deterministic_tx_id(row);

--- a/crates/ledgerr-mcp/src/mcp_adapter.rs
+++ b/crates/ledgerr-mcp/src/mcp_adapter.rs
@@ -339,6 +339,7 @@ pub fn handle_documents_tool(service: &TurboLedgerService, arguments: &Value) ->
             pdf_path,
             journal_path,
             workbook_path,
+            ontology_path,
             raw_context_bytes,
             extracted_rows,
         } => handle_ingest_pdf(
@@ -347,6 +348,7 @@ pub fn handle_documents_tool(service: &TurboLedgerService, arguments: &Value) ->
                 "pdf_path": pdf_path,
                 "journal_path": journal_path,
                 "workbook_path": workbook_path,
+                "ontology_path": ontology_path,
                 "raw_context_bytes": raw_context_bytes,
                 "extracted_rows": extracted_rows,
             }),
@@ -355,12 +357,14 @@ pub fn handle_documents_tool(service: &TurboLedgerService, arguments: &Value) ->
         DocumentsArgs::IngestRows {
             journal_path,
             workbook_path,
+            ontology_path,
             rows,
         } => handle_ingest_statement_rows(
             service,
             &json!({
                 "journal_path": journal_path,
                 "workbook_path": workbook_path,
+                "ontology_path": ontology_path,
                 "rows": rows,
             }),
             None,
@@ -911,6 +915,10 @@ fn parse_ingest_pdf_request(arguments: &Value) -> Result<IngestPdfRequest, ToolE
     let pdf_path = required_str(arguments, "pdf_path")?.to_string();
     let journal_path = PathBuf::from(required_str(arguments, "journal_path")?);
     let workbook_path = PathBuf::from(required_str(arguments, "workbook_path")?);
+    let ontology_path = arguments
+        .get("ontology_path")
+        .and_then(Value::as_str)
+        .map(PathBuf::from);
     let raw_context_bytes = parse_optional_bytes(arguments.get("raw_context_bytes"))?;
     let extracted_rows = match arguments.get("extracted_rows") {
         None | Some(Value::Null) => Vec::new(),
@@ -921,6 +929,7 @@ fn parse_ingest_pdf_request(arguments: &Value) -> Result<IngestPdfRequest, ToolE
         pdf_path,
         journal_path,
         workbook_path,
+        ontology_path,
         raw_context_bytes,
         extracted_rows,
     })
@@ -931,11 +940,16 @@ fn parse_ingest_statement_rows_request(
 ) -> Result<IngestStatementRowsRequest, ToolError> {
     let journal_path = PathBuf::from(required_str(arguments, "journal_path")?);
     let workbook_path = PathBuf::from(required_str(arguments, "workbook_path")?);
+    let ontology_path = arguments
+        .get("ontology_path")
+        .and_then(Value::as_str)
+        .map(PathBuf::from);
     let rows = parse_rows(arguments.get("rows"), "rows")?;
 
     Ok(IngestStatementRowsRequest {
         journal_path,
         workbook_path,
+        ontology_path,
         rows,
     })
 }
@@ -2097,19 +2111,7 @@ fn parse_ontology_upsert_entities_request(
     let entities = entities_json
         .iter()
         .map(|e| {
-            let kind = match e.get("kind").and_then(Value::as_str) {
-                Some("Document") => crate::OntologyEntityKind::Document,
-                Some("Account") => crate::OntologyEntityKind::Account,
-                Some("Institution") => crate::OntologyEntityKind::Institution,
-                Some("Transaction") => crate::OntologyEntityKind::Transaction,
-                Some("TaxCategory") => crate::OntologyEntityKind::TaxCategory,
-                Some("EvidenceReference") => crate::OntologyEntityKind::EvidenceReference,
-                _ => {
-                    return Err(ToolError::InvalidInput(
-                        "missing or invalid `kind` in entity (must be Document, Account, Institution, Transaction, TaxCategory, or EvidenceReference)".to_string(),
-                    ))
-                }
-            };
+            let kind = parse_ontology_entity_kind(e.get("kind").and_then(Value::as_str))?;
             let mut attrs = std::collections::BTreeMap::new();
             if let Some(id) = e.get("id").and_then(Value::as_str) {
                 attrs.insert("id".to_string(), id.to_string());
@@ -2168,4 +2170,22 @@ fn parse_ontology_upsert_edges_request(
         ontology_path,
         edges,
     })
+}
+
+fn parse_ontology_entity_kind(raw: Option<&str>) -> Result<crate::OntologyEntityKind, ToolError> {
+    match raw {
+        Some("Document") => Ok(crate::OntologyEntityKind::Document),
+        Some("Account") => Ok(crate::OntologyEntityKind::Account),
+        Some("Institution") => Ok(crate::OntologyEntityKind::Institution),
+        Some("Transaction") => Ok(crate::OntologyEntityKind::Transaction),
+        Some("TaxCategory") => Ok(crate::OntologyEntityKind::TaxCategory),
+        Some("EvidenceReference") => Ok(crate::OntologyEntityKind::EvidenceReference),
+        Some("XeroContact") => Ok(crate::OntologyEntityKind::XeroContact),
+        Some("XeroBankAccount") => Ok(crate::OntologyEntityKind::XeroBankAccount),
+        Some("XeroInvoice") => Ok(crate::OntologyEntityKind::XeroInvoice),
+        Some("WorkflowTag") => Ok(crate::OntologyEntityKind::WorkflowTag),
+        _ => Err(ToolError::InvalidInput(
+            "missing or invalid `kind` in entity (must be Document, Account, Institution, Transaction, TaxCategory, EvidenceReference, XeroContact, XeroBankAccount, XeroInvoice, or WorkflowTag)".to_string(),
+        )),
+    }
 }

--- a/crates/ledgerr-mcp/src/ontology.rs
+++ b/crates/ledgerr-mcp/src/ontology.rs
@@ -1,43 +1,15 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::path::Path;
 
+use ledger_core::ontology::{
+    artifact_content_hash, relation_content_hash, Artifact, ArtifactKind, OntologySnapshot,
+    Relation,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::ToolError;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum OntologyEntityKind {
-    Document,
-    Account,
-    Institution,
-    Transaction,
-    TaxCategory,
-    EvidenceReference,
-    // Xero-linked entity kinds
-    XeroContact,
-    XeroBankAccount,
-    XeroInvoice,
-    // Tagging
-    WorkflowTag,
-}
-
-impl OntologyEntityKind {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Document => "document",
-            Self::Account => "account",
-            Self::Institution => "institution",
-            Self::Transaction => "transaction",
-            Self::TaxCategory => "tax_category",
-            Self::EvidenceReference => "evidence_reference",
-            Self::XeroContact => "xero_contact",
-            Self::XeroBankAccount => "xero_bank_account",
-            Self::XeroInvoice => "xero_invoice",
-            Self::WorkflowTag => "workflow_tag",
-        }
-    }
-}
+pub type OntologyEntityKind = ArtifactKind;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OntologyEntityInput {
@@ -133,6 +105,33 @@ impl OntologyStore {
         let payload =
             serde_json::to_string_pretty(self).map_err(|e| ToolError::Internal(e.to_string()))?;
         std::fs::write(path, payload).map_err(|e| ToolError::Internal(e.to_string()))
+    }
+
+    pub fn to_core_snapshot(&self) -> OntologySnapshot {
+        let mut snapshot = OntologySnapshot {
+            artifacts: self
+                .entities
+                .iter()
+                .map(|entity| Artifact {
+                    id: entity.id.clone(),
+                    kind: entity.kind,
+                    attrs: entity.attrs.clone(),
+                })
+                .collect(),
+            relations: self
+                .edges
+                .iter()
+                .map(|edge| Relation {
+                    id: edge.id.clone(),
+                    from: edge.from.clone(),
+                    to: edge.to.clone(),
+                    relation: edge.relation.clone(),
+                    provenance: edge.provenance.clone(),
+                })
+                .collect(),
+        };
+        snapshot.sort_deterministic();
+        snapshot
     }
 
     pub fn upsert_entities(
@@ -282,14 +281,7 @@ impl OntologyStore {
 }
 
 pub fn entity_content_hash(kind: OntologyEntityKind, attrs: &BTreeMap<String, String>) -> String {
-    let mut canonical = format!("entity|{}", kind.as_str());
-    for (key, value) in attrs {
-        canonical.push('|');
-        canonical.push_str(key);
-        canonical.push('=');
-        canonical.push_str(value);
-    }
-    content_hash(&canonical)
+    artifact_content_hash(kind, attrs)
 }
 
 pub fn edge_content_hash(
@@ -298,16 +290,9 @@ pub fn edge_content_hash(
     relation: &str,
     provenance: &BTreeMap<String, String>,
 ) -> String {
-    let mut canonical = format!("edge|{}|{}|{}", from, to, relation);
-    for (key, value) in provenance {
-        canonical.push('|');
-        canonical.push_str(key);
-        canonical.push('=');
-        canonical.push_str(value);
-    }
-    content_hash(&canonical)
+    relation_content_hash(from, to, relation, provenance)
 }
 
 pub fn content_hash(canonical: &str) -> String {
-    blake3::hash(canonical.as_bytes()).to_hex().to_string()
+    ledger_core::ontology::content_hash(canonical)
 }

--- a/crates/ledgerr-mcp/tests/audit_playbook_contract.rs
+++ b/crates/ledgerr-mcp/tests/audit_playbook_contract.rs
@@ -1,0 +1,105 @@
+mod common;
+
+use calamine::Reader;
+use ledger_core::ingest::{deterministic_tx_id, TransactionInput};
+use ledgerr_mcp::{
+    ClassifyTransactionRequest, EventHistoryFilter, ExportCpaWorkbookRequest,
+    IngestStatementRowsRequest, OntologyStore, TurboLedgerService, TurboLedgerTools,
+};
+
+fn service(workbook_path: &std::path::Path) -> TurboLedgerService {
+    TurboLedgerService::from_manifest_str(&format!(
+        "{}\n[accounts.WF-BH-CHK]\ninstitution=\"Wise\"\ntype=\"checking\"\ncurrency=\"USD\"\n",
+        common::manifest_for_workbook(workbook_path, 2023)
+    ))
+    .expect("manifest")
+}
+
+fn cell_text<T>(range: &calamine::Range<T>, row: usize, col: usize) -> Option<String>
+where
+    T: calamine::CellType + ToString,
+{
+    range.get((row, col)).map(ToString::to_string)
+}
+
+#[test]
+fn audit_playbook_ids_match_across_workbook_ontology_and_events() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workbook_path = temp.path().join("tax-ledger.xlsx");
+    let journal_path = temp.path().join("ledger.beancount");
+    let ontology_path = temp.path().join("ontology.json");
+    let cpa_path = temp.path().join("cpa.xlsx");
+    let svc = service(&workbook_path);
+    let row = TransactionInput {
+        account_id: "WF-BH-CHK".to_string(),
+        date: "2023-01-15".to_string(),
+        amount: "-42.11".to_string(),
+        description: "Coffee Shop".to_string(),
+        source_ref: temp.path().join("wf-2023-01.rkyv").display().to_string(),
+    };
+    let expected_tx_id = deterministic_tx_id(&row);
+
+    let ingest = svc
+        .ingest_statement_rows(IngestStatementRowsRequest {
+            journal_path,
+            workbook_path,
+            ontology_path: Some(ontology_path.clone()),
+            rows: vec![row],
+        })
+        .expect("ingest rows");
+    assert_eq!(ingest.tx_ids, vec![expected_tx_id.clone()]);
+
+    svc.classify_transaction(ClassifyTransactionRequest {
+        tx_id: expected_tx_id.clone(),
+        category: "Meals".to_string(),
+        confidence: "0.91".to_string(),
+        note: Some("audit playbook deterministic fallback".to_string()),
+        actor: "agent".to_string(),
+    })
+    .expect("classify");
+
+    svc.export_cpa_workbook(ExportCpaWorkbookRequest {
+        workbook_path: cpa_path.clone(),
+    })
+    .expect("export workbook");
+
+    let mut workbook = calamine::open_workbook_auto(cpa_path).expect("workbook opens");
+    let tx_sheet = workbook.worksheet_range("TX.WF-BH-CHK").expect("TX sheet");
+    assert_eq!(cell_text(&tx_sheet, 1, 0), Some(expected_tx_id.clone()));
+    assert_eq!(cell_text(&tx_sheet, 1, 4), Some("Meals".to_string()));
+
+    let audit = workbook.worksheet_range("AUDIT.log").expect("AUDIT.log");
+    assert!(
+        (1..audit.height()).any(|row| cell_text(&audit, row, 2) == Some(expected_tx_id.clone())),
+        "AUDIT.log should include tx_id {expected_tx_id}"
+    );
+
+    let store = OntologyStore::load(&ontology_path).expect("ontology store");
+    assert!(store.entities.iter().any(|entity| {
+        entity
+            .attrs
+            .get("tx_id")
+            .map(|tx_id| tx_id == &expected_tx_id)
+            .unwrap_or(false)
+    }));
+    assert!(store.edges.iter().any(|edge| {
+        edge.relation == "documents_transaction"
+            && edge
+                .provenance
+                .get("tx_id")
+                .map(|tx_id| tx_id == &expected_tx_id)
+                .unwrap_or(false)
+    }));
+
+    let history = svc
+        .event_history(EventHistoryFilter {
+            tx_id: Some(expected_tx_id.clone()),
+            document_ref: None,
+            time_start: None,
+            time_end: None,
+        })
+        .expect("event history");
+    assert!(history.events.iter().any(
+        |event| event.event_type == "ingest" && event.tx_id.as_deref() == Some(&expected_tx_id)
+    ));
+}

--- a/crates/ledgerr-mcp/tests/contract_codegen.rs
+++ b/crates/ledgerr-mcp/tests/contract_codegen.rs
@@ -60,10 +60,64 @@ fn documents_contract_accepts_legacy_account_alias() {
     .expect("documents args parse");
 
     match parsed {
-        DocumentsArgs::IngestRows { rows, .. } => {
+        DocumentsArgs::IngestRows {
+            ontology_path,
+            rows,
+            ..
+        } => {
+            assert_eq!(ontology_path, None);
             assert_eq!(rows.len(), 1);
             assert_eq!(rows[0].account.as_deref(), Some("WF-BH-CHK"));
             assert_eq!(rows[0].account_id, None);
+        }
+        other => panic!("unexpected variant: {other:?}"),
+    }
+}
+
+#[test]
+fn documents_contract_accepts_optional_ontology_path_for_ingest() {
+    let rows = contract::parse_documents(&json!({
+        "action": "ingest_rows",
+        "journal_path": "/tmp/demo.beancount",
+        "workbook_path": "/tmp/demo.xlsx",
+        "ontology_path": "/tmp/demo.ontology.json",
+        "rows": [{
+            "account_id": "WF-BH-CHK",
+            "date": "2023-01-15",
+            "amount": "-42.11",
+            "description": "Coffee Shop",
+            "source_ref": "wf-2023-01.rkyv"
+        }]
+    }))
+    .expect("documents ingest rows args parse");
+
+    match rows {
+        DocumentsArgs::IngestRows { ontology_path, .. } => {
+            assert_eq!(
+                ontology_path,
+                Some(PathBuf::from("/tmp/demo.ontology.json"))
+            );
+        }
+        other => panic!("unexpected variant: {other:?}"),
+    }
+
+    let pdf = contract::parse_documents(&json!({
+        "action": "ingest_pdf",
+        "pdf_path": "WF--BH-CHK--2023-01--statement.pdf",
+        "journal_path": "/tmp/demo.beancount",
+        "workbook_path": "/tmp/demo.xlsx",
+        "ontology_path": "/tmp/demo.ontology.json",
+        "raw_context_bytes": [99, 116, 120],
+        "extracted_rows": []
+    }))
+    .expect("documents ingest pdf args parse");
+
+    match pdf {
+        DocumentsArgs::IngestPdf { ontology_path, .. } => {
+            assert_eq!(
+                ontology_path,
+                Some(PathBuf::from("/tmp/demo.ontology.json"))
+            );
         }
         other => panic!("unexpected variant: {other:?}"),
     }

--- a/crates/ledgerr-mcp/tests/document_inventory.rs
+++ b/crates/ledgerr-mcp/tests/document_inventory.rs
@@ -34,6 +34,7 @@ fn document_inventory_lists_ready_ingested_and_invalid_documents_deterministical
         .ingest_statement_rows(IngestStatementRowsRequest {
             journal_path: tmp.path().join("ledger.beancount"),
             workbook_path: workbook_path.clone(),
+            ontology_path: None,
             rows: vec![TransactionInput {
                 account_id: "WF-BH-CHK".to_string(),
                 date: "2023-01-15".to_string(),

--- a/crates/ledgerr-mcp/tests/e2e_bdd.rs
+++ b/crates/ledgerr-mcp/tests/e2e_bdd.rs
@@ -23,6 +23,7 @@ fn bdd_e2e_ingest_statement_and_retrieve_evidence_context() {
         pdf_path: "WF--BH-CHK--2023-01--statement.pdf".to_string(),
         journal_path: journal_path.clone(),
         workbook_path: workbook_path.clone(),
+        ontology_path: None,
         raw_context_bytes: Some(b"raw-evidence-bytes".to_vec()),
         extracted_rows: vec![TransactionInput {
             account_id: "WF-BH-CHK".to_string(),
@@ -69,6 +70,7 @@ fn bdd_e2e_reingest_is_idempotent_across_mcp_and_artifacts() {
         pdf_path: "WF--BH-CHK--2023-01--statement.pdf".to_string(),
         journal_path: journal_path.clone(),
         workbook_path: workbook_path.clone(),
+        ontology_path: None,
         raw_context_bytes: Some(b"raw-evidence-bytes".to_vec()),
         extracted_rows: vec![TransactionInput {
             account_id: "WF-BH-CHK".to_string(),
@@ -104,6 +106,7 @@ fn bdd_e2e_rejects_non_contract_pdf_filename() {
         pdf_path: "not-contract.pdf".to_string(),
         journal_path: tmp.path().join("ledger.beancount"),
         workbook_path: tmp.path().join("tax-ledger.xlsx"),
+        ontology_path: None,
         raw_context_bytes: Some(b"ctx".to_vec()),
         extracted_rows: vec![TransactionInput {
             account_id: "WF-BH-CHK".to_string(),
@@ -137,6 +140,7 @@ fn bdd_e2e_allows_missing_raw_bytes_if_source_ref_already_exists() {
         pdf_path: "WF--BH-CHK--2023-01--statement.pdf".to_string(),
         journal_path: tmp.path().join("ledger.beancount"),
         workbook_path: tmp.path().join("tax-ledger.xlsx"),
+        ontology_path: None,
         raw_context_bytes: None,
         extracted_rows: vec![TransactionInput {
             account_id: "WF-BH-CHK".to_string(),
@@ -173,6 +177,7 @@ fn bdd_e2e_requires_raw_bytes_when_source_ref_missing() {
         pdf_path: "WF--BH-CHK--2023-01--statement.pdf".to_string(),
         journal_path: tmp.path().join("ledger.beancount"),
         workbook_path: tmp.path().join("tax-ledger.xlsx"),
+        ontology_path: None,
         raw_context_bytes: None,
         extracted_rows: vec![TransactionInput {
             account_id: "WF-BH-CHK".to_string(),

--- a/crates/ledgerr-mcp/tests/e2e_mvp_flow.rs
+++ b/crates/ledgerr-mcp/tests/e2e_mvp_flow.rs
@@ -24,6 +24,7 @@ fn rel_03_e2e_mvp_flow_ingest_classify_audit_schedule() {
             pdf_path: "WF--BH-CHK--2023-01--statement.pdf".to_string(),
             journal_path: tmp.path().join("ledger.beancount"),
             workbook_path: tmp.path().join("tax-ledger.xlsx"),
+            ontology_path: None,
             raw_context_bytes: Some(b"ctx".to_vec()),
             extracted_rows: vec![TransactionInput {
                 account_id: "WF-BH-CHK".to_string(),

--- a/crates/ledgerr-mcp/tests/events_contract.rs
+++ b/crates/ledgerr-mcp/tests/events_contract.rs
@@ -33,6 +33,7 @@ fn evt_01_lifecycle_actions_append_typed_events_without_mutating_prior_entries()
         .ingest_statement_rows(IngestStatementRowsRequest {
             journal_path: temp.path().join("ledger.beancount"),
             workbook_path: temp.path().join("tax-ledger.xlsx"),
+            ontology_path: None,
             rows: vec![row],
         })
         .expect("ingest");
@@ -104,6 +105,7 @@ fn evt_01_replaying_same_operation_produces_stable_payload_and_identity_inputs()
         .ingest_statement_rows(IngestStatementRowsRequest {
             journal_path: temp.path().join("ledger.beancount"),
             workbook_path: temp.path().join("tax-ledger.xlsx"),
+            ontology_path: None,
             rows: vec![row],
         })
         .expect("ingest");

--- a/crates/ledgerr-mcp/tests/events_replay_contract.rs
+++ b/crates/ledgerr-mcp/tests/events_replay_contract.rs
@@ -34,6 +34,7 @@ fn evt_02_replay_reconstructs_stable_state_across_runs() {
         .ingest_statement_rows(IngestStatementRowsRequest {
             journal_path: temp.path().join("ledger.beancount"),
             workbook_path: temp.path().join("tax-ledger.xlsx"),
+            ontology_path: None,
             rows: vec![row],
         })
         .expect("ingest");
@@ -139,6 +140,7 @@ fn evt_02_replay_filtering_by_tx_and_document_is_deterministic() {
         .ingest_statement_rows(IngestStatementRowsRequest {
             journal_path: temp.path().join("ledger.beancount"),
             workbook_path: temp.path().join("tax-ledger.xlsx"),
+            ontology_path: None,
             rows,
         })
         .expect("ingest");

--- a/crates/ledgerr-mcp/tests/interface.rs
+++ b/crates/ledgerr-mcp/tests/interface.rs
@@ -72,6 +72,7 @@ fn ingest_statement_rows_writes_git_friendly_journal_once() {
         .ingest_statement_rows(IngestStatementRowsRequest {
             journal_path: journal_path.clone(),
             workbook_path: workbook_path.clone(),
+            ontology_path: None,
             rows: rows.clone(),
         })
         .unwrap();
@@ -79,6 +80,7 @@ fn ingest_statement_rows_writes_git_friendly_journal_once() {
         .ingest_statement_rows(IngestStatementRowsRequest {
             journal_path: journal_path.clone(),
             workbook_path,
+            ontology_path: None,
             rows,
         })
         .unwrap();
@@ -104,6 +106,7 @@ fn ingest_pdf_validates_filename_and_ingests_rows() {
             pdf_path: "WF--BH-CHK--2023-01--statement.pdf".to_string(),
             journal_path,
             workbook_path,
+            ontology_path: None,
             raw_context_bytes: Some(b"ctx".to_vec()),
             extracted_rows: vec![TransactionInput {
                 account_id: "WF-BH-CHK".to_string(),

--- a/crates/ledgerr-mcp/tests/ontology_contract.rs
+++ b/crates/ledgerr-mcp/tests/ontology_contract.rs
@@ -2,10 +2,18 @@ mod common;
 
 use std::collections::BTreeMap;
 
-use ledgerr_mcp::{
-    OntologyEdgeInput, OntologyEntityInput, OntologyEntityKind, OntologyQueryPathRequest,
-    OntologyUpsertEdgesRequest, OntologyUpsertEntitiesRequest, TurboLedgerService,
+use ledger_core::ingest::{deterministic_tx_id, TransactionInput};
+use ledger_core::ontology::Relation;
+use ledger_core::proposal::{
+    ModelMetadata, OntologyEdgeProposal, ProposalPolicy, ProposalState, ProposalValidation,
 };
+use ledgerr_mcp::{
+    mcp_adapter, IngestStatementRowsRequest, OntologyEdgeInput, OntologyEntityInput,
+    OntologyEntityKind, OntologyQueryPathRequest, OntologyStore, OntologyUpsertEdgesRequest,
+    OntologyUpsertEntitiesRequest, TurboLedgerService, TurboLedgerTools,
+};
+use rust_decimal::Decimal;
+use serde_json::json;
 use tempfile::tempdir;
 
 fn service() -> TurboLedgerService {
@@ -239,5 +247,239 @@ fn onto_02_relationship_query_returns_ordered_document_chain() {
                 "links_tax_category".to_string(),
             ),
         ]
+    );
+}
+
+// ONTO-04 / PRD-4 Phase 1: MCP store converts to the canonical ledger-core snapshot
+// without changing legacy IDs or persisted entity/edge shape.
+#[test]
+fn ontology_core_snapshot_conversion_preserves_legacy_ids() {
+    let mut doc_attrs = BTreeMap::new();
+    doc_attrs.insert("source_ref".to_string(), "wf-statement.pdf".to_string());
+    let mut tx_attrs = BTreeMap::new();
+    tx_attrs.insert("tx_id".to_string(), "tx-001".to_string());
+
+    let mut store = OntologyStore::default();
+    let entities = store
+        .upsert_entities(vec![
+            OntologyEntityInput {
+                kind: OntologyEntityKind::Document,
+                attrs: doc_attrs,
+            },
+            OntologyEntityInput {
+                kind: OntologyEntityKind::Transaction,
+                attrs: tx_attrs,
+            },
+        ])
+        .expect("entities");
+
+    let doc_id = entities.entity_ids[0].clone();
+    let tx_id = entities.entity_ids[1].clone();
+    store
+        .upsert_edges(vec![OntologyEdgeInput {
+            from: doc_id.clone(),
+            to: tx_id.clone(),
+            relation: "documents_transaction".to_string(),
+            provenance: BTreeMap::new(),
+        }])
+        .expect("edge");
+
+    let snapshot = store.to_core_snapshot();
+    assert_eq!(snapshot.artifacts.len(), 2);
+    assert_eq!(snapshot.relations.len(), 1);
+    assert!(snapshot
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.id == doc_id));
+    assert!(snapshot
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.id == tx_id));
+    assert_eq!(snapshot.relations[0].relation, "documents_transaction");
+}
+
+// ONTO-04 / PRD-4 Phase 1: the advertised entity kinds map through the legacy MCP
+// adapter into the canonical core kind aliases.
+#[test]
+fn ontology_legacy_payload_maps_to_core_types() {
+    let service = service();
+    let tmp = tempdir().expect("tempdir");
+    let ontology_path = tmp.path().join("ontology.json");
+
+    let response = mcp_adapter::handle_ontology_tool(
+        &service,
+        &json!({
+            "action": "upsert_entities",
+            "ontology_path": ontology_path.display().to_string(),
+            "entities": [
+                {"kind": "XeroContact", "properties": {"xero_id": "contact-1"}},
+                {"kind": "XeroBankAccount", "properties": {"xero_id": "bank-1"}},
+                {"kind": "XeroInvoice", "properties": {"xero_id": "invoice-1"}},
+                {"kind": "WorkflowTag", "properties": {"tag": "#needs-review"}}
+            ]
+        }),
+    );
+
+    assert_eq!(response["isError"], false);
+    let payload: serde_json::Value = serde_json::from_str(
+        response["content"][0]["text"]
+            .as_str()
+            .expect("text payload"),
+    )
+    .expect("json payload");
+    assert_eq!(payload["upserted"], 4);
+
+    let store = OntologyStore::load(&ontology_path).expect("store");
+    assert_eq!(
+        store
+            .entities
+            .iter()
+            .map(|entity| entity.kind)
+            .collect::<Vec<_>>(),
+        vec![
+            OntologyEntityKind::XeroContact,
+            OntologyEntityKind::XeroBankAccount,
+            OntologyEntityKind::XeroInvoice,
+            OntologyEntityKind::WorkflowTag,
+        ]
+    );
+}
+
+// ONTO-05 / PRD-4 Phase 2: row ingest emits deterministic source-to-transaction
+// ontology facts without requiring a separate manual ontology upsert.
+#[test]
+fn ingest_rows_emits_document_to_transaction_ontology_edges() {
+    let service = service();
+    let tmp = tempdir().expect("tempdir");
+    let journal_path = tmp.path().join("ledger.beancount");
+    let workbook_path = tmp.path().join("tax-ledger.xlsx");
+    let ontology_path = tmp.path().join("ontology.json");
+    let row = TransactionInput {
+        account_id: "WF-BH-CHK".to_string(),
+        date: "2023-01-15".to_string(),
+        amount: "-42.11".to_string(),
+        description: "Coffee Shop".to_string(),
+        source_ref: "source/wf-ctx.rkyv".to_string(),
+    };
+    let tx_id = deterministic_tx_id(&row);
+
+    let first = service
+        .ingest_statement_rows(IngestStatementRowsRequest {
+            journal_path: journal_path.clone(),
+            workbook_path: workbook_path.clone(),
+            ontology_path: Some(ontology_path.clone()),
+            rows: vec![row.clone()],
+        })
+        .expect("first ingest");
+    let second = service
+        .ingest_statement_rows(IngestStatementRowsRequest {
+            journal_path,
+            workbook_path: workbook_path.clone(),
+            ontology_path: Some(ontology_path.clone()),
+            rows: vec![row],
+        })
+        .expect("second ingest");
+
+    assert_eq!(first.inserted_count, 1);
+    assert_eq!(second.inserted_count, 0);
+
+    let store = OntologyStore::load(&ontology_path).expect("ontology store");
+    assert_eq!(store.entities.len(), 2);
+    assert_eq!(store.edges.len(), 1);
+    assert_eq!(store.edges[0].relation, "documents_transaction");
+    assert_eq!(store.edges[0].provenance.get("tx_id"), Some(&tx_id));
+
+    let snapshot = store.to_core_snapshot();
+    assert_eq!(snapshot.artifacts.len(), 2);
+    assert_eq!(snapshot.relations.len(), 1);
+}
+
+#[test]
+fn semantic_context_refs_are_added_to_model_provenance() {
+    let service = service();
+    let tmp = tempdir().expect("tempdir");
+    let ontology_path = tmp.path().join("ontology.json");
+
+    let entities = service
+        .ontology_upsert_entities(OntologyUpsertEntitiesRequest {
+            ontology_path: ontology_path.clone(),
+            entities: vec![
+                OntologyEntityInput {
+                    kind: OntologyEntityKind::Transaction,
+                    attrs: {
+                        let mut attrs = BTreeMap::new();
+                        attrs.insert("tx_id".to_string(), "tx-semantic-001".to_string());
+                        attrs
+                    },
+                },
+                OntologyEntityInput {
+                    kind: OntologyEntityKind::TaxCategory,
+                    attrs: {
+                        let mut attrs = BTreeMap::new();
+                        attrs.insert("category".to_string(), "SelfEmployment".to_string());
+                        attrs
+                    },
+                },
+            ],
+        })
+        .expect("entities should upsert");
+
+    let proposal = OntologyEdgeProposal {
+        proposal_id: "proposal-semantic-001".to_string(),
+        proposed_relation: Relation {
+            id: "draft-edge".to_string(),
+            from: entities.entity_ids[0].clone(),
+            to: entities.entity_ids[1].clone(),
+            relation: "links_tax_category".to_string(),
+            provenance: BTreeMap::new(),
+        },
+        confidence: Decimal::new(95, 2),
+        source_artifact_ids: vec![entities.entity_ids[0].clone()],
+        semantic_context_ids: vec!["semantic-rule-a".to_string(), "semantic-rule-b".to_string()],
+        model_metadata: ModelMetadata {
+            provider: "internal".to_string(),
+            model: "phi-4-mini-reasoning".to_string(),
+            endpoint_url: "http://127.0.0.1:15115/v1/chat/completions".to_string(),
+        },
+        validation: Some(ProposalValidation {
+            validator: "ledger-core".to_string(),
+            passed: true,
+            checked_at: "2026-04-28T00:00:00Z".to_string(),
+            notes: "semantic context is traceable".to_string(),
+        }),
+        approval: None,
+        state: ProposalState::Validated,
+    };
+    let relation = proposal
+        .commit_relation(&ProposalPolicy::default())
+        .expect("validated high-confidence proposal commits");
+
+    service
+        .ontology_upsert_edges(OntologyUpsertEdgesRequest {
+            ontology_path: ontology_path.clone(),
+            edges: vec![OntologyEdgeInput {
+                from: relation.from,
+                to: relation.to,
+                relation: relation.relation,
+                provenance: relation.provenance,
+            }],
+        })
+        .expect("edge should upsert");
+
+    let store = OntologyStore::load(&ontology_path).expect("ontology store");
+    let edge = store
+        .edges
+        .iter()
+        .find(|edge| edge.relation == "links_tax_category")
+        .expect("committed semantic edge");
+    assert_eq!(
+        edge.provenance
+            .get("semantic_context_ids")
+            .map(String::as_str),
+        Some("semantic-rule-a,semantic-rule-b")
+    );
+    assert_eq!(
+        edge.provenance.get("model_name").map(String::as_str),
+        Some("phi-4-mini-reasoning")
     );
 }

--- a/crates/ledgerr-mcp/tests/phase2_mcp_contract_remaining.rs
+++ b/crates/ledgerr-mcp/tests/phase2_mcp_contract_remaining.rs
@@ -16,6 +16,7 @@ fn mcp_01_ingest_pdf_returns_deterministic_tx_ids_from_real_ingest() {
             pdf_path: "WF--BH-CHK--2023-01--statement.pdf".to_string(),
             journal_path: dir.path().join("ledger.beancount"),
             workbook_path: dir.path().join("tax-ledger.xlsx"),
+            ontology_path: None,
             raw_context_bytes: Some(b"abc".to_vec()),
             extracted_rows: vec![TransactionInput {
                 account_id: "WF-BH-CHK".to_string(),

--- a/crates/ledgerr-mcp/tests/phase3_mcp_classification.rs
+++ b/crates/ledgerr-mcp/tests/phase3_mcp_classification.rs
@@ -71,6 +71,7 @@ fn mcp_03_query_flags_returns_review_queue_by_year_and_status() {
             pdf_path: "WF--BH-CHK--2023-01--statement.pdf".to_string(),
             journal_path,
             workbook_path,
+            ontology_path: None,
             raw_context_bytes: Some(b"ctx".to_vec()),
             extracted_rows: vec![TransactionInput {
                 account_id: "WF-BH-CHK".to_string(),

--- a/crates/ledgerr-mcp/tests/phase4_audit_integrity.rs
+++ b/crates/ledgerr-mcp/tests/phase4_audit_integrity.rs
@@ -21,6 +21,7 @@ fn ingest_one(svc: &TurboLedgerService, description: &str, amount: &str) -> Stri
             pdf_path: "WF--BH-CHK--2023-01--statement.pdf".to_string(),
             journal_path: dir.path().join("ledger.beancount"),
             workbook_path: dir.path().join("tax-ledger.xlsx"),
+            ontology_path: None,
             raw_context_bytes: Some(b"ctx".to_vec()),
             extracted_rows: vec![TransactionInput {
                 account_id: "WF-BH-CHK".to_string(),

--- a/crates/ledgerr-mcp/tests/phase5_cpa_outputs.rs
+++ b/crates/ledgerr-mcp/tests/phase5_cpa_outputs.rs
@@ -25,6 +25,7 @@ fn ingest(svc: &TurboLedgerService, description: &str, amount: &str, date: &str)
             pdf_path: "WF--BH-CHK--2023-01--statement.pdf".to_string(),
             journal_path: dir.path().join("ledger.beancount"),
             workbook_path: dir.path().join("tax-ledger.xlsx"),
+            ontology_path: None,
             raw_context_bytes: Some(b"ctx".to_vec()),
             extracted_rows: vec![TransactionInput {
                 account_id: "WF-BH-CHK".to_string(),

--- a/crates/ledgerr-mcp/tests/phase6_mcp_exposure_gaps.rs
+++ b/crates/ledgerr-mcp/tests/phase6_mcp_exposure_gaps.rs
@@ -739,6 +739,7 @@ fn invariant_classify_ingested_confidence_is_decimal_exact() {
         pdf_path: "WF--BH-CHK--2023-01--statement.pdf".to_string(),
         journal_path: dir.path().join("ledger.beancount"),
         workbook_path: dir.path().join("tax.xlsx"),
+        ontology_path: None,
         raw_context_bytes: Some(b"ctx".to_vec()),
         extracted_rows: vec![TransactionInput {
             account_id: "WF-BH-CHK".to_string(),
@@ -804,6 +805,7 @@ fn invariant_query_flags_confidence_is_decimal_exact() {
         pdf_path: "WF--BH-CHK--2023-01--statement.pdf".to_string(),
         journal_path: dir.path().join("ledger.beancount"),
         workbook_path: dir.path().join("tax.xlsx"),
+        ontology_path: None,
         raw_context_bytes: Some(b"ctx".to_vec()),
         extracted_rows: vec![TransactionInput {
             account_id: "WF-BH-CHK".to_string(),

--- a/crates/ledgerr-mcp/tests/restart_persistence.rs
+++ b/crates/ledgerr-mcp/tests/restart_persistence.rs
@@ -39,6 +39,7 @@ fn restart_01_persists_ingest_review_audit_state_and_idempotency() {
             .ingest_statement_rows(IngestStatementRowsRequest {
                 journal_path: journal_path.clone(),
                 workbook_path: workbook_path.clone(),
+                ontology_path: None,
                 rows: vec![row.clone()],
             })
             .expect("ingest");
@@ -60,6 +61,7 @@ fn restart_01_persists_ingest_review_audit_state_and_idempotency() {
         .ingest_statement_rows(IngestStatementRowsRequest {
             journal_path: journal_path.clone(),
             workbook_path: workbook_path.clone(),
+            ontology_path: None,
             rows: vec![row],
         })
         .expect("reingest after restart");
@@ -113,6 +115,7 @@ fn restart_02_persists_event_history_and_replay_state() {
             .ingest_statement_rows(IngestStatementRowsRequest {
                 journal_path: journal_path.clone(),
                 workbook_path: workbook_path.clone(),
+                ontology_path: None,
                 rows: vec![row.clone()],
             })
             .expect("ingest");

--- a/crates/ledgerr-mcp/tests/tax_evidence_chain_contract.rs
+++ b/crates/ledgerr-mcp/tests/tax_evidence_chain_contract.rs
@@ -25,6 +25,7 @@ fn seed_chain_fixture(
         .ingest_statement_rows(IngestStatementRowsRequest {
             journal_path: temp.path().join("ledger.beancount"),
             workbook_path: temp.path().join("tax-ledger.xlsx"),
+            ontology_path: None,
             rows: vec![TransactionInput {
                 account_id: "WF-BH-CHK".to_string(),
                 date: "2023-01-15".to_string(),

--- a/scripts/mcp_cli_demo.sh
+++ b/scripts/mcp_cli_demo.sh
@@ -1,23 +1,37 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-JOURNAL_PATH="${JOURNAL_PATH:-/tmp/demo.beancount}"
-WORKBOOK_PATH="${WORKBOOK_PATH:-/tmp/demo.xlsx}"
+DEMO_ROOT="${DEMO_ROOT:-/tmp/l3dg3rr-mcp-demo-$$}"
+JOURNAL_PATH="${JOURNAL_PATH:-$DEMO_ROOT/demo.beancount}"
+WORKBOOK_PATH="${WORKBOOK_PATH:-$DEMO_ROOT/demo.xlsx}"
+ONTOLOGY_PATH="${ONTOLOGY_PATH:-$DEMO_ROOT/demo.ontology.json}"
 SOURCE_REF="${SOURCE_REF:-wf-2023-01.rkyv}"
+MODE="${1:-basic}"
 
-cargo run -q -p ledgerr-mcp --bin ledgerr-mcp-server <<EOF
+if [[ "$MODE" == "basic" ]]; then
+  cargo run -q -p ledgerr-mcp --bin ledgerr-mcp-server <<EOF
 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"demo","version":"0.1.0"}}}
 {"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
 {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
 {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"pipeline_status"}}}
 {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"list_accounts"}}}
-{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"ingest_pdf","pdf_path":"WF--BH-CHK--2023-01--statement.pdf","journal_path":"$JOURNAL_PATH","workbook_path":"$WORKBOOK_PATH","raw_context_bytes":[99,116,120],"extracted_rows":[{"account_id":"WF-BH-CHK","date":"2023-01-15","amount":"-42.11","description":"Coffee Shop","source_ref":"$SOURCE_REF"}]}}}
-{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"get_raw_context","rkyv_ref":"$SOURCE_REF"}}}
+{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"ingest_pdf","pdf_path":"WF--BH-CHK--2023-01--statement.pdf","journal_path":"$JOURNAL_PATH","workbook_path":"$WORKBOOK_PATH","ontology_path":"$ONTOLOGY_PATH","raw_context_bytes":[99,116,120],"extracted_rows":[{"account_id":"WF-BH-CHK","date":"2023-01-15","amount":"-42.11","description":"Coffee Shop","source_ref":"$SOURCE_REF"}]}}}
+{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"ledgerr_audit","arguments":{"action":"event_history"}}}
+{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"ledgerr_ontology","arguments":{"action":"export_snapshot","ontology_path":"$ONTOLOGY_PATH"}}}
 EOF
+  exit 0
+fi
 
-# Troubleshooting path
-cat <<'EOF'
+if [[ "$MODE" == "spinning-wheels" ]]; then
+  cargo run -q -p ledgerr-mcp --bin ledgerr-mcp-server <<'EOF'
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"demo","version":"0.1.0"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"ledgerr_workflow","arguments":{"action":"resume","state_marker":"invalid-checkpoint"}}}
 {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"ledgerr_reconciliation","arguments":{"action":"commit","source_total":"100.00","extracted_total":"95.00","posting_amounts":["-95.00","95.00"]}}}
 {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"ledgerr_audit","arguments":{"action":"event_history","time_start":"2026-12-31","time_end":"2026-01-01"}}}
 EOF
+  exit 0
+fi
+
+echo "usage: $0 [basic|spinning-wheels]" >&2
+exit 2

--- a/scripts/mcp_cli_demo.sh
+++ b/scripts/mcp_cli_demo.sh
@@ -8,6 +8,8 @@ ONTOLOGY_PATH="${ONTOLOGY_PATH:-$DEMO_ROOT/demo.ontology.json}"
 SOURCE_REF="${SOURCE_REF:-wf-2023-01.rkyv}"
 MODE="${1:-basic}"
 
+mkdir -p "$DEMO_ROOT"
+
 if [[ "$MODE" == "basic" ]]; then
   cargo run -q -p ledgerr-mcp --bin ledgerr-mcp-server <<EOF
 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"demo","version":"0.1.0"}}}


### PR DESCRIPTION
## Summary

Implements PRD-4 as a staged ontology and local Phi-4 integration plan, then lands the first implementation slices through the end-to-end audit playbook.

- Adds `PRD-4.md` with phased product requirements, visual-first audit diagrams, and required tests.
- Adds canonical `ledger-core::ontology` primitives and MCP compatibility mapping while preserving legacy ontology payload shape and hash prefixes.
- Adds opt-in ingest ontology emission, ontology-to-Rhai visual DSL output, typed host-owned Phi-4 classification jobs, proposal lifecycle enforcement, deterministic local semantic retrieval, and an audit playbook contract.
- Updates mdBook capability/playbook docs, MCP CLI demo flows, and durable `AGENTS.md` guidance.

## Validation

- `cargo test -p ledger-core ontology_`
- `cargo test -p ledger-core ontology_snapshot_to_rhai_dsl`
- `cargo test -p ledger-core proposal`
- `cargo test -p ledger-core semantic`
- `cargo test -p ledger-core rule_registry`
- `cargo test -p ledgerr-host`
- `cargo test -p ledgerr-mcp`
- `cargo test -p ledgerr-mcp audit_playbook_ids_match_across_workbook_ontology_and_events`
- `cargo test -p ledgerr-host internal_phi_fallback_runs_audit_playbook_prompt`
- `just mcp-cli-basic`
- `just mcp-cli-spinning-wheels`
- `just docgen-check`
- `git diff --check`

`just test` was started and progressed through the workspace into the real Phi-4 smoke tests; it was still running in the local model output tests when the publish request arrived. Focused Phase 7 and prior-phase gates passed.