### PR TITLE
refactor(otel): idiomatic abstractions, self-telemetry, SARIF SLO wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8627,6 +8627,7 @@ version = "1.8.0"
 dependencies = [
  "anyhow",
  "axum",
+ "b00t-iface",
  "ledger-core",
  "serde",
  "serde_json",

--- a/crates/ledger-core/src/observability.rs
+++ b/crates/ledger-core/src/observability.rs
@@ -68,7 +68,7 @@ pub enum OTelSeverityNumber {
 }
 
 impl OTelSeverityNumber {
-    fn as_str(self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::Trace => "TRACE",
             Self::Debug => "DEBUG",
@@ -76,6 +76,26 @@ impl OTelSeverityNumber {
             Self::Warn => "WARN",
             Self::Error => "ERROR",
             Self::Fatal => "FATAL",
+        }
+    }
+}
+
+impl TryFrom<u8> for OTelSeverityNumber {
+    type Error = ObservabilityError;
+
+    /// Map OTLP severity number ranges (1-24) to canonical levels.
+    /// See <https://opentelemetry.io/docs/specs/otel/logs/data-model/#severity-fields>
+    fn try_from(value: u8) -> Result<Self, ObservabilityError> {
+        match value {
+            1..=4 => Ok(Self::Trace),
+            5..=8 => Ok(Self::Debug),
+            9..=12 => Ok(Self::Info),
+            13..=16 => Ok(Self::Warn),
+            17..=20 => Ok(Self::Error),
+            21..=24 => Ok(Self::Fatal),
+            _ => Err(ObservabilityError::InvalidRule(format!(
+                "severity number {value} out of OTLP range 1-24"
+            ))),
         }
     }
 }
@@ -108,6 +128,71 @@ impl OTelLogRecord {
             trace_id: None,
             span_id: None,
         }
+    }
+}
+
+/// OTLP JSON wire-format types for HTTP ingestion.
+/// These mirror the OpenTelemetry protobuf JSON encoding.
+pub mod otlp_json {
+    use super::*;
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct LogsRequest {
+        #[serde(rename = "resourceLogs")]
+        pub resource_logs: Vec<ResourceLogs>,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct ResourceLogs {
+        pub resource: Option<Resource>,
+        #[serde(rename = "scopeLogs")]
+        pub scope_logs: Vec<ScopeLogs>,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Resource {
+        pub attributes: Vec<Attribute>,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct ScopeLogs {
+        #[serde(rename = "logRecords")]
+        pub log_records: Vec<LogRecord>,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct LogRecord {
+        #[serde(rename = "timeUnixNano")]
+        pub time_unix_nano: String,
+        #[serde(rename = "severityNumber")]
+        pub severity_number: u8,
+        #[serde(rename = "severityText")]
+        pub severity_text: String,
+        pub body: AnyValue,
+        pub attributes: Vec<Attribute>,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct AnyValue {
+        #[serde(rename = "stringValue")]
+        pub string_value: Option<String>,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Attribute {
+        pub key: String,
+        pub value: AnyValue,
+    }
+}
+
+impl TryFrom<&otlp_json::LogRecord> for OTelLogRecord {
+    type Error = ObservabilityError;
+
+    fn try_from(record: &otlp_json::LogRecord) -> Result<Self, Self::Error> {
+        let time_unix_nano = record.time_unix_nano.parse().unwrap_or(0);
+        let severity = OTelSeverityNumber::try_from(record.severity_number)?;
+        let body = record.body.string_value.clone().unwrap_or_default();
+        Ok(Self::new(time_unix_nano, severity, body))
     }
 }
 
@@ -246,6 +331,23 @@ impl LogShapeClassifier {
             compiled.push((rule, regex));
         }
         Ok(Self { compiled })
+    }
+
+    /// Built-in rules that ship with l3dg3rr for common operational signals.
+    pub fn with_builtin_rules() -> Result<Self, ObservabilityError> {
+        Self::new(vec![
+            LogShapeRule {
+                rule_id: "gpu-driver-device-disappeared".to_string(),
+                abstract_regex_type: "hardware.gpu.driver.device_handle_unknown".to_string(),
+                pattern: "Unable to determine the device handle for GPU[0-9]+.*Unknown Error"
+                    .to_string(),
+                metric_name: "l3dg3rr.hardware.gpu.driver_faults".to_string(),
+                metric_delta: 1,
+                min_severity: OTelSeverityNumber::Error,
+                rationale: "GPU was expected but nvidia-smi returned an unknown device-handle error"
+                    .to_string(),
+            },
+        ])
     }
 
     pub fn classify_log(&self, log: &OTelLogRecord) -> Vec<ClassifiedJournalArtifact> {
@@ -534,5 +636,92 @@ mod tests {
             .arrow_columns
             .iter()
             .any(|c| c == "abstract_regex_type"));
+    }
+
+    #[test]
+    fn log_shape_classifier_with_builtin_rules_classifies_gpu_fault() {
+        let classifier = LogShapeClassifier::with_builtin_rules().unwrap();
+        let log = OTelLogRecord::new(
+            1,
+            OTelSeverityNumber::Error,
+            "Unable to determine the device handle for GPU0: 0000:01:00.0: Unknown Error",
+        );
+        let artifacts = classifier.classify_log(&log);
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(
+            artifacts[0].abstract_regex_type,
+            "hardware.gpu.driver.device_handle_unknown"
+        );
+    }
+
+    #[test]
+    fn otlp_severity_try_from_u8_maps_ranges_correctly() {
+        assert_eq!(OTelSeverityNumber::try_from(1).unwrap(), OTelSeverityNumber::Trace);
+        assert_eq!(OTelSeverityNumber::try_from(4).unwrap(), OTelSeverityNumber::Trace);
+        assert_eq!(OTelSeverityNumber::try_from(5).unwrap(), OTelSeverityNumber::Debug);
+        assert_eq!(OTelSeverityNumber::try_from(9).unwrap(), OTelSeverityNumber::Info);
+        assert_eq!(OTelSeverityNumber::try_from(13).unwrap(), OTelSeverityNumber::Warn);
+        assert_eq!(OTelSeverityNumber::try_from(17).unwrap(), OTelSeverityNumber::Error);
+        assert_eq!(OTelSeverityNumber::try_from(21).unwrap(), OTelSeverityNumber::Fatal);
+        assert_eq!(OTelSeverityNumber::try_from(24).unwrap(), OTelSeverityNumber::Fatal);
+    }
+
+    #[test]
+    fn otlp_severity_try_from_u8_rejects_out_of_range() {
+        assert!(OTelSeverityNumber::try_from(0).is_err());
+        assert!(OTelSeverityNumber::try_from(25).is_err());
+        assert!(OTelSeverityNumber::try_from(255).is_err());
+    }
+
+    #[test]
+    fn otlp_logs_request_deserializes_from_json() {
+        let json = r#"{
+            "resourceLogs": [
+                {
+                    "resource": { "attributes": [] },
+                    "scopeLogs": [
+                        {
+                            "logRecords": [
+                                {
+                                    "timeUnixNano": "1777724525000000000",
+                                    "severityNumber": 17,
+                                    "severityText": "ERROR",
+                                    "body": { "stringValue": "test message" },
+                                    "attributes": []
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }"#;
+
+        let req: otlp_json::LogsRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.resource_logs.len(), 1);
+        assert_eq!(req.resource_logs[0].scope_logs.len(), 1);
+        assert_eq!(req.resource_logs[0].scope_logs[0].log_records.len(), 1);
+        let record = &req.resource_logs[0].scope_logs[0].log_records[0];
+        assert_eq!(record.time_unix_nano, "1777724525000000000");
+        assert_eq!(record.severity_number, 17);
+        assert_eq!(record.body.string_value.as_deref(), Some("test message"));
+    }
+
+    #[test]
+    fn otlp_log_record_converts_to_otel_log_record() {
+        let otlp = otlp_json::LogRecord {
+            time_unix_nano: "1777724525000000000".to_string(),
+            severity_number: 17,
+            severity_text: "ERROR".to_string(),
+            body: otlp_json::AnyValue {
+                string_value: Some("GPU fault".to_string()),
+            },
+            attributes: vec![],
+        };
+
+        let log = OTelLogRecord::try_from(&otlp).unwrap();
+        assert_eq!(log.time_unix_nano, 1777724525000000000);
+        assert_eq!(log.severity_number, OTelSeverityNumber::Error);
+        assert_eq!(log.body, "GPU fault");
+        assert_eq!(log.severity_text, "ERROR");
     }
 }

--- a/crates/ledger-core/src/observability.rs
+++ b/crates/ledger-core/src/observability.rs
@@ -189,7 +189,7 @@ impl TryFrom<&otlp_json::LogRecord> for OTelLogRecord {
     type Error = ObservabilityError;
 
     fn try_from(record: &otlp_json::LogRecord) -> Result<Self, Self::Error> {
-        let time_unix_nano = record.time_unix_nano.parse().unwrap_or(0);
+        let time_unix_nano = record.time_unix_nano.parse()?;
         let severity = OTelSeverityNumber::try_from(record.severity_number)?;
         let body = record.body.string_value.clone().unwrap_or_default();
         Ok(Self::new(time_unix_nano, severity, body))

--- a/crates/ledger-core/src/observability.rs
+++ b/crates/ledger-core/src/observability.rs
@@ -189,7 +189,10 @@ impl TryFrom<&otlp_json::LogRecord> for OTelLogRecord {
     type Error = ObservabilityError;
 
     fn try_from(record: &otlp_json::LogRecord) -> Result<Self, Self::Error> {
-        let time_unix_nano = record.time_unix_nano.parse()?;
+        let time_unix_nano = record
+            .time_unix_nano
+            .parse()
+            .map_err(|_| ObservabilityError::InvalidRule)?;
         let severity = OTelSeverityNumber::try_from(record.severity_number)?;
         let body = record.body.string_value.clone().unwrap_or_default();
         Ok(Self::new(time_unix_nano, severity, body))

--- a/crates/mdbook-rhai-mermaid/Cargo.toml
+++ b/crates/mdbook-rhai-mermaid/Cargo.toml
@@ -4,6 +4,10 @@ version = "1.8.0"
 edition = "2021"
 description = "mdbook preprocessor: rhai DSL code blocks → Mermaid flowchart diagrams"
 
+[lib]
+name = "mdbook_rhai_mermaid"
+path = "src/lib.rs"
+
 [[bin]]
 name = "mdbook-rhai-mermaid"
 path = "src/main.rs"

--- a/crates/mdbook-rhai-mermaid/src/lib.rs
+++ b/crates/mdbook-rhai-mermaid/src/lib.rs
@@ -1,0 +1,7 @@
+//! Library exports for mdbook-rhai-mermaid parser and emitter.
+//!
+//! Enables consumption by b00t synergy_viz and other integrations
+//! without running the mdbook preprocessor binary.
+
+pub mod emitter;
+pub mod parser;

--- a/crates/rotel-visual/Cargo.toml
+++ b/crates/rotel-visual/Cargo.toml
@@ -17,6 +17,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ledger-core = { workspace = true }
 anyhow = { workspace = true }
+b00t-iface = { path = "../b00t-iface" }
 
 [dev-dependencies]
 tower = { version = "0.4", features = ["util"] }

--- a/crates/rotel-visual/src/lib.rs
+++ b/crates/rotel-visual/src/lib.rs
@@ -404,9 +404,16 @@ async fn otlp_logs_handler(
                                 continue;
                             }
                         };
+                        let time_unix_nano = match record.time_unix_nano.parse() {
+                            Ok(t) => t,
+                            Err(e) => {
+                                error!("Invalid time_unix_nano '{}': {}", record.time_unix_nano, e);
+                                continue;
+                            }
+                        };
 
                         let log = OTelLogRecord::new(
-                            record.time_unix_nano.parse().unwrap_or(0),
+                            time_unix_nano,
                             severity,
                             body.clone(),
                         );

--- a/crates/rotel-visual/src/lib.rs
+++ b/crates/rotel-visual/src/lib.rs
@@ -4,13 +4,18 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
+use b00t_iface::metric::MetricRegistry;
+use b00t_iface::sarif::check_otel_logic_slo_as_sarif;
 use ledger_core::observability::{
-    ClassifiedJournalArtifact, LogShapeClassifier, LogShapeRule, OTelLogRecord,
+    otlp_json, ClassifiedJournalArtifact, LogShapeClassifier, OTelLogRecord,
     OTelSeverityNumber, TelemetryArrowBatch,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 use tokio::sync::{broadcast, RwLock};
 use tracing::{error, info, instrument};
 
@@ -90,43 +95,81 @@ impl From<&ClassifiedJournalArtifact> for ClassifiedArtifactView {
     }
 }
 
+/// Self-telemetry counters for the rotel-visual surface.
+#[derive(Debug, Default)]
+struct SurfaceMetrics {
+    logs_ingested_total: AtomicU64,
+    logs_classified_total: AtomicU64,
+    metrics_ingested_total: AtomicU64,
+    traces_ingested_total: AtomicU64,
+    ws_connections_total: AtomicU64,
+    ws_connections_active: AtomicU64,
+}
+
+impl SurfaceMetrics {
+    fn inc_logs_ingested(&self, n: u64) {
+        self.logs_ingested_total.fetch_add(n, Ordering::Relaxed);
+    }
+    fn inc_logs_classified(&self, n: u64) {
+        self.logs_classified_total.fetch_add(n, Ordering::Relaxed);
+    }
+    fn inc_metrics_ingested(&self, n: u64) {
+        self.metrics_ingested_total.fetch_add(n, Ordering::Relaxed);
+    }
+    fn inc_traces_ingested(&self, n: u64) {
+        self.traces_ingested_total.fetch_add(n, Ordering::Relaxed);
+    }
+    fn inc_ws_connection(&self) {
+        self.ws_connections_total.fetch_add(1, Ordering::Relaxed);
+        self.ws_connections_active.fetch_add(1, Ordering::Relaxed);
+    }
+    fn dec_ws_connection(&self) {
+        self.ws_connections_active.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    fn snapshot(&self) -> SurfaceMetricsSnapshot {
+        SurfaceMetricsSnapshot {
+            logs_ingested_total: self.logs_ingested_total.load(Ordering::Relaxed),
+            logs_classified_total: self.logs_classified_total.load(Ordering::Relaxed),
+            metrics_ingested_total: self.metrics_ingested_total.load(Ordering::Relaxed),
+            traces_ingested_total: self.traces_ingested_total.load(Ordering::Relaxed),
+            ws_connections_total: self.ws_connections_total.load(Ordering::Relaxed),
+            ws_connections_active: self.ws_connections_active.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Serialize, Debug)]
+struct SurfaceMetricsSnapshot {
+    logs_ingested_total: u64,
+    logs_classified_total: u64,
+    metrics_ingested_total: u64,
+    traces_ingested_total: u64,
+    ws_connections_total: u64,
+    ws_connections_active: u64,
+}
+
 #[derive(Debug)]
 struct AppState {
     telemetry_tx: broadcast::Sender<TelemetryData>,
     classifier: LogShapeClassifier,
     ring_buffer: RwLock<VecDeque<TelemetryData>>,
+    metrics: SurfaceMetrics,
 }
 
 impl AppState {
     fn new() -> Result<Self, anyhow::Error> {
         let (tx, _rx) = broadcast::channel(100);
-        let classifier = Self::build_classifier()?;
+        let classifier = LogShapeClassifier::with_builtin_rules()?;
         Ok(Self {
             telemetry_tx: tx,
             classifier,
             ring_buffer: RwLock::new(VecDeque::with_capacity(100)),
+            metrics: SurfaceMetrics::default(),
         })
     }
 
-    fn build_classifier() -> Result<LogShapeClassifier, anyhow::Error> {
-        let rules = vec![
-            LogShapeRule {
-                rule_id: "gpu-driver-device-disappeared".to_string(),
-                abstract_regex_type: "hardware.gpu.driver.device_handle_unknown".to_string(),
-                pattern: "Unable to determine the device handle for GPU[0-9]+.*Unknown Error"
-                    .to_string(),
-                metric_name: "l3dg3rr.hardware.gpu.driver_faults".to_string(),
-                metric_delta: 1,
-                min_severity: OTelSeverityNumber::Error,
-                rationale: "GPU was expected but nvidia-smi returned an unknown device-handle error"
-                    .to_string(),
-            },
-        ];
-        Ok(LogShapeClassifier::new(rules)?)
-    }
-
     async fn broadcast(&self, data: TelemetryData) {
-        // Push to ring buffer
         {
             let mut buf = self.ring_buffer.write().await;
             if buf.len() >= 100 {
@@ -134,7 +177,6 @@ impl AppState {
             }
             buf.push_back(data.clone());
         }
-        // Broadcast to subscribers
         let _ = self.telemetry_tx.send(data);
     }
 
@@ -150,6 +192,11 @@ async fn health_handler() -> Json<HealthResponse> {
         status: "healthy".to_string(),
         message: "Rotel Visual OTel Surface is running".to_string(),
     })
+}
+
+#[instrument]
+async fn metrics_handler(State(state): State<Arc<AppState>>) -> Json<SurfaceMetricsSnapshot> {
+    Json(state.metrics.snapshot())
 }
 
 #[instrument]
@@ -212,7 +259,6 @@ async fn dashboard_handler() -> impl IntoResponse {
             ws.onmessage = function(event) {
                 const data = JSON.parse(event.data);
                 if (Array.isArray(data)) {
-                    // Replay buffer
                     data.forEach(batch => updateBatch(batch));
                 } else {
                     updateBatch(data);
@@ -291,7 +337,8 @@ async fn websocket_handler(
 }
 
 async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
-    // Replay ring buffer first
+    state.metrics.inc_ws_connection();
+
     let replay = state.replay_buffer().await;
     for batch in replay {
         let msg = axum::extract::ws::Message::Text(
@@ -299,11 +346,11 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
         );
         if let Err(err) = socket.send(msg).await {
             error!("Error sending replay data: {}", err);
+            state.metrics.dec_ws_connection();
             return;
         }
     }
 
-    // Subscribe to live updates
     let mut rx = state.telemetry_tx.subscribe();
 
     loop {
@@ -321,56 +368,8 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
             Err(broadcast::error::RecvError::Closed) => break,
         }
     }
-}
 
-// OTLP JSON ingestion handlers
-
-#[derive(Serialize, Deserialize, Debug)]
-struct OtlpLogsRequest {
-    #[serde(rename = "resourceLogs")]
-    resource_logs: Vec<ResourceLogs>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct ResourceLogs {
-    resource: Option<OtlpResource>,
-    #[serde(rename = "scopeLogs")]
-    scope_logs: Vec<ScopeLogs>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct OtlpResource {
-    attributes: Vec<OtlpAttribute>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct ScopeLogs {
-    #[serde(rename = "logRecords")]
-    log_records: Vec<OtlpLogRecord>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct OtlpLogRecord {
-    #[serde(rename = "timeUnixNano")]
-    time_unix_nano: String,
-    #[serde(rename = "severityNumber")]
-    severity_number: u8,
-    #[serde(rename = "severityText")]
-    severity_text: String,
-    body: OtlpAnyValue,
-    attributes: Vec<OtlpAttribute>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct OtlpAnyValue {
-    #[serde(rename = "stringValue")]
-    string_value: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct OtlpAttribute {
-    key: String,
-    value: OtlpAnyValue,
+    state.metrics.dec_ws_connection();
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -386,17 +385,25 @@ async fn otlp_logs_handler(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    let request: Result<OtlpLogsRequest, _> = serde_json::from_value(payload.clone());
+    let request: Result<otlp_json::LogsRequest, _> = serde_json::from_value(payload.clone());
     match request {
         Ok(req) => {
             let mut logs = Vec::new();
             let mut classified = Vec::new();
+            let mut log_count = 0u64;
 
             for resource_log in &req.resource_logs {
                 for scope_log in &resource_log.scope_logs {
                     for record in &scope_log.log_records {
+                        log_count += 1;
                         let body = record.body.string_value.clone().unwrap_or_default();
-                        let severity = otlp_severity_to_enum(record.severity_number);
+                        let severity = match OTelSeverityNumber::try_from(record.severity_number) {
+                            Ok(s) => s,
+                            Err(e) => {
+                                error!("Invalid severity number: {}", e);
+                                continue;
+                            }
+                        };
 
                         let log = OTelLogRecord::new(
                             record.time_unix_nano.parse().unwrap_or(0),
@@ -404,7 +411,6 @@ async fn otlp_logs_handler(
                             body.clone(),
                         );
 
-                        // Classify the log
                         let artifacts = state.classifier.classify_log(&log);
                         for artifact in &artifacts {
                             classified.push(ClassifiedArtifactView::from(artifact));
@@ -423,6 +429,9 @@ async fn otlp_logs_handler(
                     }
                 }
             }
+
+            state.metrics.inc_logs_ingested(log_count);
+            state.metrics.inc_logs_classified(classified.len() as u64);
 
             let telemetry = TelemetryData {
                 logs,
@@ -449,24 +458,14 @@ async fn otlp_logs_handler(
             let response = Json(serde_json::json!({
                 "error": format!("invalid OTLP JSON payload: {error}")
             }));
-            return (axum::http::StatusCode::BAD_REQUEST, response).into_response();
+            (axum::http::StatusCode::BAD_REQUEST, response).into_response()
         }
-    }
-}
-
-fn otlp_severity_to_enum(severity_number: u8) -> OTelSeverityNumber {
-    match severity_number {
-        1..=4 => OTelSeverityNumber::Trace,
-        5..=8 => OTelSeverityNumber::Debug,
-        9..=12 => OTelSeverityNumber::Info,
-        13..=16 => OTelSeverityNumber::Warn,
-        17..=20 => OTelSeverityNumber::Error,
-        _ => OTelSeverityNumber::Fatal,
     }
 }
 
 #[instrument]
 async fn otlp_metrics_handler(
+    State(state): State<Arc<AppState>>,
     Json(payload): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     let resource_count = payload
@@ -474,6 +473,8 @@ async fn otlp_metrics_handler(
         .and_then(|v| v.as_array())
         .map(|a| a.len())
         .unwrap_or(0);
+
+    state.metrics.inc_metrics_ingested(resource_count as u64);
 
     let response = Json(OtlpIngestResponse {
         accepted: true,
@@ -489,6 +490,7 @@ async fn otlp_metrics_handler(
 
 #[instrument]
 async fn otlp_traces_handler(
+    State(state): State<Arc<AppState>>,
     Json(payload): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     let resource_count = payload
@@ -496,6 +498,8 @@ async fn otlp_traces_handler(
         .and_then(|v| v.as_array())
         .map(|a| a.len())
         .unwrap_or(0);
+
+    state.metrics.inc_traces_ingested(resource_count as u64);
 
     let response = Json(OtlpIngestResponse {
         accepted: true,
@@ -509,24 +513,61 @@ async fn otlp_traces_handler(
     (axum::http::StatusCode::ACCEPTED, response).into_response()
 }
 
-pub fn create_app() -> Router {
-    let state = Arc::new(AppState::new().expect("Failed to initialize app state"));
+#[derive(Serialize, Deserialize, Debug)]
+struct EvaluateSloRequest {
+    gate_name: String,
+    expression: String,
+    log_shape_observed: bool,
+    metric_observed: bool,
+    slo_expected: bool,
+}
 
-    Router::new()
+#[instrument]
+async fn evaluate_slo_handler(
+    Json(req): Json<EvaluateSloRequest>,
+) -> impl IntoResponse {
+    let mut registry = MetricRegistry::new();
+    let report = check_otel_logic_slo_as_sarif(
+        &mut registry,
+        &req.gate_name,
+        &req.expression,
+        req.log_shape_observed,
+        req.metric_observed,
+        req.slo_expected,
+    );
+
+    let status = if report.has_errors() {
+        axum::http::StatusCode::OK
+    } else {
+        axum::http::StatusCode::OK
+    };
+
+    (status, Json(report)).into_response()
+}
+
+pub fn create_app() -> Result<Router, anyhow::Error> {
+    let state = Arc::new(AppState::new()?);
+
+    Ok(Router::new()
         .route("/", get(dashboard_handler))
         .route("/health", get(health_handler))
+        .route("/metrics", get(metrics_handler))
         .route("/ws/telemetry", get(websocket_handler))
         .route("/v1/logs", post(otlp_logs_handler))
         .route("/v1/metrics", post(otlp_metrics_handler))
         .route("/v1/traces", post(otlp_traces_handler))
-        .with_state(state)
+        .route("/rotel/evaluate", post(evaluate_slo_handler))
+        .with_state(state))
 }
 
-pub async fn run_server() {
+pub async fn run_server() -> Result<(), anyhow::Error> {
     let listener = tokio::net::TcpListener::bind("0.0.0.0:8080")
         .await
-        .unwrap();
+        .map_err(|e| anyhow::anyhow!("Failed to bind to 0.0.0.0:8080: {e}"))?;
     info!("Rotel Visual OTel Surface starting on 0.0.0.0:8080");
 
-    axum::serve(listener, create_app()).await.unwrap();
+    axum::serve(listener, create_app()?)
+        .await
+        .map_err(|e| anyhow::anyhow!("Server error: {e}"))?;
+    Ok(())
 }

--- a/crates/rotel-visual/src/lib.rs
+++ b/crates/rotel-visual/src/lib.rs
@@ -651,13 +651,7 @@ async fn evaluate_slo_handler(
         req.slo_expected,
     );
 
-    let status = if report.has_errors() {
-        axum::http::StatusCode::OK
-    } else {
-        axum::http::StatusCode::OK
-    };
-
-    (status, Json(report)).into_response()
+    (axum::http::StatusCode::OK, Json(report)).into_response()
 }
 
 pub fn create_app() -> Result<Router, anyhow::Error> {

--- a/crates/rotel-visual/src/lib.rs
+++ b/crates/rotel-visual/src/lib.rs
@@ -562,18 +562,59 @@ async fn otlp_metrics_handler(
     (axum::http::StatusCode::ACCEPTED, response).into_response()
 }
 
+#[derive(Deserialize, Debug)]
+struct OtlpTraceExportRequest {
+    #[serde(rename = "resourceSpans")]
+    resource_spans: Vec<OtlpResourceSpans>,
+}
+
+#[derive(Deserialize, Debug)]
+struct OtlpResourceSpans {
+    #[serde(rename = "scopeSpans")]
+    scope_spans: Vec<OtlpScopeSpans>,
+}
+
+#[derive(Deserialize, Debug)]
+struct OtlpScopeSpans {
+    spans: Vec<OtlpSpan>,
+}
+
+#[derive(Deserialize, Debug)]
+struct OtlpSpan {
+    #[serde(rename = "traceId")]
+    trace_id: String,
+    #[serde(rename = "spanId")]
+    span_id: String,
+    name: String,
+}
+
 #[instrument]
 async fn otlp_traces_handler(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    let resource_count = payload
-        .get("resourceSpans")
-        .and_then(|v| v.as_array())
-        .map(|a| a.len())
-        .unwrap_or(0);
+    let request: OtlpTraceExportRequest = match serde_json::from_value(payload) {
+        Ok(request) => request,
+        Err(error) => {
+            let response = Json(serde_json::json!({
+                "accepted": false,
+                "signal": "trace",
+                "error": format!("invalid OTLP trace payload: {error}"),
+            }));
+            return (axum::http::StatusCode::BAD_REQUEST, response).into_response();
+        }
+    };
 
-    state.metrics.inc_traces_ingested(resource_count as u64);
+    let resource_count = request.resource_spans.len();
+    let span_records: Vec<(&str, &str, &str)> = request
+        .resource_spans
+        .iter()
+        .flat_map(|resource_spans| resource_spans.scope_spans.iter())
+        .flat_map(|scope_spans| scope_spans.spans.iter())
+        .map(|span| (span.trace_id.as_str(), span.span_id.as_str(), span.name.as_str()))
+        .collect();
+
+    state.metrics.inc_traces_ingested(span_records.len() as u64);
 
     let response = Json(OtlpIngestResponse {
         accepted: true,

--- a/crates/rotel-visual/src/lib.rs
+++ b/crates/rotel-visual/src/lib.rs
@@ -354,18 +354,33 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
     let mut rx = state.telemetry_tx.subscribe();
 
     loop {
-        match rx.recv().await {
-            Ok(telemetry) => {
-                let msg = axum::extract::ws::Message::Text(
-                    serde_json::to_string(&telemetry).unwrap().into()
-                );
-                if let Err(err) = socket.send(msg).await {
-                    error!("Error sending telemetry data: {}", err);
-                    break;
+        tokio::select! {
+            ws_msg = socket.recv() => {
+                match ws_msg {
+                    Some(Ok(axum::extract::ws::Message::Close(_))) => break,
+                    Some(Ok(_)) => continue,
+                    Some(Err(err)) => {
+                        error!("Error receiving websocket message: {}", err);
+                        break;
+                    }
+                    None => break,
                 }
             }
-            Err(broadcast::error::RecvError::Lagged(_)) => continue,
-            Err(broadcast::error::RecvError::Closed) => break,
+            recv = rx.recv() => {
+                match recv {
+                    Ok(telemetry) => {
+                        let msg = axum::extract::ws::Message::Text(
+                            serde_json::to_string(&telemetry).unwrap().into()
+                        );
+                        if let Err(err) = socket.send(msg).await {
+                            error!("Error sending telemetry data: {}", err);
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
         }
     }
 

--- a/crates/rotel-visual/src/lib.rs
+++ b/crates/rotel-visual/src/lib.rs
@@ -470,18 +470,70 @@ async fn otlp_logs_handler(
     }
 }
 
+#[derive(Debug, serde::Deserialize)]
+struct OtlpMetricsRequest {
+    #[serde(rename = "resourceMetrics")]
+    resource_metrics: Vec<OtlpResourceMetrics>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct OtlpResourceMetrics {
+    #[serde(rename = "scopeMetrics", default)]
+    scope_metrics: Vec<OtlpScopeMetrics>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct OtlpScopeMetrics {
+    #[serde(default)]
+    metrics: Vec<OtlpMetric>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct OtlpMetric {
+    name: String,
+}
+
 #[instrument]
 async fn otlp_metrics_handler(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    let resource_count = payload
-        .get("resourceMetrics")
-        .and_then(|v| v.as_array())
-        .map(|a| a.len())
-        .unwrap_or(0);
+    let request = match serde_json::from_value::<OtlpMetricsRequest>(payload) {
+        Ok(request) if !request.resource_metrics.is_empty() => request,
+        Ok(_) => {
+            return (
+                axum::http::StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "accepted": false,
+                    "signal": "metric",
+                    "error": "invalid OTLP metric payload: resourceMetrics must be a non-empty array"
+                })),
+            )
+                .into_response();
+        }
+        Err(error) => {
+            return (
+                axum::http::StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "accepted": false,
+                    "signal": "metric",
+                    "error": format!("invalid OTLP metric payload: {error}")
+                })),
+            )
+                .into_response();
+        }
+    };
 
-    state.metrics.inc_metrics_ingested(resource_count as u64);
+    let resource_count = request.resource_metrics.len();
+    let metric_count = request
+        .resource_metrics
+        .iter()
+        .flat_map(|resource| resource.scope_metrics.iter())
+        .flat_map(|scope| scope.metrics.iter())
+        .filter(|metric| !metric.name.is_empty())
+        .count();
+
+    state.metrics.inc_metrics_ingested(metric_count as u64);
 
     let response = Json(OtlpIngestResponse {
         accepted: true,

--- a/crates/rotel-visual/src/lib.rs
+++ b/crates/rotel-visual/src/lib.rs
@@ -606,15 +606,14 @@ async fn otlp_traces_handler(
     };
 
     let resource_count = request.resource_spans.len();
-    let span_records: Vec<(&str, &str, &str)> = request
+    let span_count = request
         .resource_spans
         .iter()
         .flat_map(|resource_spans| resource_spans.scope_spans.iter())
         .flat_map(|scope_spans| scope_spans.spans.iter())
-        .map(|span| (span.trace_id.as_str(), span.span_id.as_str(), span.name.as_str()))
-        .collect();
+        .count();
 
-    state.metrics.inc_traces_ingested(span_records.len() as u64);
+    state.metrics.inc_traces_ingested(span_count as u64);
 
     let response = Json(OtlpIngestResponse {
         accepted: true,

--- a/crates/rotel-visual/src/main.rs
+++ b/crates/rotel-visual/src/main.rs
@@ -1,10 +1,10 @@
 use tracing_subscriber;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), anyhow::Error> {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    rotel_visual::run_server().await;
+    rotel_visual::run_server().await
 }

--- a/crates/rotel-visual/tests/health_dashboard_tests.rs
+++ b/crates/rotel-visual/tests/health_dashboard_tests.rs
@@ -3,11 +3,13 @@ use axum::http::{Request, StatusCode};
 use serde_json::json;
 use tower::ServiceExt;
 
+fn app() -> axum::Router {
+    rotel_visual::create_app().unwrap()
+}
+
 #[tokio::test]
 async fn test_health_endpoint() {
-    let app = rotel_visual::create_app();
-
-    let response = app
+    let response = app()
         .oneshot(
             Request::builder()
                 .uri("/health")
@@ -22,9 +24,7 @@ async fn test_health_endpoint() {
 
 #[tokio::test]
 async fn test_dashboard_endpoint() {
-    let app = rotel_visual::create_app();
-
-    let response = app
+    let response = app()
         .oneshot(
             Request::builder()
                 .uri("/")
@@ -46,8 +46,6 @@ async fn test_dashboard_endpoint() {
 
 #[tokio::test]
 async fn test_otlp_logs_ingestion_accepts_json_and_returns_202() {
-    let app = rotel_visual::create_app();
-
     let body = json!({
         "resourceLogs": [
             {
@@ -57,7 +55,7 @@ async fn test_otlp_logs_ingestion_accepts_json_and_returns_202() {
         ]
     });
 
-    let response = app
+    let response = app()
         .oneshot(
             Request::builder()
                 .uri("/v1/logs")
@@ -74,8 +72,6 @@ async fn test_otlp_logs_ingestion_accepts_json_and_returns_202() {
 
 #[tokio::test]
 async fn test_otlp_metrics_ingestion_accepts_json_and_returns_202() {
-    let app = rotel_visual::create_app();
-
     let body = json!({
         "resourceMetrics": [
             {
@@ -85,7 +81,7 @@ async fn test_otlp_metrics_ingestion_accepts_json_and_returns_202() {
         ]
     });
 
-    let response = app
+    let response = app()
         .oneshot(
             Request::builder()
                 .uri("/v1/metrics")
@@ -102,8 +98,6 @@ async fn test_otlp_metrics_ingestion_accepts_json_and_returns_202() {
 
 #[tokio::test]
 async fn test_otlp_traces_ingestion_accepts_json_and_returns_202() {
-    let app = rotel_visual::create_app();
-
     let body = json!({
         "resourceSpans": [
             {
@@ -113,7 +107,7 @@ async fn test_otlp_traces_ingestion_accepts_json_and_returns_202() {
         ]
     });
 
-    let response = app
+    let response = app()
         .oneshot(
             Request::builder()
                 .uri("/v1/traces")
@@ -130,9 +124,7 @@ async fn test_otlp_traces_ingestion_accepts_json_and_returns_202() {
 
 #[tokio::test]
 async fn test_otlp_logs_rejects_invalid_json_with_400() {
-    let app = rotel_visual::create_app();
-
-    let response = app
+    let response = app()
         .oneshot(
             Request::builder()
                 .uri("/v1/logs")
@@ -149,12 +141,6 @@ async fn test_otlp_logs_rejects_invalid_json_with_400() {
 
 #[tokio::test]
 async fn test_classified_artifacts_are_broadcast_to_websocket() {
-    // This test verifies that when OTLP logs are ingested and classified,
-    // the resulting artifacts are broadcast to WebSocket subscribers.
-    // We test this indirectly by checking the telemetry channel state.
-    let app = rotel_visual::create_app();
-
-    // Ingest a log that matches the GPU fault rule
     let body = json!({
         "resourceLogs": [
             {
@@ -170,9 +156,7 @@ async fn test_classified_artifacts_are_broadcast_to_websocket() {
                                 "timeUnixNano": "1777724525000000000",
                                 "severityNumber": 17,
                                 "severityText": "ERROR",
-                                "body": {
-                                    "stringValue": "Unable to determine the device handle for GPU0: 0000:01:00.0: Unknown Error"
-                                },
+                                "body": { "stringValue": "Unable to determine the device handle for GPU0: 0000:01:00.0: Unknown Error" },
                                 "attributes": []
                             }
                         ]
@@ -182,7 +166,7 @@ async fn test_classified_artifacts_are_broadcast_to_websocket() {
         ]
     });
 
-    let response = app
+    let response = app()
         .clone()
         .oneshot(
             Request::builder()
@@ -200,11 +184,6 @@ async fn test_classified_artifacts_are_broadcast_to_websocket() {
 
 #[tokio::test]
 async fn test_ring_buffer_replays_classified_artifacts_to_new_subscribers() {
-    // Verify that new WebSocket connections receive replayed artifacts
-    // from the ring buffer before live updates.
-    let app = rotel_visual::create_app();
-
-    // Ingest a log to populate the ring buffer
     let body = json!({
         "resourceLogs": [
             {
@@ -216,9 +195,7 @@ async fn test_ring_buffer_replays_classified_artifacts_to_new_subscribers() {
                                 "timeUnixNano": "1777724525000000000",
                                 "severityNumber": 17,
                                 "severityText": "ERROR",
-                                "body": {
-                                    "stringValue": "Unable to determine the device handle for GPU0: 0000:01:00.0: Unknown Error"
-                                },
+                                "body": { "stringValue": "Unable to determine the device handle for GPU0: 0000:01:00.0: Unknown Error" },
                                 "attributes": []
                             }
                         ]
@@ -228,7 +205,7 @@ async fn test_ring_buffer_replays_classified_artifacts_to_new_subscribers() {
         ]
     });
 
-    let response = app
+    let response = app()
         .clone()
         .oneshot(
             Request::builder()
@@ -242,4 +219,152 @@ async fn test_ring_buffer_replays_classified_artifacts_to_new_subscribers() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::ACCEPTED);
+}
+
+#[tokio::test]
+async fn test_metrics_endpoint_returns_self_telemetry() {
+    let response = app()
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let snapshot: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(snapshot.get("logs_ingested_total").is_some());
+    assert!(snapshot.get("ws_connections_active").is_some());
+}
+
+#[tokio::test]
+async fn test_metrics_endpoint_increments_after_ingestion() {
+    let app = app();
+
+    // Get baseline
+    let baseline = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let baseline_body = axum::body::to_bytes(baseline.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let baseline_json: serde_json::Value = serde_json::from_slice(&baseline_body).unwrap();
+    let baseline_logs = baseline_json["logs_ingested_total"].as_u64().unwrap();
+
+    // Ingest a metric
+    let body = json!({
+        "resourceMetrics": [
+            {
+                "resource": { "attributes": [] },
+                "scopeMetrics": []
+            }
+        ]
+    });
+    let _ = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/metrics")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Check incremented
+    let after = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let after_body = axum::body::to_bytes(after.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let after_json: serde_json::Value = serde_json::from_slice(&after_body).unwrap();
+    let after_logs = after_json["metrics_ingested_total"].as_u64().unwrap();
+
+    assert_eq!(after_logs, baseline_logs + 1);
+}
+
+#[tokio::test]
+async fn test_rotel_evaluate_endpoint_returns_sarif() {
+    let body = json!({
+        "gate_name": "test-gate",
+        "expression": "log_shape && metric",
+        "log_shape_observed": true,
+        "metric_observed": true,
+        "slo_expected": true
+    });
+
+    let response = app()
+        .oneshot(
+            Request::builder()
+                .uri("/rotel/evaluate")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let sarif: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(sarif.get("runs").is_some());
+}
+
+#[tokio::test]
+async fn test_rotel_evaluate_detects_slo_failure() {
+    let body = json!({
+        "gate_name": "test-gate-fail",
+        "expression": "log_shape && metric",
+        "log_shape_observed": true,
+        "metric_observed": false,
+        "slo_expected": true
+    });
+
+    let response = app()
+        .oneshot(
+            Request::builder()
+                .uri("/rotel/evaluate")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let sarif: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let runs = sarif["runs"].as_array().unwrap();
+    assert_eq!(runs.len(), 1);
+    let results = runs[0]["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["rule_id"], "l3dg3rr/otel/build-gate-slo");
 }

--- a/crates/rotel-visual/tests/health_dashboard_tests.rs
+++ b/crates/rotel-visual/tests/health_dashboard_tests.rs
@@ -268,7 +268,27 @@ async fn test_metrics_endpoint_increments_after_ingestion() {
         "resourceMetrics": [
             {
                 "resource": { "attributes": [] },
-                "scopeMetrics": []
+                "scopeMetrics": [
+                    {
+                        "scope": {
+                            "name": "test-scope"
+                        },
+                        "metrics": [
+                            {
+                                "name": "test.metric",
+                                "gauge": {
+                                    "dataPoints": [
+                                        {
+                                            "asInt": "1",
+                                            "timeUnixNano": "1",
+                                            "attributes": []
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                ]
             }
         ]
     });

--- a/crates/rotel-visual/tests/health_dashboard_tests.rs
+++ b/crates/rotel-visual/tests/health_dashboard_tests.rs
@@ -261,7 +261,7 @@ async fn test_metrics_endpoint_increments_after_ingestion() {
         .await
         .unwrap();
     let baseline_json: serde_json::Value = serde_json::from_slice(&baseline_body).unwrap();
-    let baseline_logs = baseline_json["logs_ingested_total"].as_u64().unwrap();
+    let baseline_logs = baseline_json["metrics_ingested_total"].as_u64().unwrap();
 
     // Ingest a metric
     let body = json!({


### PR DESCRIPTION
## Summary
Supersedes #66. Rebases the OTel refactor stack onto a dedicated branch and carries the additional local `mdbook-rhai-mermaid` library export so integrations can consume the parser/emitter without shelling out to the preprocessor binary.

## Included work
- PR #66 OTEL stack: shared abstractions, self-telemetry, SARIF SLO wiring
- local follow-up: expose `mdbook-rhai-mermaid` as a reusable library target

## Validation
- `cargo test -p mdbook-rhai-mermaid`
