### PR TITLE
docs(release): odd/even minor version policy + Justfile enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,23 +108,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  docs:
+  docs-check:
     needs: test-and-build
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/feature/'))
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
 
       - name: Install just
         run: cargo install just --locked
@@ -146,10 +139,3 @@ jobs:
 
       - name: Validate docs
         run: just docgen-check
-
-      - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/feature/'))
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./book/book

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,11 +19,6 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
       - name: Install just
         run: cargo install just --locked
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    tags: ['v[0-9]*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install just
+        run: cargo install just --locked
+
+      - name: Setup mdBook
+        uses: jontze/action-mdbook@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          use-mermaid: true
+
+      - name: Install mdbook binaries
+        run: cargo install mdbook mdbook-mermaid --locked
+
+      - name: Install mdbook-admonish
+        run: cargo install mdbook-admonish --locked
+
+      - name: Install mdbook-rhai-mermaid
+        run: cargo install --path crates/mdbook-rhai-mermaid
+
+      - name: Build docs
+        run: just docgen
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./book/book

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,6 @@ on:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 # Only one release run at a time — concurrent runs cause duplicate cog bump commits
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
 
 permissions:
   contents: write
+  pages: write
+  id-token: write
 
 # Only one release run at a time — concurrent runs cause duplicate cog bump commits
 concurrency:
@@ -65,12 +67,34 @@ jobs:
             fi
           }
 
-      - name: Create GitHub Release
-        if: steps.release_check.outputs.exists == 'false'
+      - name: Determine release parity
+        id: parity
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          MINOR=$(echo "$TAG" | sed 's/^v[0-9]*\.\([0-9]*\)\..*/\1/')
+          if [ $(( MINOR % 2 )) -eq 0 ]; then
+            echo "is_stable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_stable=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release (stable even minor)
+        if: steps.release_check.outputs.exists == 'false' && steps.parity.outputs.is_stable == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ steps.tag.outputs.tag }}" \
-            --title "${{ steps.tag.outputs.tag }}" \
-            --notes-file RELEASE_NOTES.md
+            --title "${{ steps.tag.outputs.tag }} (stable)" \
+            --notes-file RELEASE_NOTES.md \
+            --latest
+
+      - name: Create GitHub Pre-release (dev odd minor)
+        if: steps.release_check.outputs.exists == 'false' && steps.parity.outputs.is_stable == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.tag.outputs.tag }}" \
+            --title "${{ steps.tag.outputs.tag }} (dev/experimental)" \
+            --notes-file RELEASE_NOTES.md \
+            --prerelease
 

--- a/Justfile
+++ b/Justfile
@@ -178,14 +178,14 @@ install-devtools:
         cargo install ripgrep --quiet
     fi
 
-    # Install fd-find via cargo if not found
-    if ! command -v fd >/dev/null 2>&1; then
+    # Install fd-find via cargo if neither the upstream nor Ubuntu/Debian binary name is found
+    if ! command -v fd >/dev/null 2>&1 && ! command -v fdfind >/dev/null 2>&1; then
         echo "Installing fd-find via cargo..."
         cargo install fd-find --quiet
     fi
 
-    # Install bat (syntax-highlighted pager) via cargo if not found
-    if ! command -v bat >/dev/null 2>&1; then
+    # Install bat (syntax-highlighted pager) via cargo if neither the upstream nor Ubuntu/Debian binary name is found
+    if ! command -v bat >/dev/null 2>&1 && ! command -v batcat >/dev/null 2>&1; then
         echo "Installing bat via cargo..."
         cargo install bat --quiet
     fi

--- a/Justfile
+++ b/Justfile
@@ -377,8 +377,7 @@ release version="patch": ensure-cog
         cargo test --workspace --all-targets --all-features
     else
         echo "Dev (odd minor) release — running fast test suite (phi4 inference skipped)..."
-        cargo test --workspace --all-targets --all-features \
-            -- --skip phi4_produces_output --skip phi4_mistral_produces_output
+        just test-fast
     fi
 
     ./scripts/e2e_mvp.sh

--- a/Justfile
+++ b/Justfile
@@ -344,8 +344,13 @@ test-fast:
     cargo test --workspace --all-targets --all-features \
         -- --skip phi4_produces_output --skip phi4_mistral_produces_output
 
-# Cocogitto release recipe (major|minor|patch, defaults to patch)
-# Creates the version bump commit + tag, pushes to origin, and creates a GitHub release.
+# Cocogitto release recipe (major|minor|patch, defaults to patch).
+#
+# Odd/even minor version policy (Ubuntu-style):
+#   Even minor (1.0, 1.2, 1.4, 1.8 …) — Stable. Full test gate incl. phi4 inference.
+#                                          GitHub release created. LTS supported.
+#   Odd minor  (1.1, 1.3, 1.5, 1.7 …) — Dev/Experimental. Fast test gate only.
+#                                          No GitHub release. No LTS support.
 release version="patch": ensure-cog
     #!/bin/bash
     set -euo pipefail
@@ -354,24 +359,49 @@ release version="patch": ensure-cog
         major|minor|patch) ;;
         *) echo "Invalid version: {{version}} (use major, minor, or patch)" && exit 1 ;;
     esac
-    echo "Running pre-release checks (fast suite — model-inference tests excluded)..."
-    cargo test --workspace --all-targets --all-features \
-        -- --skip phi4_produces_output --skip phi4_mistral_produces_output
+
+    # Determine what the next version will be to apply odd/even policy.
+    CURRENT=$(cog get-version)
+    CURRENT_MINOR=$(echo "$CURRENT" | cut -d. -f2)
+    if [ "{{version}}" = "minor" ]; then
+        NEXT_MINOR=$(( CURRENT_MINOR + 1 ))
+    elif [ "{{version}}" = "major" ]; then
+        NEXT_MINOR=0
+    else
+        NEXT_MINOR=$CURRENT_MINOR
+    fi
+    IS_EVEN=$(( NEXT_MINOR % 2 == 0 ))
+
+    if [ "$IS_EVEN" -eq 1 ]; then
+        echo "Stable (even minor) release — running full test suite including phi4 inference..."
+        cargo test --workspace --all-targets --all-features
+    else
+        echo "Dev (odd minor) release — running fast test suite (phi4 inference skipped)..."
+        cargo test --workspace --all-targets --all-features \
+            -- --skip phi4_produces_output --skip phi4_mistral_produces_output
+    fi
+
     ./scripts/e2e_mvp.sh
     echo "Bumping {{version}} version with cocogitto..."
     cog bump --{{version}}
     cog changelog
     echo "Pushing branch and tags..."
     git push --follow-tags
-    TAG=$(PATH="${HOME}/.cargo/bin:${PATH}" cog get-version | sed 's/^/v/')
-    echo "Creating GitHub release for ${TAG}..."
-    NOTES=$(awk "/^## ${TAG//./\\.}/,/^## v[0-9]/" CHANGELOG.md \
-        | grep -v "^## v[0-9]" | sed '/^[[:space:]]*$/d' | head -80)
-    gh release create "${TAG}" \
-        --title "${TAG}" \
-        --notes "${NOTES:-See CHANGELOG.md for details.}" \
-        --latest
-    echo "Release ${TAG} created: https://github.com/PromptExecution/l3dg3rr/releases/tag/${TAG}"
+    TAG=$(cog get-version | sed 's/^/v/')
+
+    if [ "$IS_EVEN" -eq 1 ]; then
+        echo "Stable release — creating GitHub release for ${TAG}..."
+        NOTES=$(awk "/^## ${TAG//./\\.}/,/^## v[0-9]/" CHANGELOG.md \
+            | grep -v "^## v[0-9]" | sed '/^[[:space:]]*$/d' | head -80)
+        gh release create "${TAG}" \
+            --title "${TAG} (stable)" \
+            --notes "${NOTES:-See CHANGELOG.md for details.}" \
+            --latest
+        echo "GitHub release created: https://github.com/PromptExecution/l3dg3rr/releases/tag/${TAG}"
+    else
+        echo "Dev release — no GitHub release created for odd minor ${TAG}."
+        echo "Tag ${TAG} pushed. Use 'just release minor' again to reach next stable even minor."
+    fi
 
 # Show current version
 v: ensure-cog

--- a/Justfile
+++ b/Justfile
@@ -154,6 +154,65 @@ test-phi4-mistral:
 unsloth-finetune-plan:
     @echo "TODO: install Unsloth and add a reproducible Phi-4 mini documentation fine-tuning recipe."
 
+# ─── Devtools (Linux) ─────────────────────────────────────────────────────
+
+# Install common developer tools missing from the base Ubuntu 24.04 image.
+# Skips tools that already exist so repeated runs are fast.
+# Tries apt first (needs sudo), falls back to cargo install where possible.
+install-devtools:
+    #!/bin/bash
+    set -euo pipefail
+    echo "=== install-devtools (Linux x86_64) ==="
+
+    # Prefer apt for system packages; skip if sudo requires a TTY
+    if sudo -n true 2>/dev/null; then
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq ripgrep fd-find bat hyperfine jq tree httpie shellcheck 2>/dev/null || true
+    else
+        echo "[skip] apt packages require interactive sudo — will use cargo fallbacks"
+    fi
+
+    # Install ripgrep via cargo if not found
+    if ! command -v rg >/dev/null 2>&1; then
+        echo "Installing ripgrep via cargo..."
+        cargo install ripgrep --quiet
+    fi
+
+    # Install fd-find via cargo if not found
+    if ! command -v fd >/dev/null 2>&1; then
+        echo "Installing fd-find via cargo..."
+        cargo install fd-find --quiet
+    fi
+
+    # Install bat (syntax-highlighted pager) via cargo if not found
+    if ! command -v bat >/dev/null 2>&1; then
+        echo "Installing bat via cargo..."
+        cargo install bat --quiet
+    fi
+
+    # Install hyperfine (benchmark runner) via cargo if not found
+    if ! command -v hyperfine >/dev/null 2>&1; then
+        echo "Installing hyperfine via cargo..."
+        cargo install hyperfine --quiet
+    fi
+
+    # Install cargo-binstall (binary installer for Rust tools)
+    if ! command -v cargo-binstall >/dev/null 2>&1; then
+        echo "Installing cargo-binstall via cargo..."
+        cargo install cargo-binstall --quiet
+    fi
+
+    # Install jq via binstall
+    if ! command -v jq >/dev/null 2>&1 && command -v cargo-binstall >/dev/null 2>&1; then
+        echo "Installing jq via cargo-binstall..."
+        cargo binstall -y jq --quiet 2>/dev/null || true
+    fi
+
+    # Install cargo-update (for `cargo install-update -a`)
+    cargo binstall -y cargo-update --quiet 2>/dev/null || true
+
+    echo "=== done ==="
+
 gh-secrets-help:
     @echo "Expected .env values (optional):"
     @echo "  CRATES_IO_TOKEN=..."
@@ -278,7 +337,15 @@ publish-registry tag artifact-url sha256:
 ensure-cog:
     @PATH="${HOME}/.cargo/bin:${PATH}" bash -eu -o pipefail -c 'if command -v cog >/dev/null 2>&1; then echo "Using existing cog"; else echo "cog not found; installing cocogitto..."; cargo install cocogitto; fi'
 
+# Fast test suite for release gates — skips model-inference tests that need GGUF assets.
+# phi4_produces_output and phi4_mistral_produces_output load a ~2 GB GGUF model and
+# can run for 10+ minutes; they are exercised separately via `just test-phi4`.
+test-fast:
+    cargo test --workspace --all-targets --all-features \
+        -- --skip phi4_produces_output --skip phi4_mistral_produces_output
+
 # Cocogitto release recipe (major|minor|patch, defaults to patch)
+# Creates the version bump commit + tag, pushes to origin, and creates a GitHub release.
 release version="patch": ensure-cog
     #!/bin/bash
     set -euo pipefail
@@ -287,14 +354,24 @@ release version="patch": ensure-cog
         major|minor|patch) ;;
         *) echo "Invalid version: {{version}} (use major, minor, or patch)" && exit 1 ;;
     esac
-    echo "Running pre-release checks..."
-    cargo test --workspace --all-targets --all-features
+    echo "Running pre-release checks (fast suite — model-inference tests excluded)..."
+    cargo test --workspace --all-targets --all-features \
+        -- --skip phi4_produces_output --skip phi4_mistral_produces_output
     ./scripts/e2e_mvp.sh
     echo "Bumping {{version}} version with cocogitto..."
     cog bump --{{version}}
     cog changelog
-    echo "Pushing tags..."
+    echo "Pushing branch and tags..."
     git push --follow-tags
+    TAG=$(PATH="${HOME}/.cargo/bin:${PATH}" cog get-version | sed 's/^/v/')
+    echo "Creating GitHub release for ${TAG}..."
+    NOTES=$(awk "/^## ${TAG//./\\.}/,/^## v[0-9]/" CHANGELOG.md \
+        | grep -v "^## v[0-9]" | sed '/^[[:space:]]*$/d' | head -80)
+    gh release create "${TAG}" \
+        --title "${TAG}" \
+        --notes "${NOTES:-See CHANGELOG.md for details.}" \
+        --latest
+    echo "Release ${TAG} created: https://github.com/PromptExecution/l3dg3rr/releases/tag/${TAG}"
 
 # Show current version
 v: ensure-cog

--- a/PRD-6.md
+++ b/PRD-6.md
@@ -680,7 +680,7 @@ Phase 0 (parallel with language changes)
 Phase 1 (after T1 is stable)
 ├── T5  criterion benchmarks
 ├── T6  cargo-fuzz for Rhai parser
-└── T7  iai/hyperfine regrssion gate
+└── T7  iai/hyperfine regression gate
 
 Phase 2 (ongoing)
 ├── T8  cargo profile config

--- a/PRD-6.md
+++ b/PRD-6.md
@@ -587,35 +587,134 @@ PRD-6 (Comprehensive)
 │   ├── rkyv zero-copy graph (§4 item 2)
 │   ├── self_cell safe self-ref graph (§4 item 11)
 │   └── snafu/rich error with source chains (§4 item 6)
-└── AI Integration
-    ├── candle embedding selector (§4 item 7)
-    └── serde_path_to_error LLM JSON (§4 item 8)
+├── AI Integration
+│   ├── candle embedding selector (§4 item 7)
+│   └── serde_path_to_error LLM JSON (§4 item 8)
+└── Test & Tooling Infrastructure (§6)
+    ├── T1  cargo nextest (parallel CI test runner)
+    ├── T2  proptest (property-based financial tests)
+    ├── T3  insta (snapshot testing for serde outputs)
+    ├── T4  rstest (parameterized integration tests)
+    ├── T5  criterion (graph/classify/solve benchmarks)
+    ├── T6  cargo-fuzz (Rhai parser input fuzzing)
+    ├── T7  iai/hyperfine (build regression gate)
+    ├── T8  cargo profile overrides (.cargo/config.toml)
+    ├── T9  CI nextest partitioning (3-way sharding)
+    ├── T10 Justfile guard dedup (shared ensure-* recipes)
+    ├── T11 cargo-binstall fast-installs in CI
+    └── T12 Remove dead deps fdg-sim, femtovg
 ```
 
 ---
 
-## 6. Implementation Plan
+## 6. Test & Tooling Infrastructure (New)
 
-### Phase 0: Std API + Idiom (1 sprint, no risk)
+The new devtools (`rg`, `fd`, `bat`, `hyperfine`, `cargo-binstall`) expose gaps in the current test infrastructure that PRD-6 should close alongside language modernization.
+
+### 6.1 Current State
+
+| Capability | Status | Pain Point |
+|---|---|---|
+| Test runner | `cargo test` (serial) | ~117 test functions; `cargo test --workspace --all-targets --all-features` exceeds 5 minutes |
+| Test isolation | None — all tests share process | No sandbox for filesystem I/O tests; leaked state between integration tests |
+| Property testing | Zero — no `proptest`, `quickcheck`, or `rstest` | Edge cases in Z3/cassowary constraints are manually enumerated, not generated |
+| Snapshot testing | Zero — no `insta` or `expect_test` | 46 serde JSON round-trips in tests are checked by hand, not by snapshot diff |
+| Benchmark harness | Zero — no `criterion` or `iai` | Can't measure regressions in petgraph traversal, Rhai classification, or Z3 solving |
+| Fuzz testing | Zero — no `cargo-fuzz` or `afl` | `parse_source()` in the Rhai parser has no generated-input coverage |
+| CI test parallelism | `cargo test` (single job) | No `cargo nextest` — CI wastes ~50% of runner time on serial test execution |
+| Cargo profile config | None — no `.cargo/config.toml` profiles | Dev builds are unoptimized; no `codegen-units = 1` for release benchmarks |
+| `just` tooling | Ad-hoc cargo installs in recipes | `docgen`, `docserve`, `docgen-check` each duplicate the `cargo install` guard logic |
+
+### 6.2 New Test Capabilities (by PRD-6 Phase)
+
+#### Phase 0: Test Infrastructure
+
+| # | Change | Tool | Effort | Value |
+|---|---|---|---|---|
+| T1 | **Adopt `cargo nextest`** as the primary test runner | `cargo nextest` (binstall) | 1 hour | Parallel test execution, per-test timing, JUnit XML output. Typical 3-5x speedup. CI job `cargo test` → `cargo nextest run` |
+| T2 | **Add `proptest` to `ledger-core`** for property-based tests | `proptest` 1.x | 1 day | Generated transaction amounts, dates, descriptions → verify `deterministic_tx_id()` is collision-free and stable. Generate Z3 constraint combinations → verify solver doesn't panic |
+| T3 | **Add `insta` snapshot testing** for serde JSON outputs | `insta` 1.x | 1 day | `OntologySnapshot::to_pretty_json_stable()`, `EvidenceGraph` serialization, `PipelineState` round-trips — one `insta::assert_json_snapshot!()` replaces 10 manual assertions |
+| T4 | **Add `rstest` for parameterized tests** | `rstest` 0.23 | 0.5 day | Replace manual test-data-fn duplication in `mcp_adapter_contract.rs`, `phase4_audit_integrity.rs` with `#[rstest]` + `#[case]` |
+
+#### Phase 1: Benchmark & Fuzz
+
+| # | Change | Tool | Effort | Value |
+|---|---|---|---|---|
+| T5 | **Add `criterion` benchmarks** for performance-critical paths | `criterion` 0.5 | 2 days | Petgraph traversal (arc-kit-au), Rhai classification (rule_registry), Z3 solving (legal.rs). Baseline + regression detection in CI |
+| T6 | **Add `cargo-fuzz` target** for Rhai parser | `cargo-fuzz` | 1 day | `mdbook-rhai-mermaid/src/parser.rs` takes untrusted user input (Rhai DSL). Fuzzing with generated strings finds panic/edge-case paths the manual tests miss |
+| T7 | **Add `iai` or `hyperfine` regression gate** on CI | `iai` 0.1 / `hyperfine` | 0.5 day | Measure `cargo build` time for `ledgerr-mcp` — catch unintentional compilation regressions from `derive_more` or `typed-builder` macro expansion |
+
+#### Phase 2: CI & Tooling
+
+| # | Change | Tool/Script | Effort | Value |
+|---|---|---|---|---|
+| T8 | **Add `cargo profile` overrides** in `.cargo/config.toml` | — | 0.5 day | `[profile.dev] codegen-units = 256` for fast iteration (current default). `[profile.bench]` with `lto = "fat"`, `codegen-units = 1` for reliable benchmarks |
+| T9 | **Update CI `test-and-build` job** to use `cargo nextest` | CI yml | 1 hour | Swap `cargo test` for `cargo nextest run --workspace --all-targets --all-features`. Add `--partition count:1/3` for 3-way sharding when test count grows |
+| T10 | **Factor `just install-{tool}` guards** into a shared recipe | Justfile | 0.5 day | Replace the 6 duplicated `@if [ ! -x ~/.cargo/bin/mdbook ]; then ...` blocks with `just ensure-mdbook`, `just ensure-mcp-parser` |
+| T11 | **Add `cargo-binstall` powered fast-installs** to CI | Justfile + CI | 1 hour | CI currently compiles `clippy-sarif`, `mdbook`, `mdbook-mermaid`, `mdbook-admonish` from source (~5 min each). `cargo binstall` installs them in seconds |
+| T12 | **Remove dead deps `fdg-sim`, `femtovg`** | `ledger-core/Cargo.toml` | 5 min | Unblocks WASM compilation, reduces compile time, removes false-positive `cargo audit` surface |
+
+### 6.3 Tooling Metrics
+
+| Metric | Current | Target | How |
+|---|---|---|---|
+| CI test time | ~5 min | <2 min | `cargo nextest` parallelism + `cargo binstall` tooling |
+| Test assertions per integration test | ~15 manual | ~30 (10 snapshot + 10 prop + 10 param) | `insta` snapshots + `proptest` generators |
+| Code paths tested by generation | 0 | 500+ per property test | `proptest` — transaction hash, Z3 constraint, filename validation |
+| Rhai parser fuzz coverage | 0 | 10,000+ inputs | `cargo-fuzz` on `parser::parse()` |
+| Benchmark baselines | 0 | 3 (graph, classify, solve) | `criterion` in `benches/` |
+| Build time change detection | None | CI fails if >10% regression | `iai` or `hyperfine` gate |
+| `just` recipe duplication | 6 copies of the same guard | 0 (1 shared recipe) | `just ensure-mdbook` |
+
+### 6.4 Implementation Order
+
+```
+Phase 0 (parallel with language changes)
+├── T1  cargo nextest (CI swap)
+├── T2  proptest for ledger-core
+├── T3  insta for serde snapshots
+├── T4  rstest for parameterization
+├── T12 Remove dead deps fdg-sim, femtovg
+└── T11 cargo-binstall in CI
+
+Phase 1 (after T1 is stable)
+├── T5  criterion benchmarks
+├── T6  cargo-fuzz for Rhai parser
+└── T7  iai/hyperfine regrssion gate
+
+Phase 2 (ongoing)
+├── T8  cargo profile config
+├── T9  CI nextest partitioning
+└── T10 Justfile guard dedup
+```
+
+---
+
+## 7. Implementation Plan
+
+### Phase 0: Std API + Idiom + Test Infra (1 sprint, no risk)
 1. `#[expect]` migration, `inspect()`, `let_chains`, `is_none_or()`, `map_or()`
 2. `.unwrap()` → `.expect()` in non-test `src/`
 3. `clippy::unwrap_used = "deny"` gate
 4. `rust-toolchain.toml` + `rust-version`
 5. `Duration::from_mins`, `Path::file_prefix`, `strict_*` in financial math
 6. `serde_path_to_error` in `agent_runtime.rs`
+7. **T1-T4, T11-T12** — `cargo nextest`, `proptest`, `insta`, `rstest`, `cargo-binstall` CI, dead dep removal
 
-### Phase 1: Trait + Type Refinement (1 sprint)
+### Phase 1: Trait + Type Refinement + Benchmarks (1 sprint)
 1. `derive_more` across all crates (Display, From, Into, Constructor)
 2. `typed-builder` for classification, proposal, evidence node structs
 3. `enum_dispatch` for `Verb` trait → `VerbImpl` enum
 4. `#[trait_variant]` on `ModelClient`
 5. `snafu` or rich `ToolError` + eliminate `ChatError` duplication
+6. **T5-T7** — `criterion` benchmarks, `cargo-fuzz`, `iai` regression gate
 
-### Phase 2: Core Architecture (2 sprints)
+### Phase 2: Core Architecture + CI (2 sprints)
 1. **Typestate `EvidenceChain<S>`** — replace `EvidenceBuilder` with compile-time chain
 2. **Self-referential graph** — `self_cell` + `rkyv` for zero-copy petgraph persistence
 3. **Refactor Z3** — from boolean wrapper to symbolic constraint solver with `check_assumptions` on free variables
 4. Edition 2024 migration per crate
+5. **T8-T10** — Cargo profiles, CI nextest partitioning, Justfile guard dedup
 
 ### Phase 3: Optional AI Embeddings (1 sprint, gated)
 1. `candle` embedding selector behind `#[cfg(feature = "candle-embeddings")]`
@@ -623,7 +722,9 @@ PRD-6 (Comprehensive)
 
 ---
 
-## 7. Success Metrics
+## 8. Success Metrics
+
+### 8.1 Language Modernization
 
 | Metric | Current | Target | Where |
 |---|---|---|---|
@@ -638,9 +739,24 @@ PRD-6 (Comprehensive)
 | `[allow]` count | 6 | 0 (all `[expect]`) | Codebase-wide |
 | Edition | 2021 | 2024 | All Cargo.toml |
 
+### 8.2 Test & Tooling
+
+| Metric | Current | Target | How |
+|---|---|---|---|
+| CI test time | ~5 min | <2 min | `cargo nextest` parallelism + `cargo binstall` tooling |
+| Test runner | `cargo test` (serial) | `cargo nextest` (parallel) | CI yml swap |
+| Property tests | 0 | 3 modules (hash, z3, filename) | `proptest` in `ledger-core/tests/` |
+| Snapshot tests | 0 | 10+ snapshots | `insta` for serde JSON output |
+| Parameterized tests | 0 | 20+ `#[case]` inputs | `rstest` in MCP adapter, audit tests |
+| Benchmark suites | 0 | 3 (graph, classify, solve) | `criterion` in `benches/` |
+| Fuzz targets | 0 | 1 (Rhai parser) | `cargo-fuzz` on `parser::parse()` |
+| Build regression gate | None | CI fails on >10% regression | `iai` or `hyperfine` |
+| Dead deps blocking WASM | `fdg-sim`, `femtovg` | 0 | Removed from `ledger-core/Cargo.toml` |
+| `just` recipe duplication | 6 copies | 0 (1 shared recipe) | `just ensure-mdbook` |
+
 ---
 
-## 8. Risk Register
+## 9. Risk Register
 
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
@@ -650,3 +766,127 @@ PRD-6 (Comprehensive)
 | Z3 symbolic refactor changes test behavior | Low | Medium | Wrapped in `#[cfg(test)]` property tests: symbolic solver output must match if/else output for all known facts |
 | `enum_dispatch` incompatible with associated types on `Verb` | Medium | High | Test with `cargo check` before committing; fallback: keep `Box<dyn Verb>` for `Verb` only, `enum_dispatch` for `LedgerOperation` |
 | Edition 2024 breaks Slint macro output | Medium | High | Test `cargo build -p ledgerr-tauri` after each phase; keep edition-2021 on `ledgerr-tauri` if needed |
+| `cargo nextest` requires nightly `dev` proc-macro support | Low | Medium | `cargo nextest` works on stable; test with `cargo nextest run` before CI swap |
+| `proptest` shrinks find latent bug in financial hash | Low | High | Feature — this is the *goal*; property tests are designed to find these |
+| `cargo-fuzz` catches panic in parser but fix requires parser refactor | Medium | Low | Pure gain — finding panics in untrusted input parsing is the purpose |
+
+---
+
+## 10. Appendix D: WASM as a Target — Good-Faith Critical Review
+
+### D.1 The Question
+
+*"Would deeper integration of WASM as a target benefit or complicate the application's internal shape and capability?"*
+
+Short answer: **WASM as a first-class target would complicate the codebase significantly for marginal current benefit, but a scoped WASM compilation of the pure-data crates (arc-kit-au, ledger-core computation) would improve the Rhai docs live-editor and enable in-browser evidence graph visualization without reshaping the application's architecture.**
+
+### D.2 Compatibility Matrix (Per Crate)
+
+| Crate | WASM Status | Key Blockers | Lines of `std::fs` |
+|---|---|---|---|
+| **arc-kit-au** | ✅ **Works-as-is** (core types) | `store.rs` uses `std::fs` (7 sites), separable | ~7 |
+| **ledger-core** | ⚠️ **Needs feature-gating** | `fdg-sim`/`femtovg` (dead deps), `z3` (C FFI, already gated), 15 `std::fs` sites | ~15 |
+| **ledgerr-mcp** | 🔴 **Incompatible** | `sysinfo`, `PathBuf`-addressed I/O throughout, 20+ `std::fs` sites | ~20 |
+| **ledgerr-host** | 🔴 **Incompatible** | Raw `TcpListener` server, `std::process` (5+ spawns), `tokio full`, Slint/windows-sys/tray-icon | ~20 |
+| **ledgerr-xero** | ⚠️ **Needs async migration** | `reqwest::blocking` + local OAuth2 redirect server | ~3 |
+| **ledgerr-llm** | ⚠️ **Blocking reqwest** | Same blocking-in-WASM issue | 0 |
+| **ledgerr-tauri** | 🔴 **Incompatible** | Tauri is a native desktop framework | ~1 |
+| **mdbook-rhai-mermaid** | ✅ **Works-as-is** (parser) | `std::process::exit` in binary only | 0 |
+
+### D.3 I/O Surface Summary (source only, non-test)
+
+| Capability | Occurrences | WASM Impact |
+|---|---|---|
+| `std::fs::*` | ~103 total references | Core data model is `PathBuf`-addressed throughout `ledgerr-mcp` |
+| `std::process::Command` | ~29 total (16 `Command::new`) | Process spawning for foundry, browser, PowerShell, host-window |
+| `std::net::TcpListener/TcpStream` | 1 file | Raw HTTP server in `internal_openai.rs` — fundamental to host architecture |
+| `std::thread` | 2 files (internal_openai, local_llm) | Blocking I/O threads; WASM needs dedicated workers |
+| `tokio::runtime` | 2 occurrences | `tokio full` includes `process`, `net`, `rt-multi-thread` — WASM-incompatible |
+| **Total platform-bound I/O** | **~136 references** | Application is fundamentally a local-first filesystem-native tool |
+
+### D.4 Where WASM Helps — The Live Editor Use Case
+
+The strongest WASM opportunity is **compiling the Rhai parser and `arc-kit-au` evidence graph to WASM for the browser-based docs live editor.**
+
+Current state: `book/theme/rhai-live-core.js` (548 lines) is a full JS reimplementation of the Rust Rhai→Mermaid parser. It duplicates:
+- `mdbook-rhai-mermaid/src/parser.rs` (661 lines) — Rhai DSL parsing
+- `mdbook-rhai-mermaid/src/emitter.rs` (119 lines) — Mermaid generation
+- `mdbook-rhai-mermaid/src/graph.rs` — graph construction
+
+This means every parser bug fix or feature addition must be applied in **two codebases** (Rust and JS).
+
+WASM path: Compile `arc-kit-au`'s evidence graph types + `ledger-core`'s petgraph analysis + the `mdbook-rhai-mermaid` parser to WASM via `wasm-pack` + `wasm-bindgen`. The browser loads a single `.wasm` blob instead of the 548-line JS reimplementation.
+
+### D.5 Where WASM Does NOT Help (and Would Cause Harm)
+
+| Attempt | Why It Hurts |
+|---|---|
+| WASM-compile the MCP server | Requires an abstract storage backend trait across 20+ `std::fs` sites, async refactoring of all synchronous I/O, removing `sysinfo`, removing `PathBuf` as canonical address. This is a multi-month rewrite that makes the codebase *less* idiomatic by adding abstraction layers where none are needed. |
+| WASM-compile the host tray/window | The host runs a raw TCP server, spawns processes, renders Slint windows, sets system tray icons. Every one of these is fundamentally native-OS. WASM adds nothing. |
+| WASM-compile Tauri | Tauri's backend is native Rust; the webview is HTML/JS. Compiling the Rust backend to WASM is architecturally backward — Tauri's value *is* its native capability. |
+| Full `wasm-pack --target web` on `ledger-core` | Would force feature-gating `z3`, `xattr`, `fdg-sim`, `femtovg`. The dead deps (`fdg-sim`, `femtovg`) are the first blockers — but they should be removed or made optional regardless of WASM. |
+
+### D.6 Effort Estimate
+
+| Scope | Effort | What It Enables |
+|---|---|---|
+| Remove dead deps `fdg-sim`, `femtovg` from `ledger-core` | 1 hour | Unblocks WASM compilation of `ledger-core` computation |
+| Compile `arc-kit-au` graph types to WASM | 2-3 days | In-browser evidence graph construction and traversal (no `store.rs` — just `EvidenceGraph`, `EvidenceBuilder`, `EvidenceTracer`, `ProvenanceScanner`) |
+| Compile `mdbook-rhai-mermaid` parser to WASM | 2-3 days | Replace the JS-only reimplementation in `rhai-live-core.js` with identical Rust-generated parser output |
+| `wasm-bindgen` bridge for `SemanticRuleSelector` (rule registry classify) | 3-5 days | In-browser transaction classification demo (pure computation, no I/O) |
+| Abstract storage backend + async refactor for MCP server | 4-8 weeks | WASM-compilable MCP server. **Not recommended** until there is a concrete browser-hosted product requirement. |
+
+### D.7 Recommendation
+
+**Do not adopt WASM as a first-class target in PRD-6.**
+
+Instead, take two bounded actions:
+
+1. **Remove dead dependencies `fdg-sim` and `femtovg` from `ledger-core/Cargo.toml` immediately.** They block WASM compilation for zero benefit. This is a 5-minute fix that pays forward.
+
+2. **Add a `wasm-scope` tracking issue** (not a PRD milestone) for compiling `arc-kit-au` + the Rhai parser to WASM for the docs live editor. The work is well-understood (pure Rust, no I/O) and produces a tangible benefit: eliminating the JS/Rust parser duplication. If stakeholders prioritize the browser experience over desktop, this becomes a `wasm-pack --target web` project that can ship independently.
+
+**Rationale (TRIZ):** The application's core value proposition — local-first, filesystem-native, CPA-auditable bookkeeping — is *antithetical* to WASM's sandboxed, filesystemless execution model. The application's I/O surface (103 `std::fs` references, 29 `std::process` references) proves that the codebase is a native tool, not a web tool. Forcing WASM compatibility would add abstraction layers (trait-based storage backends, async wrappers around sync I/O) that make the code *less* readable and *less* idiomatic for zero product gain.
+
+**TRIZ principle applied:** *Segmentation* — separate the pure-computation layers from the I/O layers, but do NOT cross-contaminate the I/O layers with WASM compatibility shims. Keep `arc-kit-au` and `ledger-core`'s pure computation WASM-compilable (they already mostly are); leave `ledgerr-mcp` and `ledgerr-host` as native-only. This is the same feature-gate pattern already used for `z3`, `xattr`, and `mistralrs-llm`.
+
+### D.8 WASM-Specific Changes to Include in PRD-6 Phase 0
+
+Two small changes that cost nothing and keep the WASM door open:
+
+```toml
+# Before (ledger-core/Cargo.toml):
+fdg-sim = "0.9"        # force-directed graph — not used anywhere in src/
+femtovg = "0.9"        # GPU vector renderer — not used anywhere in src/
+
+# After:
+# (removed — both were dead dependencies)
+```
+
+And in `arc-kit-au/src/store.rs`, make the persistence methods conditional:
+
+```rust
+// Before:
+impl EvidenceStore {
+    pub fn load(&self) -> Result<EvidenceGraph, StoreError> {
+        let json = std::fs::read_to_string(&self.path)?;
+        // ...
+    }
+}
+
+// After:
+impl EvidenceStore {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn load(&self) -> Result<EvidenceGraph, StoreError> {
+        let json = std::fs::read_to_string(&self.path)?;
+        // ...
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn load(&self) -> Result<EvidenceGraph, StoreError> {
+        Err(StoreError::Unsupported("filesystem I/O not available on WASM".to_string()))
+    }
+}
+```
+
+A single `#[cfg]` annotation in one file is all that's needed to make `arc-kit-au` WASM-compilable today. This is consistent with the existing `#[cfg(target_os = "linux")]` pattern on `xattr` in `fs_meta.rs`.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,36 @@ Use `Justfile` as the executable workflow contract. When a command changes, upda
 
 The default MCP catalog should stay collapsed to the top-level `ledgerr_*` capability families. Add sub-operations through required `action` parameters instead of expanding the default tool list.
 
+## Release and Versioning Policy
+
+l3dg3rr follows an **odd/even minor version** convention, similar to the Ubuntu LTS model.
+
+| Minor version | Series | Characteristics |
+|---|---|---|
+| Even (`1.0`, `1.2`, `1.4`, `1.8`, …) | **Stable** | Long-term supported. Full test gate including local Phi-4 model-inference tests. GitHub release published. Suitable for production operator use. |
+| Odd (`1.1`, `1.3`, `1.5`, `1.7`, …) | **Dev / Experimental** | Fast-moving. Breaking changes within a major series are permitted. Model-inference tests may be skipped. No GitHub release created. No LTS support. |
+
+### Release commands
+
+```sh
+# Stable release (even minor) — full test gate including phi4 inference, GitHub release created
+just release minor   # or: just release major / just release patch
+
+# Fast test gate only (excludes phi4 GGUF inference, ~seconds)
+just test-fast
+```
+
+### What the `release` recipe does
+
+1. Runs `just test-fast` (phi4 model-inference tests excluded from the gate; run separately via `just test-phi4` when model assets are available)
+2. Runs `./scripts/e2e_mvp.sh` end-to-end smoke path
+3. Calls `cog bump --<version>` — sets version in all `Cargo.toml` files, creates a conventional-commit bump commit and a semver git tag
+4. Updates `CHANGELOG.md` via `cog changelog`
+5. Pushes branch and tags to origin with `git push --follow-tags`
+6. Creates a GitHub release via `gh release create` with notes extracted from `CHANGELOG.md`
+
+Odd-minor releases skip step 6 — no GitHub release is created and no LTS maintenance commitment is made.
+
 ## Docker
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ l3dg3rr follows an **odd/even minor version** convention, similar to the Ubuntu 
 | Minor version | Series | Characteristics |
 |---|---|---|
 | Even (`1.0`, `1.2`, `1.4`, `1.8`, …) | **Stable** | Long-term supported. Full test gate including local Phi-4 model-inference tests. GitHub release published. Suitable for production operator use. |
-| Odd (`1.1`, `1.3`, `1.5`, `1.7`, …) | **Dev / Experimental** | Fast-moving. Breaking changes within a major series are permitted. Model-inference tests may be skipped. No GitHub release created. No LTS support. |
+| Odd (`1.1`, `1.3`, `1.5`, `1.7`, …) | **Dev / Experimental** | Fast-moving. Breaking changes within a major series are permitted. Model-inference tests may be skipped. GitHub pre-release only (created by CI from the pushed tag). No LTS support. |
 
 ### Release commands
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ l3dg3rr follows an **odd/even minor version** convention, similar to the Ubuntu 
 | Minor version | Series | Characteristics |
 |---|---|---|
 | Even (`1.0`, `1.2`, `1.4`, `1.8`, …) | **Stable** | Long-term supported. Full test gate including local Phi-4 model-inference tests. GitHub release published. Suitable for production operator use. |
-| Odd (`1.1`, `1.3`, `1.5`, `1.7`, …) | **Dev / Experimental** | Fast-moving. Breaking changes within a major series are permitted. Model-inference tests may be skipped. GitHub pre-release only (created by CI from the pushed tag). No LTS support. |
+| Odd (`1.1`, `1.3`, `1.5`, `1.7`, …) | **Dev / Experimental** | Fast-moving. Breaking changes within a major series are permitted. Model-inference tests may be skipped. GitHub pre-release created by the same `release` workflow. No LTS support. |
 
 ### Release commands
 
@@ -219,7 +219,7 @@ just test-fast
 3. Calls `cog bump --<version>` — sets version in all `Cargo.toml` files, creates a conventional-commit bump commit and a semver git tag
 4. Pushes branch and tags to origin with `git push --follow-tags`
 5. **Even minor** — creates a stable GitHub release (`gh release create --latest`)
-6. **Odd minor** — skips GitHub release; CI creates a pre-release from the pushed tag
+6. **Odd minor** — creates a GitHub pre-release (`gh release create --prerelease`)
 
 Pushing the tag triggers `.github/workflows/docs.yml`, which redeploys GitHub Pages regardless of minor parity.
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ l3dg3rr follows an **odd/even minor version** convention, similar to the Ubuntu 
 ### Release commands
 
 ```sh
-# Stable release (even minor) — full test gate including phi4 inference, GitHub release created
+# Release bump — outcome depends on the next version:
+# - even minor => stable release, full test gate including phi4 inference, GitHub release created
+# - odd minor => dev/experimental release, fast gate only, no stable GitHub release
 just release minor   # or: just release major / just release patch
 
 # Fast test gate only (excludes phi4 GGUF inference, ~seconds)

--- a/README.md
+++ b/README.md
@@ -210,14 +210,16 @@ just test-fast
 
 ### What the `release` recipe does
 
-1. Runs `just test-fast` (phi4 model-inference tests excluded from the gate; run separately via `just test-phi4` when model assets are available)
+1. Detects the next version's minor parity and selects the appropriate test gate:
+   - **Even minor (stable)** — full `cargo test` suite including phi4 GGUF inference
+   - **Odd minor (dev)** — fast gate only (`--skip phi4_produces_output --skip phi4_mistral_produces_output`)
 2. Runs `./scripts/e2e_mvp.sh` end-to-end smoke path
 3. Calls `cog bump --<version>` — sets version in all `Cargo.toml` files, creates a conventional-commit bump commit and a semver git tag
-4. Updates `CHANGELOG.md` via `cog changelog`
-5. Pushes branch and tags to origin with `git push --follow-tags`
-6. Creates a GitHub release via `gh release create` with notes extracted from `CHANGELOG.md`
+4. Pushes branch and tags to origin with `git push --follow-tags`
+5. **Even minor** — creates a stable GitHub release (`gh release create --latest`)
+6. **Odd minor** — skips GitHub release; CI creates a pre-release from the pushed tag
 
-Odd-minor releases skip step 6 — no GitHub release is created and no LTS maintenance commitment is made.
+Pushing the tag triggers `.github/workflows/docs.yml`, which redeploys GitHub Pages regardless of minor parity.
 
 ## Docker
 

--- a/crates/arc-kit-au/src/graph.rs
+++ b/crates/arc-kit-au/src/graph.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::edge::{EdgeType, EvidenceEdge};
-use crate::missing::{ProvenanceScanner, ProvenanceGap};
+use crate::missing::ProvenanceScanner;
 use crate::node::{EvidenceNode, NodeId, NodeType};
 
 /// Summary of the evidence graph's work queue state.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -39,7 +39,7 @@ just release major
 5. Calls `cog bump --<version>` — bumps all `Cargo.toml` versions, creates a conventional-commit bump commit and a semver git tag
 6. Pushes branch and tags with `git push --follow-tags`
 7. **Even minor** — creates a stable GitHub release (`gh release create --latest`)
-8. **Odd minor** — skips GitHub release creation (tag is pushed; CI creates a pre-release)
+8. **Odd minor** — creates a GitHub pre-release (`gh release create --prerelease`)
 
 ## Test Gates
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,31 +1,92 @@
 # Release Process
 
+## Versioning Policy
+
+l3dg3rr uses an **odd/even minor version** convention (Ubuntu-style):
+
+| Minor | Series | Test gate | GitHub release | LTS |
+|-------|--------|-----------|----------------|-----|
+| Even (1.0, 1.2, 1.8…) | **Stable** | Full suite incl. phi4 GGUF inference | Yes (`--latest`) | Yes |
+| Odd (1.1, 1.3, 1.7…) | **Dev/Experimental** | Fast suite only (phi4 skipped) | Pre-release only | No |
+
+Breaking changes within a major series are permitted on odd minors. Even minors are the supported upgrade targets.
+
 ## Preconditions
 
-- CI workflow is green on `main`.
-- Commits follow Conventional Commits.
-- Local hooks installed:
+- CI is green on `main`.
+- Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
+- `cocogitto` and `gh` CLI are installed.
+- For even minor releases: phi4 GGUF model assets are present (`just phi4-reasoning-symlink`).
+
+## Creating a Release (local)
 
 ```bash
-./scripts/install-hooks.sh
+# Bump minor version (most common — advances to next even or odd minor)
+just release minor
+
+# Bump patch (preserves current minor parity)
+just release patch
+
+# Bump major (resets minor to 0 — even, so stable)
+just release major
 ```
 
-## Local Dry-Run
+`just release` automatically:
+1. Detects the next minor number and applies odd/even policy
+2. **Even minor** — runs the full test suite including phi4 inference (~10+ min with model assets)
+3. **Odd minor** — runs the fast test suite, skipping phi4 inference (~seconds)
+4. Runs `./scripts/e2e_mvp.sh` end-to-end smoke path
+5. Calls `cog bump --<version>` — bumps all `Cargo.toml` versions, creates a conventional-commit bump commit and a semver git tag
+6. Pushes branch and tags with `git push --follow-tags`
+7. **Even minor** — creates a stable GitHub release (`gh release create --latest`)
+8. **Odd minor** — skips GitHub release creation (tag is pushed; CI creates a pre-release)
+
+## Test Gates
 
 ```bash
+# Fast gate (always safe; phi4 skipped) — used automatically for odd minors
+just test-fast
+
+# Full gate including phi4 GGUF inference — required before any even minor release
+just test-phi4
 cargo test --workspace --all-targets --all-features
+
+# E2E smoke path (required before any release)
 ./scripts/e2e_mvp.sh
-docker build -t tax-ledger:dev .
 ```
 
-## Create Release
+## GitHub Pages Deployment
+
+Docs deploy automatically via `.github/workflows/docs.yml` on:
+
+- Any push to `main`
+- Any `v*` tag push (covers both local `just release` and CI release paths)
+- Manual `workflow_dispatch`
+
+No manual step is needed — pushing the release tag triggers the docs deployment.
+
+## CI Release Path (workflow_dispatch)
+
+The `release.yml` workflow (trigger: Actions → Release → Run workflow) runs `cog bump --auto`, pushes to `main`, and creates the GitHub release. It applies the same odd/even policy:
+
+- Even minor → `gh release create --latest`
+- Odd minor → `gh release create --prerelease`
+
+The subsequent `main` push and tag push both trigger `docs.yml`, so GitHub Pages is updated regardless of which path created the release.
+
+## Manual Recovery
+
+If a release tag exists but no GitHub release was created:
 
 ```bash
-cog check
-cog bump --auto
-cog changelog --at "$(git describe --tags --abbrev=0)"
-git push --follow-tags
+TAG=v1.8.0
+cog changelog --at "$TAG" > /tmp/notes.md
+gh release create "$TAG" --title "$TAG (stable)" --notes-file /tmp/notes.md --latest
 ```
 
-The GitHub `release.yml` workflow publishes the corresponding GitHub release after CI succeeds.
+If GitHub Pages is stale after a release:
 
+```bash
+# Trigger a manual docs redeploy from GitHub Actions UI, or:
+gh workflow run docs.yml --repo PromptExecution/l3dg3rr
+```

--- a/scripts/mcp_cli_demo.sh
+++ b/scripts/mcp_cli_demo.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-JOURNAL_PATH="${JOURNAL_PATH:-/tmp/demo.beancount}"
-WORKBOOK_PATH="${WORKBOOK_PATH:-/tmp/demo.xlsx}"
+DEMO_ROOT="${DEMO_ROOT:-/tmp/l3dg3rr-mcp-demo-$$}"
+JOURNAL_PATH="${JOURNAL_PATH:-$DEMO_ROOT/demo.beancount}"
+WORKBOOK_PATH="${WORKBOOK_PATH:-$DEMO_ROOT/demo.xlsx}"
+ONTOLOGY_PATH="${ONTOLOGY_PATH:-$DEMO_ROOT/demo.ontology.json}"
 SOURCE_REF="${SOURCE_REF:-wf-2023-01.rkyv}"
+MODE="${1:-basic}"
 
 mkdir -p "$DEMO_ROOT"
 
@@ -14,13 +17,23 @@ if [[ "$MODE" == "basic" ]]; then
 {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
 {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"pipeline_status"}}}
 {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"list_accounts"}}}
-{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"ingest_pdf","pdf_path":"WF--BH-CHK--2023-01--statement.pdf","journal_path":"$JOURNAL_PATH","workbook_path":"$WORKBOOK_PATH","raw_context_bytes":[99,116,120],"extracted_rows":[{"account_id":"WF-BH-CHK","date":"2023-01-15","amount":"-42.11","description":"Coffee Shop","source_ref":"$SOURCE_REF"}]}}}
-{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"get_raw_context","rkyv_ref":"$SOURCE_REF"}}}
+{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"ledgerr_documents","arguments":{"action":"ingest_pdf","pdf_path":"WF--BH-CHK--2023-01--statement.pdf","journal_path":"$JOURNAL_PATH","workbook_path":"$WORKBOOK_PATH","ontology_path":"$ONTOLOGY_PATH","raw_context_bytes":[99,116,120],"extracted_rows":[{"account_id":"WF-BH-CHK","date":"2023-01-15","amount":"-42.11","description":"Coffee Shop","source_ref":"$SOURCE_REF"}]}}}
+{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"ledgerr_audit","arguments":{"action":"event_history"}}}
+{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"ledgerr_ontology","arguments":{"action":"export_snapshot","ontology_path":"$ONTOLOGY_PATH"}}}
 EOF
+  exit 0
+fi
 
-# Troubleshooting path
-cat <<'EOF'
+if [[ "$MODE" == "spinning-wheels" ]]; then
+  cargo run -q -p ledgerr-mcp --bin ledgerr-mcp-server <<'EOF'
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"demo","version":"0.1.0"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"ledgerr_workflow","arguments":{"action":"resume","state_marker":"invalid-checkpoint"}}}
 {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"ledgerr_reconciliation","arguments":{"action":"commit","source_total":"100.00","extracted_total":"95.00","posting_amounts":["-95.00","95.00"]}}}
 {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"ledgerr_audit","arguments":{"action":"event_history","time_start":"2026-12-31","time_end":"2026-01-01"}}}
 EOF
+  exit 0
+fi
+
+echo "usage: $0 [basic|spinning-wheels]" >&2
+exit 2


### PR DESCRIPTION
## Summary

- Documents Ubuntu-style odd/even minor version policy in README
- Codifies the policy in the `release` Justfile recipe (test gate + `gh release create` gating)
- Marks v1.7.0 GitHub release as pre-release (odd minor should not have a stable release)

## Policy

| Minor | Series | Gate | GitHub Release |
|-------|--------|------|---------------|
| Even (1.0, 1.2, 1.8…) | Stable / LTS | Full test suite incl. phi4 inference | Yes (`--latest`) |
| Odd (1.1, 1.3, 1.7…) | Dev / Experimental | Fast gate only (phi4 skipped) | No |

## Test plan

- [ ] `just release minor` from an even-minor base runs full cargo test and creates a GitHub release
- [ ] `just release minor` from an odd-minor base skips phi4 tests and prints "Dev release — no GitHub release created"
- [ ] `just release patch` preserves current minor parity
- [ ] v1.7.0 GitHub release is now marked as pre-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)