### PR TITLE
feat(mdbook-rhai-mermaid): expose parser and emitter as library

### DIFF
--- a/crates/mdbook-rhai-mermaid/Cargo.toml
+++ b/crates/mdbook-rhai-mermaid/Cargo.toml
@@ -4,6 +4,10 @@ version = "1.8.1"
 edition = "2021"
 description = "mdbook preprocessor: rhai DSL code blocks → Mermaid flowchart diagrams"
 
+[lib]
+name = "mdbook_rhai_mermaid"
+path = "src/lib.rs"
+
 [[bin]]
 name = "mdbook-rhai-mermaid"
 path = "src/main.rs"

--- a/crates/mdbook-rhai-mermaid/src/lib.rs
+++ b/crates/mdbook-rhai-mermaid/src/lib.rs
@@ -1,0 +1,7 @@
+//! Library exports for mdbook-rhai-mermaid parser and emitter.
+//!
+//! Enables consumption by b00t synergy_viz and other integrations
+//! without running the mdbook preprocessor binary.
+
+pub mod emitter;
+pub mod parser;


### PR DESCRIPTION
## Summary
Expose `mdbook-rhai-mermaid` as a reusable library target so integrations can import the parser and emitter directly instead of shelling out to the preprocessor binary.

## Changes
- add a `[lib]` target for `mdbook_rhai_mermaid`
- export `emitter` and `parser` modules from `src/lib.rs`

## Validation
- `cargo test -p mdbook-rhai-mermaid`
