### PR TITLE
feat(rotel): OTel journal surface — embedded collector, log-shape classifier, visual dashboard

### DIFF
--- a/.b00tignore
+++ b/.b00tignore
@@ -1,0 +1,2 @@
+# b00t session files
+_b00t_.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,222 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "arrow"
+version = "58.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "607e64bb911ee4f90483e044fe78f175989148c2892e659a2cd25429e782ec54"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e754319ed8a85d817fe7adf183227e0b5308b82790a737b426c1124626b48118"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841321891f247aa86c6112c80d83d89cb36e0addd020fa2425085b8eb6c3f579"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.17.0",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f955dfb73fae000425f49c8226d2044dab60fb7ad4af1e24f961756354d996c9"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5e686972523798f76bef355145bc1ae25a84c731e650268d31ab763c701663"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "58.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86c276756867fc8186ec380c72c290e6e3b23a1d4fb05df6b1d62d2e62666d48"
+dependencies = [
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3b5846209775b6dc8056d77ff9a032b27043383dd5488abd0b663e265b9373"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8907ddd8f9fbabf91ec2c85c1d81fe2874e336d2443eb36373595e28b98dd5"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "58.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4518c59acc501f10d7dcae397fe12b8db3d81bc7de94456f8a58f9165d6f502"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "chrono",
+ "half",
+ "indexmap 2.13.0",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa70d9d6b1356f1fb9f1f651b84a725b7e0abb93f188cf7d31f14abfa2f2e6f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faec88a945338192beffbbd4be0def70135422930caa244ac3cec0cd213b26b4"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18aa020f6bc8e5201dcd2d4b7f98c68f8a410ef37128263243e6ff2a47a67d4f"
+
+[[package]]
+name = "arrow-select"
+version = "58.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a657ab5132e9c8ca3b24eb15a823d0ced38017fe3930ff50167466b02e2d592c"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6de2efbbd1a9f9780ceb8d1ff5d20421b35863b361e3386b4f571f1fc69fcb8"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "as-any"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +798,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atoi_simd"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +950,64 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "base64 0.22.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite 0.24.0",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2882,6 +3165,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustc_version",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3908,6 +4201,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "hashlink"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4093,6 +4392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4106,6 +4411,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec 1.15.1",
@@ -5108,6 +5414,7 @@ version = "1.8.0"
 dependencies = [
  "anyhow",
  "arc-kit-au",
+ "arrow",
  "automod",
  "blake3",
  "calamine",
@@ -5118,6 +5425,7 @@ dependencies = [
  "glam 0.27.0",
  "kasuari",
  "petgraph 0.6.5",
+ "regex",
  "rhai",
  "rust_decimal",
  "rust_xlsxwriter",
@@ -5231,6 +5539,63 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
 ]
 
 [[package]]
@@ -5581,6 +5946,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matrixmultiply"
@@ -8064,7 +8435,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -8110,7 +8481,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -8248,6 +8619,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rotel-visual"
+version = "1.8.0"
+dependencies = [
+ "axum",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower 0.4.13",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -8867,6 +9251,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -10642,6 +11037,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -10814,6 +11221,21 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -10825,6 +11247,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -10840,7 +11263,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -11046,6 +11469,24 @@ dependencies = [
  "rand 0.8.5",
  "rustls",
  "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
   "crates/arc-kit-au",
   "crates/datum",
   "crates/b00t-iface",
-  "xtask",
+  "xtask", "crates/rotel-visual",
 ]
 resolver = "2"
 

--- a/crates/b00t-iface/src/sarif/mod.rs
+++ b/crates/b00t-iface/src/sarif/mod.rs
@@ -7,6 +7,9 @@
 use serde::Serialize;
 use std::collections::HashMap;
 
+use crate::metric::{MetricRegistry, MetricValue};
+use datum::logic::{nand, nor, tokenize_shorthand, ShorthandToken};
+
 /// SARIF v2.1.0 log file.
 #[derive(Debug, Clone, Serialize)]
 pub struct SarifLog {
@@ -433,6 +436,80 @@ fn first_line_containing(content: &str, needle: &str) -> u64 {
         .unwrap_or(0)
 }
 
+/// Evaluate an observable OTel/Rotel build-gate expression using existing
+/// symbolic logic helpers. Supported forms are `log_shape && metric` and
+/// `log_shape || metric`; AND/OR are derived from NAND/NOR.
+pub fn evaluate_otel_logic_expression(expression: &str, log_shape_observed: bool, metric_observed: bool) -> bool {
+    let tokens = tokenize_shorthand(expression);
+    if tokens.iter().any(|t| matches!(t, ShorthandToken::Or)) {
+        !nor(log_shape_observed, metric_observed)
+    } else if tokens.iter().any(|t| matches!(t, ShorthandToken::And)) {
+        !nand(log_shape_observed, metric_observed)
+    } else {
+        log_shape_observed
+    }
+}
+
+/// Record an observable Rotel/OTel log-shape/metric SLI in `MetricRegistry` and
+/// emit SARIF when the SLO build gate is not met.
+pub fn check_otel_logic_slo_as_sarif(
+    registry: &mut MetricRegistry,
+    gate_name: &str,
+    expression: &str,
+    log_shape_observed: bool,
+    metric_observed: bool,
+    slo_expected: bool,
+) -> SarifLog {
+    let surface = format!("rotel-otel:{gate_name}");
+    let sli_met = evaluate_otel_logic_expression(expression, log_shape_observed, metric_observed);
+
+    registry.record(&surface, "log_shape_observed", MetricValue::Counter(log_shape_observed as u64));
+    registry.record(&surface, "metric_observed", MetricValue::Counter(metric_observed as u64));
+    registry.record(&surface, "sli_met", MetricValue::Gauge(if sli_met { 1.0 } else { 0.0 }));
+    registry.record(&surface, "slo_expected", MetricValue::Gauge(if slo_expected { 1.0 } else { 0.0 }));
+    registry.record(
+        &surface,
+        "build_gate",
+        MetricValue::State(if sli_met == slo_expected { "pass".into() } else { "fail".into() }),
+    );
+
+    let rule = LintRule {
+        id: "l3dg3rr/otel/build-gate-slo".into(),
+        short_desc: "Rotel OTel SLI satisfies build-gate SLO".into(),
+        long_desc: format!(
+            "OTel logic gate `{gate_name}` expected `{slo_expected}` for `{expression}` but observed `{sli_met}`"
+        ),
+        level: SarifLevel::Error,
+    };
+
+    let mut log = SarifLog::new();
+    let mut run = SarifRun::new("l3dg3rr-otel-slo", "1.0.0");
+    run.tool.driver.rules.push(rule.to_sarif_rule());
+
+    if sli_met != slo_expected {
+        let mut properties = HashMap::new();
+        properties.insert("sli.name".to_string(), gate_name.to_string());
+        properties.insert("sli.expression".to_string(), expression.to_string());
+        properties.insert("sli.value".to_string(), sli_met.to_string());
+        properties.insert("slo.expected".to_string(), slo_expected.to_string());
+        properties.insert("otel.log_shape_observed".to_string(), log_shape_observed.to_string());
+        properties.insert("otel.metric_observed".to_string(), metric_observed.to_string());
+        properties.insert("rotel.surface".to_string(), surface.clone());
+
+        run.add_result(SarifResult {
+            rule_id: rule.id,
+            level: SarifLevel::Error,
+            message: SarifMessage { text: rule.long_desc },
+            locations: None,
+            fixes: None,
+            properties: Some(properties),
+        });
+    }
+
+    log.add_run(run);
+    log
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -586,6 +663,63 @@ mod tests {
             .filter(|r| r.rule_id.contains("z3-kasuari-coherence"))
             .collect();
         assert!(coherence_results.is_empty(), "should pass when both z3 and constraints are used");
+    }
+
+    #[test]
+    fn otel_logic_and_gate_records_visual_metrics_and_passes_slo() {
+        let mut registry = MetricRegistry::new();
+        let report = check_otel_logic_slo_as_sarif(
+            &mut registry,
+            "gpu-driver-fault",
+            "log_shape && metric",
+            true,
+            true,
+            true,
+        );
+
+        assert!(!report.has_errors());
+        let flat = registry.flat_display();
+        let surface = flat.get("rotel-otel:gpu-driver-fault").expect("surface metrics");
+        assert_eq!(surface.get("log_shape_observed").map(String::as_str), Some("1"));
+        assert_eq!(surface.get("metric_observed").map(String::as_str), Some("1"));
+        assert_eq!(surface.get("build_gate").map(String::as_str), Some("pass"));
+    }
+
+    #[test]
+    fn otel_logic_and_gate_outputs_sarif_error_when_metric_missing() {
+        let mut registry = MetricRegistry::new();
+        let report = check_otel_logic_slo_as_sarif(
+            &mut registry,
+            "gpu-driver-fault",
+            "log_shape && metric",
+            true,
+            false,
+            true,
+        );
+
+        assert!(report.has_errors());
+        let result = &report.runs[0].results[0];
+        assert_eq!(result.rule_id, "l3dg3rr/otel/build-gate-slo");
+        let props = result.properties.as_ref().expect("sarif properties");
+        assert_eq!(props.get("sli.expression").map(String::as_str), Some("log_shape && metric"));
+        assert_eq!(props.get("sli.value").map(String::as_str), Some("false"));
+        assert_eq!(props.get("otel.metric_observed").map(String::as_str), Some("false"));
+    }
+
+    #[test]
+    fn otel_logic_or_gate_allows_log_shape_without_metric() {
+        let mut registry = MetricRegistry::new();
+        let report = check_otel_logic_slo_as_sarif(
+            &mut registry,
+            "classified-log-visible",
+            "log_shape || metric",
+            true,
+            false,
+            true,
+        );
+
+        assert!(!report.has_errors());
+        assert!(evaluate_otel_logic_expression("log_shape || metric", true, false));
     }
 
     #[test]

--- a/crates/ledger-core/Cargo.toml
+++ b/crates/ledger-core/Cargo.toml
@@ -14,6 +14,7 @@ rust_xlsxwriter = { workspace = true }
 calamine = "0.34"
 thiserror = "2"
 blake3 = "1.8.3"
+regex = "1"
 rhai = "1.24.0"
 z3 = { workspace = true, optional = true }
 kasuari = { workspace = true }
@@ -23,6 +24,7 @@ petgraph = "0.6"
 fdg-sim = "0.9"
 glam = "0.27"
 femtovg = "0.9"
+arrow = { version = "58.2.0", optional = true }
 arc-kit-au = { path = "../arc-kit-au", optional = true }
 
 # filesystem metadata — xattr on Linux; sidecar fallback is pure std
@@ -32,6 +34,7 @@ xattr = "1"
 [features]
 default = ["arc-kit-au"]
 legal-z3 = ["dep:z3"]
+otel-arrow = ["dep:arrow"]
 
 [lints]
 workspace = true

--- a/crates/ledger-core/src/lib.rs
+++ b/crates/ledger-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod layout;
 pub mod ledger_ops;
 pub mod legal;
 pub mod manifest;
+pub mod observability;
 pub mod ontology;
 pub mod pipeline;
 pub mod proposal;

--- a/crates/ledger-core/src/observability.rs
+++ b/crates/ledger-core/src/observability.rs
@@ -1,0 +1,538 @@
+//! Internal OpenTelemetry/Rotel surface for l3dg3rr.
+//!
+//! This module deliberately models the OpenTelemetry object shapes that l3dg3rr
+//! needs before choosing a collector transport. Rotel remains the embedded
+//! collector boundary; classification and audit justification stay typed here.
+
+use std::collections::BTreeMap;
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum OTelAnyValue {
+    String(String),
+    Bool(bool),
+    I64(i64),
+    F64(f64),
+    Bytes(Vec<u8>),
+    Array(Vec<OTelAnyValue>),
+    KvList(BTreeMap<String, OTelAnyValue>),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OTelKeyValue {
+    pub key: String,
+    pub value: OTelAnyValue,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OTelResource {
+    pub attributes: BTreeMap<String, String>,
+    pub schema_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OTelInstrumentationScope {
+    pub name: String,
+    pub version: Option<String>,
+    pub attributes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OTelSignal {
+    Log,
+    Metric,
+    Trace,
+}
+
+impl OTelSignal {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Log => "log",
+            Self::Metric => "metric",
+            Self::Trace => "trace",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum OTelSeverityNumber {
+    Trace = 1,
+    Debug = 5,
+    Info = 9,
+    Warn = 13,
+    Error = 17,
+    Fatal = 21,
+}
+
+impl OTelSeverityNumber {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Trace => "TRACE",
+            Self::Debug => "DEBUG",
+            Self::Info => "INFO",
+            Self::Warn => "WARN",
+            Self::Error => "ERROR",
+            Self::Fatal => "FATAL",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OTelLogRecord {
+    pub time_unix_nano: u64,
+    pub observed_time_unix_nano: u64,
+    pub severity_number: OTelSeverityNumber,
+    pub severity_text: String,
+    pub body: String,
+    pub attributes: BTreeMap<String, String>,
+    pub trace_id: Option<String>,
+    pub span_id: Option<String>,
+}
+
+impl OTelLogRecord {
+    pub fn new(
+        time_unix_nano: u64,
+        severity_number: OTelSeverityNumber,
+        body: impl Into<String>,
+    ) -> Self {
+        Self {
+            time_unix_nano,
+            observed_time_unix_nano: time_unix_nano,
+            severity_number,
+            severity_text: severity_number.as_str().to_string(),
+            body: body.into(),
+            attributes: BTreeMap::new(),
+            trace_id: None,
+            span_id: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OTelSpanKind {
+    Internal,
+    Server,
+    Client,
+    Producer,
+    Consumer,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OTelSpanEvent {
+    pub name: String,
+    pub time_unix_nano: u64,
+    pub attributes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OTelSpan {
+    pub trace_id: String,
+    pub span_id: String,
+    pub parent_span_id: Option<String>,
+    pub name: String,
+    pub kind: OTelSpanKind,
+    pub start_time_unix_nano: u64,
+    pub end_time_unix_nano: u64,
+    pub attributes: BTreeMap<String, String>,
+    pub events: Vec<OTelSpanEvent>,
+    pub status_code: Option<String>,
+    pub status_message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum OTelMetricData {
+    Gauge {
+        value: f64,
+    },
+    Sum {
+        value: f64,
+        monotonic: bool,
+    },
+    Histogram {
+        count: u64,
+        sum: f64,
+        bucket_counts: Vec<u64>,
+        explicit_bounds: Vec<f64>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OTelMetric {
+    pub name: String,
+    pub description: String,
+    pub unit: String,
+    pub time_unix_nano: u64,
+    pub attributes: BTreeMap<String, String>,
+    pub data: OTelMetricData,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum OTelEnvelope {
+    Log(OTelLogRecord),
+    Metric(OTelMetric),
+    Trace(OTelSpan),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LogShapeRule {
+    pub rule_id: String,
+    pub abstract_regex_type: String,
+    pub pattern: String,
+    pub metric_name: String,
+    pub metric_delta: i64,
+    pub min_severity: OTelSeverityNumber,
+    pub rationale: String,
+}
+
+impl LogShapeRule {
+    pub fn validate(&self) -> Result<(), ObservabilityError> {
+        if self.rule_id.trim().is_empty() {
+            return Err(ObservabilityError::InvalidRule(
+                "rule_id is required".to_string(),
+            ));
+        }
+        if self.abstract_regex_type.trim().is_empty() {
+            return Err(ObservabilityError::InvalidRule(
+                "abstract_regex_type is required".to_string(),
+            ));
+        }
+        if self.metric_name.trim().is_empty() {
+            return Err(ObservabilityError::InvalidRule(
+                "metric_name is required".to_string(),
+            ));
+        }
+        Regex::new(&self.pattern)
+            .map(|_| ())
+            .map_err(|e| ObservabilityError::InvalidRule(format!("invalid regex: {e}")))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MetricJustification {
+    pub rule_id: String,
+    pub metric_name: String,
+    pub metric_delta: i64,
+    pub reason: String,
+    pub evidence_digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClassifiedJournalArtifact {
+    pub artifact_id: String,
+    pub signal: OTelSignal,
+    pub abstract_regex_type: String,
+    pub source_time_unix_nano: u64,
+    pub severity_text: String,
+    pub matched_excerpt: String,
+    pub justification: MetricJustification,
+    pub attributes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct LogShapeClassifier {
+    compiled: Vec<(LogShapeRule, Regex)>,
+}
+
+impl LogShapeClassifier {
+    pub fn new(rules: Vec<LogShapeRule>) -> Result<Self, ObservabilityError> {
+        let mut compiled = Vec::with_capacity(rules.len());
+        for rule in rules {
+            rule.validate()?;
+            let regex = Regex::new(&rule.pattern)
+                .map_err(|e| ObservabilityError::InvalidRule(format!("invalid regex: {e}")))?;
+            compiled.push((rule, regex));
+        }
+        Ok(Self { compiled })
+    }
+
+    pub fn classify_log(&self, log: &OTelLogRecord) -> Vec<ClassifiedJournalArtifact> {
+        self.compiled
+            .iter()
+            .filter(|(rule, _)| log.severity_number >= rule.min_severity)
+            .filter_map(|(rule, regex)| {
+                let capture = regex.find(&log.body)?;
+                Some(classified_artifact(rule, log, capture.as_str()))
+            })
+            .collect()
+    }
+}
+
+fn classified_artifact(
+    rule: &LogShapeRule,
+    log: &OTelLogRecord,
+    matched_excerpt: &str,
+) -> ClassifiedJournalArtifact {
+    let evidence = format!(
+        "{}|{}|{}|{}",
+        rule.rule_id, rule.abstract_regex_type, log.time_unix_nano, log.body
+    );
+    let evidence_digest = blake3::hash(evidence.as_bytes()).to_hex().to_string();
+    let artifact_identity = format!(
+        "classified-journal|{}|{}|{}",
+        rule.rule_id, evidence_digest, rule.metric_name
+    );
+
+    let mut attributes = log.attributes.clone();
+    attributes.insert(
+        "otel.signal".to_string(),
+        OTelSignal::Log.as_str().to_string(),
+    );
+    attributes.insert("otel.severity_text".to_string(), log.severity_text.clone());
+    if let Some(trace_id) = &log.trace_id {
+        attributes.insert("otel.trace_id".to_string(), trace_id.clone());
+    }
+    if let Some(span_id) = &log.span_id {
+        attributes.insert("otel.span_id".to_string(), span_id.clone());
+    }
+
+    ClassifiedJournalArtifact {
+        artifact_id: blake3::hash(artifact_identity.as_bytes())
+            .to_hex()
+            .to_string(),
+        signal: OTelSignal::Log,
+        abstract_regex_type: rule.abstract_regex_type.clone(),
+        source_time_unix_nano: log.time_unix_nano,
+        severity_text: log.severity_text.clone(),
+        matched_excerpt: matched_excerpt.to_string(),
+        justification: MetricJustification {
+            rule_id: rule.rule_id.clone(),
+            metric_name: rule.metric_name.clone(),
+            metric_delta: rule.metric_delta,
+            reason: rule.rationale.clone(),
+            evidence_digest,
+        },
+        attributes,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TelemetryArrowRow {
+    pub artifact_id: String,
+    pub signal: String,
+    pub abstract_regex_type: String,
+    pub metric_name: String,
+    pub metric_delta: i64,
+    pub severity_text: String,
+    pub matched_excerpt: String,
+    pub justification_digest: String,
+    pub source_time_unix_nano: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TelemetryArrowBatch {
+    pub rows: Vec<TelemetryArrowRow>,
+}
+
+impl TelemetryArrowBatch {
+    pub fn from_artifacts(artifacts: &[ClassifiedJournalArtifact]) -> Self {
+        Self {
+            rows: artifacts
+                .iter()
+                .map(|artifact| TelemetryArrowRow {
+                    artifact_id: artifact.artifact_id.clone(),
+                    signal: artifact.signal.as_str().to_string(),
+                    abstract_regex_type: artifact.abstract_regex_type.clone(),
+                    metric_name: artifact.justification.metric_name.clone(),
+                    metric_delta: artifact.justification.metric_delta,
+                    severity_text: artifact.severity_text.clone(),
+                    matched_excerpt: artifact.matched_excerpt.clone(),
+                    justification_digest: artifact.justification.evidence_digest.clone(),
+                    source_time_unix_nano: artifact.source_time_unix_nano,
+                })
+                .collect(),
+        }
+    }
+
+    pub fn classification_columns() -> &'static [&'static str] {
+        &[
+            "artifact_id",
+            "signal",
+            "abstract_regex_type",
+            "metric_name",
+            "metric_delta",
+            "severity_text",
+            "matched_excerpt",
+            "justification_digest",
+            "source_time_unix_nano",
+        ]
+    }
+
+    #[cfg(feature = "otel-arrow")]
+    pub fn arrow_schema() -> arrow::datatypes::Schema {
+        use arrow::datatypes::{DataType, Field, Schema};
+
+        Schema::new(vec![
+            Field::new("artifact_id", DataType::Utf8, false),
+            Field::new("signal", DataType::Utf8, false),
+            Field::new("abstract_regex_type", DataType::Utf8, false),
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("metric_delta", DataType::Int64, false),
+            Field::new("severity_text", DataType::Utf8, false),
+            Field::new("matched_excerpt", DataType::Utf8, false),
+            Field::new("justification_digest", DataType::Utf8, false),
+            Field::new("source_time_unix_nano", DataType::UInt64, false),
+        ])
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RotelEndpoint {
+    pub otlp_http_endpoint: String,
+    pub otlp_grpc_endpoint: String,
+    pub arrow_connector_enabled: bool,
+}
+
+impl Default for RotelEndpoint {
+    fn default() -> Self {
+        Self {
+            otlp_http_endpoint: "http://127.0.0.1:4318".to_string(),
+            otlp_grpc_endpoint: "http://127.0.0.1:4317".to_string(),
+            arrow_connector_enabled: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RotelExportPlan {
+    pub logs_url: String,
+    pub metrics_url: String,
+    pub traces_url: String,
+    pub arrow_connector_enabled: bool,
+    pub arrow_columns: Vec<String>,
+}
+
+impl RotelExportPlan {
+    pub fn from_endpoint(endpoint: &RotelEndpoint) -> Self {
+        let base = endpoint.otlp_http_endpoint.trim_end_matches('/');
+        Self {
+            logs_url: format!("{base}/v1/logs"),
+            metrics_url: format!("{base}/v1/metrics"),
+            traces_url: format!("{base}/v1/traces"),
+            arrow_connector_enabled: endpoint.arrow_connector_enabled,
+            arrow_columns: TelemetryArrowBatch::classification_columns()
+                .iter()
+                .map(|column| (*column).to_string())
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ObservabilityError {
+    #[error("invalid observability rule: {0}")]
+    InvalidRule(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gpu_fault_rule() -> LogShapeRule {
+        LogShapeRule {
+            rule_id: "gpu-driver-device-disappeared".to_string(),
+            abstract_regex_type: "hardware.gpu.driver.device_handle_unknown".to_string(),
+            pattern: "Unable to determine the device handle for GPU[0-9]+.*Unknown Error"
+                .to_string(),
+            metric_name: "l3dg3rr.hardware.gpu.driver_faults".to_string(),
+            metric_delta: 1,
+            min_severity: OTelSeverityNumber::Error,
+            rationale: "GPU was expected but nvidia-smi returned an unknown device-handle error"
+                .to_string(),
+        }
+    }
+
+    #[test]
+    fn classifies_log_shape_into_journal_artifact_and_metric_trigger() {
+        let classifier = LogShapeClassifier::new(vec![gpu_fault_rule()]).unwrap();
+        let mut log = OTelLogRecord::new(
+            1_777_724_525,
+            OTelSeverityNumber::Error,
+            "Unable to determine the device handle for GPU0: 0000:01:00.0: Unknown Error",
+        );
+        log.attributes
+            .insert("host.name".to_string(), "sm3llsl1k3s0ld3r".to_string());
+
+        let artifacts = classifier.classify_log(&log);
+
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(
+            artifacts[0].abstract_regex_type,
+            "hardware.gpu.driver.device_handle_unknown"
+        );
+        assert_eq!(
+            artifacts[0].justification.metric_name,
+            "l3dg3rr.hardware.gpu.driver_faults"
+        );
+        assert_eq!(artifacts[0].justification.metric_delta, 1);
+        assert_eq!(
+            artifacts[0].attributes.get("host.name").map(String::as_str),
+            Some("sm3llsl1k3s0ld3r")
+        );
+    }
+
+    #[test]
+    fn classified_artifact_id_is_deterministic() {
+        let classifier = LogShapeClassifier::new(vec![gpu_fault_rule()]).unwrap();
+        let log = OTelLogRecord::new(
+            42,
+            OTelSeverityNumber::Error,
+            "Unable to determine the device handle for GPU0: 0000:01:00.0: Unknown Error",
+        );
+
+        let first = classifier.classify_log(&log);
+        let second = classifier.classify_log(&log);
+
+        assert_eq!(first[0].artifact_id, second[0].artifact_id);
+        assert_eq!(
+            first[0].justification.evidence_digest,
+            second[0].justification.evidence_digest
+        );
+    }
+
+    #[test]
+    fn telemetry_arrow_batch_uses_stable_classification_columns() {
+        let classifier = LogShapeClassifier::new(vec![gpu_fault_rule()]).unwrap();
+        let log = OTelLogRecord::new(
+            7,
+            OTelSeverityNumber::Fatal,
+            "Unable to determine the device handle for GPU0: 0000:01:00.0: Unknown Error",
+        );
+        let artifacts = classifier.classify_log(&log);
+        let batch = TelemetryArrowBatch::from_artifacts(&artifacts);
+
+        assert_eq!(batch.rows.len(), 1);
+        assert_eq!(
+            TelemetryArrowBatch::classification_columns(),
+            &[
+                "artifact_id",
+                "signal",
+                "abstract_regex_type",
+                "metric_name",
+                "metric_delta",
+                "severity_text",
+                "matched_excerpt",
+                "justification_digest",
+                "source_time_unix_nano",
+            ]
+        );
+        assert_eq!(batch.rows[0].signal, "log");
+    }
+
+    #[test]
+    fn rotel_export_plan_keeps_otlp_and_arrow_connector_explicit() {
+        let endpoint = RotelEndpoint::default();
+        let plan = RotelExportPlan::from_endpoint(&endpoint);
+
+        assert_eq!(plan.logs_url, "http://127.0.0.1:4318/v1/logs");
+        assert_eq!(plan.metrics_url, "http://127.0.0.1:4318/v1/metrics");
+        assert_eq!(plan.traces_url, "http://127.0.0.1:4318/v1/traces");
+        assert!(plan.arrow_connector_enabled);
+        assert!(plan
+            .arrow_columns
+            .iter()
+            .any(|c| c == "abstract_regex_type"));
+    }
+}

--- a/crates/ledgerr-host/src/internal_openai.rs
+++ b/crates/ledgerr-host/src/internal_openai.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use ledger_core::observability::{OTelSignal, RotelEndpoint, RotelExportPlan};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -15,6 +16,11 @@ use crate::settings::ChatSettings;
 pub const INTERNAL_OPENAI_ADDR: &str = "127.0.0.1:15115";
 pub const INTERNAL_OPENAI_CHAT_URL: &str = "http://127.0.0.1:15115/v1/chat/completions";
 pub const INTERNAL_DOCS_URL: &str = "http://127.0.0.1:15115/docs/";
+pub const INTERNAL_ROTEL_HEALTH_URL: &str = "http://127.0.0.1:15115/rotel/health";
+pub const INTERNAL_ROTEL_EXPORT_PLAN_URL: &str = "http://127.0.0.1:15115/rotel/export-plan";
+pub const INTERNAL_ROTEL_LOGS_URL: &str = "http://127.0.0.1:15115/v1/logs";
+pub const INTERNAL_ROTEL_METRICS_URL: &str = "http://127.0.0.1:15115/v1/metrics";
+pub const INTERNAL_ROTEL_TRACES_URL: &str = "http://127.0.0.1:15115/v1/traces";
 pub const INTERNAL_PHI_MODEL: &str = "phi-4-mini-reasoning";
 pub const INTERNAL_LOCAL_API_KEY: &str = "local-tool-tray";
 pub const DEFAULT_CLOUD_CHAT_URL: &str = "https://api.openai.com/v1/chat/completions";
@@ -237,6 +243,26 @@ impl InternalOpenAiHandle {
     pub fn docs_url(&self) -> String {
         format!("http://{}/docs/", self.addr)
     }
+
+    pub fn rotel_health_url(&self) -> String {
+        format!("http://{}/rotel/health", self.addr)
+    }
+
+    pub fn rotel_export_plan_url(&self) -> String {
+        format!("http://{}/rotel/export-plan", self.addr)
+    }
+
+    pub fn rotel_logs_url(&self) -> String {
+        format!("http://{}/v1/logs", self.addr)
+    }
+
+    pub fn rotel_metrics_url(&self) -> String {
+        format!("http://{}/v1/metrics", self.addr)
+    }
+
+    pub fn rotel_traces_url(&self) -> String {
+        format!("http://{}/v1/traces", self.addr)
+    }
 }
 
 impl Drop for InternalOpenAiHandle {
@@ -433,6 +459,19 @@ pub fn docs_playbook_status() -> String {
         ),
         None => "Docs playbook is not built. Run `just docgen` to generate book/book before opening the local docs route.".to_string(),
     }
+}
+
+pub fn internal_rotel_status() -> String {
+    let plan = RotelExportPlan::from_endpoint(&internal_rotel_endpoint(INTERNAL_OPENAI_ADDR));
+    [
+        "rotel: embedded in internal OpenAI-compatible listener".to_string(),
+        format!("health_endpoint: {INTERNAL_ROTEL_HEALTH_URL}"),
+        format!("logs_endpoint: {}", plan.logs_url),
+        format!("metrics_endpoint: {}", plan.metrics_url),
+        format!("traces_endpoint: {}", plan.traces_url),
+        format!("arrow_connector_enabled: {}", plan.arrow_connector_enabled),
+    ]
+    .join("\n")
 }
 
 #[derive(Debug, Clone)]
@@ -734,12 +773,18 @@ fn serve_loop(
     backend: Arc<dyn InternalChatBackend>,
     docs_root: Option<PathBuf>,
 ) {
+    let server_addr = listener
+        .local_addr()
+        .map(|addr| addr.to_string())
+        .unwrap_or_else(|_| INTERNAL_OPENAI_ADDR.to_string());
     loop {
         if shutdown_rx.try_recv().is_ok() {
             break;
         }
         match listener.accept() {
-            Ok((stream, _)) => handle_stream(stream, backend.as_ref(), docs_root.as_deref()),
+            Ok((stream, _)) => {
+                handle_stream(stream, backend.as_ref(), docs_root.as_deref(), &server_addr)
+            }
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
                 thread::sleep(Duration::from_millis(25));
             }
@@ -752,6 +797,7 @@ fn handle_stream(
     mut stream: TcpStream,
     backend: &dyn InternalChatBackend,
     docs_root: Option<&Path>,
+    server_addr: &str,
 ) {
     let mut buffer = Vec::with_capacity(8192);
     let mut chunk = [0_u8; 2048];
@@ -769,7 +815,7 @@ fn handle_stream(
         }
     }
 
-    let response = route_http_request(&buffer, backend, docs_root);
+    let response = route_http_request_for_addr(&buffer, backend, docs_root, server_addr);
     let _ = stream.write_all(response.as_bytes());
     let _ = stream.flush();
 }
@@ -783,10 +829,20 @@ fn request_complete(buffer: &[u8]) -> bool {
     buffer.len() >= header_end + 4 + content_length
 }
 
+#[cfg(test)]
 fn route_http_request(
     raw: &[u8],
     backend: &dyn InternalChatBackend,
     docs_root: Option<&Path>,
+) -> String {
+    route_http_request_for_addr(raw, backend, docs_root, INTERNAL_OPENAI_ADDR)
+}
+
+fn route_http_request_for_addr(
+    raw: &[u8],
+    backend: &dyn InternalChatBackend,
+    docs_root: Option<&Path>,
+    server_addr: &str,
 ) -> String {
     let Some(header_end) = find_header_end(raw) else {
         return json_response(400, &serde_json::json!({ "error": "invalid request" }));
@@ -818,6 +874,19 @@ fn route_http_request(
         return json_response(200, &payload);
     }
 
+    if request_line.starts_with("GET /rotel/health ") {
+        return json_response(200, &rotel_health_payload(server_addr));
+    }
+
+    if request_line.starts_with("GET /rotel/export-plan ") {
+        let plan = RotelExportPlan::from_endpoint(&internal_rotel_endpoint(server_addr));
+        return json_response(200, &plan);
+    }
+
+    if let Some(signal) = otlp_signal_from_request_line(request_line) {
+        return rotel_otlp_response(signal, body);
+    }
+
     if !request_line.starts_with("POST /v1/chat/completions ") {
         return json_response(404, &serde_json::json!({ "error": "not found" }));
     }
@@ -844,6 +913,85 @@ fn route_http_request(
         Err(error) => return json_response(500, &serde_json::json!({ "error": error })),
     };
     json_response(200, &chat_response(&request, assistant_text))
+}
+
+fn internal_rotel_endpoint(addr: &str) -> RotelEndpoint {
+    RotelEndpoint {
+        otlp_http_endpoint: format!("http://{addr}"),
+        otlp_grpc_endpoint: "internal-listener-disabled".to_string(),
+        arrow_connector_enabled: true,
+    }
+}
+
+fn rotel_health_payload(addr: &str) -> serde_json::Value {
+    let endpoint = internal_rotel_endpoint(addr);
+    let plan = RotelExportPlan::from_endpoint(&endpoint);
+    serde_json::json!({
+        "status": "ok",
+        "service": "rotel-embedded",
+        "listener": "l3dg3rr-internal-openai",
+        "otlp_http_endpoint": endpoint.otlp_http_endpoint,
+        "otlp_grpc_endpoint": endpoint.otlp_grpc_endpoint,
+        "arrow_connector_enabled": endpoint.arrow_connector_enabled,
+        "routes": {
+            "logs": plan.logs_url,
+            "metrics": plan.metrics_url,
+            "traces": plan.traces_url,
+            "export_plan": format!("http://{addr}/rotel/export-plan")
+        }
+    })
+}
+
+fn otlp_signal_from_request_line(request_line: &str) -> Option<OTelSignal> {
+    if request_line.starts_with("POST /v1/logs ") {
+        Some(OTelSignal::Log)
+    } else if request_line.starts_with("POST /v1/metrics ") {
+        Some(OTelSignal::Metric)
+    } else if request_line.starts_with("POST /v1/traces ") {
+        Some(OTelSignal::Trace)
+    } else {
+        None
+    }
+}
+
+fn rotel_otlp_response(signal: OTelSignal, body: &[u8]) -> String {
+    let payload = match serde_json::from_slice::<serde_json::Value>(body) {
+        Ok(value) => value,
+        Err(error) => {
+            return json_response(
+                400,
+                &serde_json::json!({ "error": format!("invalid OTLP JSON payload: {error}") }),
+            );
+        }
+    };
+    let resource_count = otlp_resource_count(signal, &payload);
+    json_response(
+        202,
+        &serde_json::json!({
+            "accepted": true,
+            "service": "rotel-embedded",
+            "listener": "l3dg3rr-internal-openai",
+            "signal": signal.as_str(),
+            "content_type": "application/json",
+            "resource_count": resource_count,
+            "payload_bytes": body.len(),
+            "arrow_connector_enabled": true,
+            "classification_columns": ledger_core::observability::TelemetryArrowBatch::classification_columns(),
+        }),
+    )
+}
+
+fn otlp_resource_count(signal: OTelSignal, payload: &serde_json::Value) -> usize {
+    let key = match signal {
+        OTelSignal::Log => "resourceLogs",
+        OTelSignal::Metric => "resourceMetrics",
+        OTelSignal::Trace => "resourceSpans",
+    };
+    payload
+        .get(key)
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::len)
+        .unwrap_or_default()
 }
 
 pub fn open_internal_docs_in_browser() -> std::io::Result<()> {
@@ -945,6 +1093,8 @@ fn redirect_response(location: &str) -> String {
 fn bytes_response(status: u16, content_type: &str, body: &[u8]) -> String {
     let reason = match status {
         200 => "OK",
+        202 => "Accepted",
+        400 => "Bad Request",
         404 => "Not Found",
         _ => "OK",
     };
@@ -995,6 +1145,7 @@ fn json_response(status: u16, payload: &impl Serialize) -> String {
         .unwrap_or_else(|_| "{\"error\":\"serialization failure\"}".to_string());
     let reason = match status {
         200 => "OK",
+        202 => "Accepted",
         400 => "Bad Request",
         404 => "Not Found",
         500 => "Internal Server Error",
@@ -1139,6 +1290,110 @@ mod tests {
 
         assert!(response.starts_with("HTTP/1.1 200 OK"));
         assert!(response.contains("\"id\":\"phi-4-mini-reasoning\""));
+    }
+
+    #[test]
+    fn rotel_health_route_is_hosted_on_internal_listener() {
+        let raw = "GET /rotel/health HTTP/1.1\r\nHost: localhost\r\n\r\n";
+
+        let response = route_http_request(raw.as_bytes(), &FixedBackend, None);
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.contains("\"service\":\"rotel-embedded\""));
+        assert!(response.contains("\"listener\":\"l3dg3rr-internal-openai\""));
+        assert!(response.contains("\"logs\":\"http://127.0.0.1:15115/v1/logs\""));
+        assert!(response.contains("\"arrow_connector_enabled\":true"));
+    }
+
+    #[test]
+    fn rotel_export_plan_reuses_core_otlp_shape() {
+        let raw = "GET /rotel/export-plan HTTP/1.1\r\nHost: localhost\r\n\r\n";
+
+        let response = route_http_request(raw.as_bytes(), &FixedBackend, None);
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.contains("\"logs_url\":\"http://127.0.0.1:15115/v1/logs\""));
+        assert!(response.contains("\"metrics_url\":\"http://127.0.0.1:15115/v1/metrics\""));
+        assert!(response.contains("\"traces_url\":\"http://127.0.0.1:15115/v1/traces\""));
+        assert!(response.contains("\"abstract_regex_type\""));
+    }
+
+    #[test]
+    fn rotel_export_plan_reflects_bound_listener_address() {
+        let raw = "GET /rotel/export-plan HTTP/1.1\r\nHost: localhost\r\n\r\n";
+
+        let response =
+            route_http_request_for_addr(raw.as_bytes(), &FixedBackend, None, "127.0.0.1:18081");
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.contains("\"logs_url\":\"http://127.0.0.1:18081/v1/logs\""));
+        assert!(response.contains("\"metrics_url\":\"http://127.0.0.1:18081/v1/metrics\""));
+        assert!(response.contains("\"traces_url\":\"http://127.0.0.1:18081/v1/traces\""));
+    }
+
+    #[test]
+    fn rotel_otlp_logs_route_accepts_json_payloads() {
+        let body = serde_json::json!({
+            "resourceLogs": [
+                {
+                    "resource": { "attributes": [] },
+                    "scopeLogs": []
+                }
+            ]
+        })
+        .to_string();
+        let raw = format!(
+            "POST /v1/logs HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+
+        let response = route_http_request(raw.as_bytes(), &FixedBackend, None);
+
+        assert!(response.starts_with("HTTP/1.1 202 Accepted"));
+        assert!(response.contains("\"accepted\":true"));
+        assert!(response.contains("\"signal\":\"log\""));
+        assert!(response.contains("\"resource_count\":1"));
+        assert!(response.contains("\"classification_columns\""));
+    }
+
+    #[test]
+    fn rotel_otlp_route_rejects_invalid_json() {
+        let raw =
+            "POST /v1/metrics HTTP/1.1\r\nHost: localhost\r\nContent-Length: 8\r\n\r\nnot-json";
+
+        let response = route_http_request(raw.as_bytes(), &FixedBackend, None);
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request"));
+        assert!(response.contains("invalid OTLP JSON payload"));
+    }
+
+    #[test]
+    fn internal_openai_handle_exposes_rotel_listener_urls() {
+        let (shutdown_tx, _shutdown_rx) = mpsc::channel();
+        let handle = InternalOpenAiHandle {
+            addr: "127.0.0.1:18080".to_string(),
+            shutdown_tx,
+            join: None,
+        };
+
+        assert_eq!(
+            handle.rotel_health_url(),
+            "http://127.0.0.1:18080/rotel/health"
+        );
+        assert_eq!(
+            handle.rotel_export_plan_url(),
+            "http://127.0.0.1:18080/rotel/export-plan"
+        );
+        assert_eq!(handle.rotel_logs_url(), "http://127.0.0.1:18080/v1/logs");
+        assert_eq!(
+            handle.rotel_metrics_url(),
+            "http://127.0.0.1:18080/v1/metrics"
+        );
+        assert_eq!(
+            handle.rotel_traces_url(),
+            "http://127.0.0.1:18080/v1/traces"
+        );
     }
 
     #[test]

--- a/crates/rotel-visual/Cargo.toml
+++ b/crates/rotel-visual/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "rotel-visual"
+edition = "2024"
+license.workspace = true
+version.workspace = true
+
+[dependencies]
+axum = { version = "0.7", features = ["ws", "json"] }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tower = { version = "0.4", features = ["util"] }
+
+[lints]
+workspace = true

--- a/crates/rotel-visual/src/lib.rs
+++ b/crates/rotel-visual/src/lib.rs
@@ -1,0 +1,215 @@
+use axum::{
+    extract::{State, ws::{WebSocket, WebSocketUpgrade}},
+    response::IntoResponse,
+    routing::get,
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tracing::{error, info, instrument};
+
+#[derive(Serialize, Deserialize, Debug)]
+struct HealthResponse {
+    status: String,
+    message: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct TelemetryData {
+    logs: Vec<LogRecord>,
+    metrics: Vec<MetricRecord>,
+    spans: Vec<SpanRecord>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct LogRecord {
+    timestamp: String,
+    level: String,
+    message: String,
+    shape: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct MetricRecord {
+    name: String,
+    value: f64,
+    timestamp: String,
+    labels: Vec<Label>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct SpanRecord {
+    trace_id: String,
+    span_id: String,
+    parent_span_id: Option<String>,
+    name: String,
+    start_time: String,
+    end_time: Option<String>,
+    status: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct Label {
+    key: String,
+    value: String,
+}
+
+#[derive(Debug)]
+struct AppState {
+    telemetry_tx: broadcast::Sender<TelemetryData>,
+}
+
+#[instrument]
+async fn health_handler() -> Json<HealthResponse> {
+    Json(HealthResponse {
+        status: "healthy".to_string(),
+        message: "Rotel Visual OTel Surface is running".to_string(),
+    })
+}
+
+#[instrument]
+async fn dashboard_handler() -> impl IntoResponse {
+    let html = r#"
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Rotel OTel Visual Surface</title>
+        <style>
+            body { font-family: Arial, sans-serif; margin: 0; padding: 20px; }
+            .dashboard { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+            .panel { border: 1px solid #ddd; padding: 15px; border-radius: 5px; }
+            .logs { height: 400px; overflow-y: auto; }
+            .metrics { height: 400px; }
+            .spans { height: 400px; }
+            .log-entry { margin-bottom: 5px; padding: 5px; border-radius: 3px; }
+            .log-entry.error { background-color: #ffe6e6; }
+            .log-entry.warn { background-color: #fff3cd; }
+            .log-entry.info { background-color: #e7f3ff; }
+        </style>
+    </head>
+    <body>
+        <h1>Rotel OTel Visual Surface</h1>
+        <div class="dashboard">
+            <div class="panel">
+                <h2>Real-time Logs</h2>
+                <div id="logs" class="logs"></div>
+            </div>
+            <div class="panel">
+                <h2>Metrics</h2>
+                <div id="metrics" class="metrics"></div>
+            </div>
+            <div class="panel">
+                <h2>Trace Spans</h2>
+                <div id="spans" class="spans"></div>
+            </div>
+            <div class="panel">
+                <h2>System Status</h2>
+                <div id="status">Connected</div>
+            </div>
+        </div>
+
+        <script>
+            const logsDiv = document.getElementById('logs');
+            const metricsDiv = document.getElementById('metrics');
+            const spansDiv = document.getElementById('spans');
+
+            const ws = new WebSocket('ws://' + location.host + '/ws/telemetry');
+
+            ws.onmessage = function(event) {
+                const data = JSON.parse(event.data);
+                updateLogs(data.logs);
+                updateMetrics(data.metrics);
+                updateSpans(data.spans);
+            };
+
+            function updateLogs(logs) {
+                logsDiv.innerHTML = logs.map(log => `
+                    <div class="log-entry ${log.level.toLowerCase()}">
+                        <strong>${log.timestamp}</strong> [${log.level}] ${log.message}
+                        <small>(Shape: ${log.shape})</small>
+                    </div>
+                `).join('');
+            }
+
+            function updateMetrics(metrics) {
+                metricsDiv.innerHTML = metrics.map(metric => `
+                    <div>
+                        <strong>${metric.name}</strong>: ${metric.value}
+                        <small>${metric.labels.map(l => `${l.key}=${l.value}`).join(', ')}</small>
+                    </div>
+                `).join('');
+            }
+
+            function updateSpans(spans) {
+                spansDiv.innerHTML = spans.map(span => `
+                    <div>
+                        <strong>${span.name}</strong>
+                        <small>Trace: ${span.trace_id.substring(0, 8)}...</small>
+                        <small>Span: ${span.span_id.substring(0, 8)}...</small>
+                        <small>Status: ${span.status}</small>
+                    </div>
+                `).join('');
+            }
+
+            ws.onopen = function() {
+                console.log('Connected to telemetry stream');
+            };
+
+            ws.onclose = function() {
+                console.log('Disconnected from telemetry stream');
+                document.getElementById('status').textContent = 'Disconnected';
+            };
+        </script>
+    </body>
+    </html>
+    "#;
+
+    axum::response::Html(html.to_string())
+}
+
+#[instrument]
+async fn websocket_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    ws.on_upgrade(|socket| handle_socket(socket, state))
+}
+
+async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
+    let mut rx = state.telemetry_tx.subscribe();
+
+    tokio::spawn(async move {
+        while let Ok(telemetry) = rx.recv().await {
+            let msg = axum::extract::ws::Message::Text(
+                serde_json::to_string(&telemetry).unwrap().into()
+            );
+            if let Err(err) = socket.send(msg).await {
+                error!("Error sending telemetry data: {}", err);
+                break;
+            }
+        }
+    });
+}
+
+pub fn create_app() -> Router {
+    let (tx, _rx) = broadcast::channel(100);
+    let state = Arc::new(AppState { telemetry_tx: tx });
+
+    Router::new()
+        .route("/", get(dashboard_handler))
+        .route("/health", get(health_handler))
+        .route("/ws/telemetry", get(websocket_handler))
+        .with_state(state)
+}
+
+pub async fn run_server() {
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080")
+        .await
+        .unwrap();
+    info!("Rotel Visual OTel Surface starting on 0.0.0.0:8080");
+
+    axum::serve(listener, create_app()).await.unwrap();
+}

--- a/crates/rotel-visual/tests/health_dashboard_tests.rs
+++ b/crates/rotel-visual/tests/health_dashboard_tests.rs
@@ -1,0 +1,44 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn test_health_endpoint() {
+    let app = rotel_visual::create_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_dashboard_endpoint() {
+    let app = rotel_visual::create_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(response
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .starts_with("text/html"));
+}

--- a/docs/rotel-otel-journal-surface.md
+++ b/docs/rotel-otel-journal-surface.md
@@ -1,0 +1,87 @@
+# Rotel OTel Journal Surface
+
+l3dg3rr owns typed telemetry semantics before data reaches a collector.
+Rotel is the embedded OpenTelemetry collector boundary; the Rust core models
+OTel object-shape polyfills, classifies log shapes, and emits deterministic
+journal artifacts that justify metric triggers.
+
+## Contract
+
+- `OTelLogRecord`, `OTelMetric`, and `OTelSpan` polyfill the log, metric, and
+  trace object shapes l3dg3rr needs internally.
+- `LogShapeClassifier` maps abstract regex types to classified journal
+  artifacts.
+- `ClassifiedJournalArtifact` records the matched excerpt, rule id,
+  evidence digest, metric name, and metric delta.
+- `TelemetryArrowBatch` provides the stable column contract for the embedded
+  Rotel/OTel-Arrow classification path.
+- `RotelExportPlan` keeps standard OTLP HTTP endpoints and the Arrow connector
+  intent explicit.
+
+## Internal Listener
+
+The l3dg3rr host service exposes the embedded Rotel surface on the same
+internal OpenAI-compatible model gateway listener:
+
+```text
+GET  http://127.0.0.1:15115/rotel/health
+GET  http://127.0.0.1:15115/rotel/export-plan
+POST http://127.0.0.1:15115/v1/logs
+POST http://127.0.0.1:15115/v1/metrics
+POST http://127.0.0.1:15115/v1/traces
+```
+
+The `/v1/*` OTLP paths accept JSON payloads and return an explicit
+`rotel-embedded` acceptance artifact. The gateway still owns OpenAI chat at
+`/v1/chat/completions`; Rotel hosting is additive on the internal listener.
+
+## Example Rule
+
+```text
+rule_id: gpu-driver-device-disappeared
+abstract_regex_type: hardware.gpu.driver.device_handle_unknown
+pattern: Unable to determine the device handle for GPU[0-9]+.*Unknown Error
+metric_name: l3dg3rr.hardware.gpu.driver_faults
+metric_delta: 1
+```
+
+When a matching error log is observed, l3dg3rr creates a classified journal
+artifact. That artifact is the justification for incrementing the metric; the
+metric is not triggered by raw text alone.
+
+## Arrow Columns
+
+The initial classification batch shape is:
+
+```text
+artifact_id
+signal
+abstract_regex_type
+metric_name
+metric_delta
+severity_text
+matched_excerpt
+justification_digest
+source_time_unix_nano
+```
+
+The `otel-arrow` Cargo feature enables an Apache Arrow schema for this batch
+without forcing Arrow into the default build.
+
+## Build Gate Pattern
+
+The observable build-gate path reuses existing b00t interface types:
+
+- `MetricRegistry` / `MetricValue` expose the visual SLI state.
+- `SarifLog` / `LintRule` / `SarifResult` emit the build-gate SLO result.
+- `datum::logic` tokenization plus NAND/NOR implements `&&` and `||`.
+
+Example:
+
+```text
+log_shape && metric
+```
+
+If the classified log shape is present but the expected metric is missing,
+the gate records visible metrics under `rotel-otel:<gate>` and emits SARIF
+rule `l3dg3rr/otel/build-gate-slo`.


### PR DESCRIPTION
## Summary
Adds the Rotel OTel Journal Surface: typed telemetry semantics, embedded collector endpoints, and a real-time visual dashboard.

## Changes
- **ledger-core**: New `observability` module with OTel polyfill types (`OTelLogRecord`, `OTelMetric`, `OTelSpan`), `LogShapeClassifier`, `ClassifiedJournalArtifact`, `TelemetryArrowBatch`, and `RotelExportPlan`. Wires `regex` dependency and optional `arrow` feature for otel-arrow schema.
- **b00t-iface**: SARIF build-gate SLO evaluation for OTel logic expressions (`evaluate_otel_logic_expression`, `check_otel_logic_slo_as_sarif`).
- **ledgerr-host**: Embeds rotel health (`/rotel/health`), export-plan (`/rotel/export-plan`), and OTLP v1/logs|metrics|traces routes on the internal OpenAI-compatible listener.
- **rotel-visual**: New axum crate with real-time WebSocket dashboard at `/`, health endpoint at `/health`, and telemetry stream at `/ws/telemetry`.
- **docs**: `docs/rotel-otel-journal-surface.md` documents the contract and example rule.
- ** hygiene**: `.b00tignore` for session files.

## Test Evidence
- `cargo test -p ledger-core` — 35 passed
- `cargo test -p b00t-iface` — 51 passed  
- `cargo test -p ledgerr-host` — 20 passed (including 6 new rotel/otlp endpoint tests)
- `cargo test -p rotel-visual` — 2 passed
- `cargo check -p rotel-visual -p ledger-core -p b00t-iface -p ledgerr-host` — clean

## Checklist
- [x] Tests added/updated and passing
- [x] New crate compiles and is wired into workspace
- [x] Design doc included
- [x] Conventional commit format followed