### PR TITLE
chore(clippy): zero warnings baseline, agent tooling efficiency mandate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,13 @@ Future agents should follow this working loop unless the user directs otherwise:
 - memoize stable next steps, constraints, and unresolved risks back into this file when they matter for later sessions;
 - repeat until the user is satisfied.
 
+Code discovery rule (mandatory, not optional):
+- NEVER use grep/bash -r for structural code queries (function defs, callers, types, routes, imports, dependencies, architecture).
+- ALWAYS use `codebase-memory-mcp` tools (`search_graph`, `trace_path`, `get_code_snippet`, `get_architecture`, `query_graph`) for structural queries.
+- ALWAYS use `b00t-mcp` tools (`b00t_grok_ask`, `b00t_grok_learn`) for RAG-augmented knowledge retrieval.
+- Fall back to grep/glob ONLY for string literals, error messages, config values, and non-code files (Dockerfiles, shell scripts, YAML).
+- Rationale: grep -r burns CPU budget (10-30s per call), misses cross-crate relationships, and pulls irrelevant context. codebase-memory-mcp resolves in 1-3s with structural labels and relationship edges.
+
 Practical interpretation:
 - prefer one agent/sub-agent for implementation and another for targeted verification when the user explicitly wants delegation or parallel work;
 - do not treat green tests as the only completion signal if the UX, notification path, tray behavior, or host integration still lacks a real validation path;
@@ -423,6 +430,12 @@ Treat this as a standing operational gate, not a one-time migration task.
   - Describe `l3dg3rr` as a strongly typed, ontologically linked graph of scriptable visual-first workflows for supervised AI/LLM ETL into CPA-auditable bookkeeping artifacts.
   - Keep README structure MECE: bookkeeping truth, typed domain model, ontology graph, scriptable policy, workflow control, visualization, MCP/agent boundary, and operator host.
   - Clarify Rhai surfaces separately: transaction rules use `fn classify(tx)`, workflow compiler output may emit Rhai `switch`, and docs visualization uses the narrow `match expr => Arm -> target` DSL.
+- 2026-05-03: Clippy zero-warnings baseline established, agent tooling efficiency mandate.
+  - **Code discovery rule (mandatory)**: Added explicit rule to Execution Loop section: NEVER grep -r for structural queries. ALWAYS use codebase-memory-mcp (search_graph/trace_path) or b00t-mcp (b00t_grok_ask). grep/glob only for string literals, config values, non-code files. Rationale: grep burns 10-30s CPU budget per call, misses cross-crate relationships, pulls irrelevant context; graph tools resolve in 1-3s with structural labels.
+  - **`handle_external_tool`**: Removed vestigial `_registry` parameter — function always uses `GLOBAL_PROVIDER_REGISTRY` static internally. Call site no longer creates dummy `McpProviderRegistry::new()`.
+  - **Unmapped surfaces survey**: Confirmed `ConstraintSolver`/`Verb` traits are test+visualization-only but not truly dead (exercised by xtask + iso_lint). `LedgerOperation`/`SemanticRuleSelector`/`MultiModelVerifier` are future-feature stubs, not gaps. `HasVisualization` all 20 impls exercised. 13 ledger-core modules not consumed by MCP/host is architectural intent (iso/layout/render are visualization-only).
+  - **Zero clippy warnings** across workspace (excluding pre-existing ledgerr-tauri WSL issue). Fixed: unused constants behind cfg gates, dead_code on struct fields used only in tests, large Err variant allow.
+  - **Sub-agent pattern**: Used explore sub-agents with codebase-memory-mcp for survey (returned structured report in ~30s). Compare: previous grep-based survey attempt in PR #69 took 10+ minutes of CPU with truncated output. This validated the new tooling approach.
 
 
 <!-- GSD:profile-start -->

--- a/crates/arc-kit-au/src/node.rs
+++ b/crates/arc-kit-au/src/node.rs
@@ -43,7 +43,7 @@ impl NodeId {
     }
 
     pub fn hash(&self) -> &str {
-        self.0.splitn(2, ':').nth(1).unwrap_or(&self.0)
+        self.0.split_once(':').map(|x| x.1).unwrap_or(&self.0)
     }
 }
 

--- a/crates/b00t-iface/src/core/surface.rs
+++ b/crates/b00t-iface/src/core/surface.rs
@@ -122,6 +122,12 @@ pub enum DatumWatcherError {
     Validation(String),
 }
 
+impl Default for DatumWatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DatumWatcher {
     pub fn new() -> Self {
         let base = if cfg!(test) {

--- a/crates/b00t-iface/src/sarif/mod.rs
+++ b/crates/b00t-iface/src/sarif/mod.rs
@@ -415,15 +415,14 @@ pub fn check_l3dg3rr_standards(doc_files: &[(&str, &str)]) -> SarifLog {
 
             if rule.id.contains("unwired-legal-verification") {
                 // Check that PipelineBuilder::build() references LegalSolver
-                if content.contains("PipelineBuilder") && content.contains("fn build(") {
-                    if !content.contains("LegalSolver") && !content.contains("legal_solver") {
+                if content.contains("PipelineBuilder") && content.contains("fn build(")
+                    && !content.contains("LegalSolver") && !content.contains("legal_solver") {
                         run.add_result(rule.to_result(
                             file,
                             first_line_containing(content, "fn build("),
                             "PipelineBuilder::build() does not instantiate LegalSolver — enable_legal_verification flag is dead code",
                         ));
                     }
-                }
             }
 
             if rule.id.contains("mcp-provider-unwired") {
@@ -431,8 +430,7 @@ pub fn check_l3dg3rr_standards(doc_files: &[(&str, &str)]) -> SarifLog {
                 if (content.contains("mcp_adapter") || content.contains("ledgerr-mcp-server"))
                     && content.contains("tool_name")
                     && content.contains("match")
-                {
-                    if !content.contains("McpProviderRegistry")
+                    && !content.contains("McpProviderRegistry")
                         && !content.contains("handle_external_tool")
                     {
                         run.add_result(rule.to_result(
@@ -441,13 +439,12 @@ pub fn check_l3dg3rr_standards(doc_files: &[(&str, &str)]) -> SarifLog {
                             "Tool dispatch in ledgerr-mcp-server does not reference McpProviderRegistry — external providers are unreachable",
                         ));
                     }
-                }
             }
 
             if rule.id.contains("z3-kasuari-coherence") {
                 // Check that both Z3 and Kasuari concepts are used together
-                if content.contains("verify_legal") || content.contains("LegalSolver::verify") {
-                    if !content.contains("constraints") && !content.contains("VendorConstraintSet")
+                if (content.contains("verify_legal") || content.contains("LegalSolver::verify"))
+                    && !content.contains("constraints") && !content.contains("VendorConstraintSet")
                     {
                         run.add_result(rule.to_result(
                             file,
@@ -455,7 +452,6 @@ pub fn check_l3dg3rr_standards(doc_files: &[(&str, &str)]) -> SarifLog {
                             "Legal verification runs without constraint checking — Z3 result should feed into Kasuari-style constraint evaluation",
                         ));
                     }
-                }
             }
         }
     }

--- a/crates/datum/src/logic.rs
+++ b/crates/datum/src/logic.rs
@@ -835,6 +835,7 @@ macro_rules! abstract_cap_test {
 pub use abstract_cap_test;
 
 /// Runtime test helper: builds flux capacitor from gate kinds and checks stability.
+#[cfg(test)]
 fn run_stable_test(kinds: &[GateKind]) {
     let mut cap = FluxCapacitor::new();
     let ids: Vec<usize> = kinds.iter().map(|k| cap.add_gate(*k)).collect();

--- a/crates/ledger-core/src/document_shape.rs
+++ b/crates/ledger-core/src/document_shape.rs
@@ -212,11 +212,10 @@ impl<'a> Classifier<'a> {
         }
 
         // Crypto hints → account type
-        if fl.contains("coinbase") || fl.contains("kraken") {
-            if self.account_type.is_empty() {
+        if (fl.contains("coinbase") || fl.contains("kraken"))
+            && self.account_type.is_empty() {
                 self.account_type = "crypto".to_string();
             }
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -470,7 +469,7 @@ fn has_date_pattern(content: &str, pattern: DatePattern) -> bool {
                     let day_tens = w[0];
                     let day_units = w[1];
                     let year_ok = w[6..10].iter().all(|c| c.is_ascii_digit());
-                    let is_valid_day_tens = day_tens >= b'0' && day_tens <= b'3';
+                    let is_valid_day_tens = (b'0'..=b'3').contains(&day_tens);
                     let unit_digit = day_units.is_ascii_digit();
                     // AU style if day tens > 1 (i.e. 20-31) or tens == 1 and units > 2 (13-19)
                     let looks_au = (day_tens == b'1' && day_units > b'2')

--- a/crates/ledger-core/src/legal.rs
+++ b/crates/ledger-core/src/legal.rs
@@ -7,17 +7,14 @@ use z3::{ast::Bool, Config, Context, SatResult, Solver};
 
 /// Jurisdiction for tax rule evaluation (US, AU, UK, etc.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Default)]
 pub enum Jurisdiction {
+    #[default]
     US,
     AU,
     UK,
 }
 
-impl Default for Jurisdiction {
-    fn default() -> Self {
-        Self::US
-    }
-}
 
 impl Jurisdiction {
     pub fn code(&self) -> &'static str {

--- a/crates/ledger-core/src/pipeline.rs
+++ b/crates/ledger-core/src/pipeline.rs
@@ -100,6 +100,7 @@ impl PipelineState<Ingested> {
 impl PipelineState<Validated> {
     /// Verify transaction against legal rules.
     /// Returns Ok(Classified) if no Unrecoverable violations, Err(NeedsReview) otherwise.
+    #[allow(clippy::result_large_err)]
     pub fn verify_legal(
         self,
         solver: &crate::legal::LegalSolver,
@@ -280,7 +281,9 @@ impl LedgerPipeline {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Default)]
 pub enum State {
+    #[default]
     Ingested,
     Validating,
     Classifying,
@@ -289,11 +292,6 @@ pub enum State {
     NeedsReview,
 }
 
-impl Default for State {
-    fn default() -> Self {
-        State::Ingested
-    }
-}
 
 pub fn init() -> State {
     State::Ingested

--- a/crates/ledger-core/src/validation.rs
+++ b/crates/ledger-core/src/validation.rs
@@ -184,13 +184,13 @@ where
     let issues = next.issues.clone();
     let _issue_count = issues.len();
     let meta = next.meta.advance(stage, next.confidence, &issues);
-    let result = StageResult {
+    
+    StageResult {
         data: next.data,
         confidence: next.confidence,
         issues,
         meta,
-    };
-    result
+    }
 }
 
 /// Reversibility defines whether a verb can be undone and under what conditions.

--- a/crates/ledgerr-host/src/agent_runtime.rs
+++ b/crates/ledgerr-host/src/agent_runtime.rs
@@ -348,7 +348,7 @@ impl RigAgentRuntime {
             }
         };
         let assistant_text =
-            extract_assistant_message(response.choice.into_iter()).ok_or_else(|| {
+            extract_assistant_message(response.choice).ok_or_else(|| {
                 self.audit_sink
                     .record_model_call(event_base.failed("missing_assistant_message"));
                 AgentRuntimeError::MissingAssistantMessage

--- a/crates/ledgerr-host/src/internal_openai.rs
+++ b/crates/ledgerr-host/src/internal_openai.rs
@@ -717,7 +717,7 @@ fn default_internal_backend() -> Arc<dyn InternalChatBackend> {
         }
     }
 
-    Arc::new(Phi4LocalFallbackBackend::default())
+    Arc::new(Phi4LocalFallbackBackend)
 }
 
 #[cfg(feature = "mistralrs-llm")]

--- a/crates/ledgerr-mcp-core/src/provider.rs
+++ b/crates/ledgerr-mcp-core/src/provider.rs
@@ -371,8 +371,7 @@ pub mod mock {
             self.call_count.fetch_add(1, Ordering::SeqCst);
             self.call_result
                 .as_ref()
-                .map_err(|e| e.clone())
-                .map(|v| v.clone())
+                .map_err(|e| e.clone()).cloned()
         }
 
         fn shutdown(&self) {}

--- a/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs
+++ b/crates/ledgerr-mcp/src/bin/ledgerr-mcp-server.rs
@@ -259,8 +259,7 @@ fn handle_request(request: Value) -> Option<Value> {
                         // Registry is accessed internally by handle_external_tool
                         // via mcp_adapter's GLOBAL_PROVIDER_REGISTRY.
                         let ext_args = params.get("arguments").cloned().unwrap_or(Value::Null);
-                        let dummy = ledgerr_mcp_core::McpProviderRegistry::new();
-                        mcp_adapter::handle_external_tool(&dummy, tool_name, &ext_args)
+                        mcp_adapter::handle_external_tool(tool_name, &ext_args)
                     }
                     #[cfg(not(feature = "b00t"))]
                     {
@@ -302,5 +301,5 @@ fn global_raw_service() -> &'static ledgerr_mcp::TurboLedgerService {
         &'static ledgerr_mcp::TurboLedgerService,
         ledgerr_mcp::actor::ServiceHandle,
     )> = OnceLock::new();
-    PAIR.get_or_init(|| build_service()).0
+    PAIR.get_or_init(build_service).0
 }

--- a/crates/ledgerr-mcp/src/mcp_adapter.rs
+++ b/crates/ledgerr-mcp/src/mcp_adapter.rs
@@ -124,11 +124,7 @@ pub fn tool_names() -> Vec<String> {
 
 /// Hook for external MCP providers.  Dispatches via the global provider registry.
 #[cfg(feature = "b00t")]
-pub fn handle_external_tool(
-    _registry: &ledgerr_mcp_core::McpProviderRegistry,
-    tool_name: &str,
-    arguments: &Value,
-) -> Value {
+pub fn handle_external_tool(tool_name: &str, arguments: &Value) -> Value {
     let Some(reg) = GLOBAL_PROVIDER_REGISTRY.get() else {
         return unknown_tool_result(tool_name);
     };
@@ -142,7 +138,7 @@ pub fn handle_external_tool(
 }
 
 #[cfg(not(feature = "b00t"))]
-pub fn handle_external_tool(_registry: (), tool_name: &str, _arguments: &Value) -> Value {
+pub fn handle_external_tool(tool_name: &str, _arguments: &Value) -> Value {
     unknown_tool_result(tool_name)
 }
 

--- a/crates/ledgerr-mcp/src/plugin_info.rs
+++ b/crates/ledgerr-mcp/src/plugin_info.rs
@@ -21,7 +21,9 @@ use serde_json::{json, Value};
 
 pub const PLUGIN_INFO_TOOL: &str = "l3dg3rr_plugin_info";
 
+#[allow(dead_code)]
 const GITHUB_OWNER: &str = "PromptExecution";
+#[allow(dead_code)]
 const GITHUB_REPO: &str = "l3dg3rr";
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/crates/mdbook-rhai-mermaid/src/parser.rs
+++ b/crates/mdbook-rhai-mermaid/src/parser.rs
@@ -96,6 +96,7 @@ impl SemanticRole {
         SemanticRole::Step
     }
 
+    #[allow(dead_code)]
     pub fn key(&self) -> &'static str {
         match self {
             SemanticRole::Ingest => "ingest",
@@ -116,14 +117,18 @@ pub struct Node {
     /// Stable identity key — survives cosmetic label changes.
     /// Defaults to the same as `id` but can be set explicitly for
     /// identity-stable reflow across source edits.
+    #[allow(dead_code)]
     pub identity_key: String,
     pub label: String,
     pub kind: NodeKind,
     /// Semantic role inferred from label keywords.
+    #[allow(dead_code)]
     pub role: SemanticRole,
     /// For match arms: declaration order index within the match group.
+    #[allow(dead_code)]
     pub arm_index: Option<usize>,
     /// Whether this node is a default/fallback arm (`_` or `else`).
+    #[allow(dead_code)]
     pub is_default: bool,
 }
 
@@ -133,9 +138,11 @@ pub struct Edge {
     pub to: String,
     pub label: Option<String>,
     /// For match arms: declaration order index.
+    #[allow(dead_code)]
     pub arm_index: Option<usize>,
     /// Whether this edge represents a default/fallback path.
     pub is_default: bool,
+
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
## Summary

- **Zero clippy warnings** across the entire workspace (excluding pre-existing `ledgerr-tauri` WSL path issue)
- **Agent tooling efficiency mandate**: mandatory code-discovery rule added to `AGENTS.md` — always use `codebase-memory-mcp`/`b00t-mcp` for structural queries instead of `grep -r` (saves 10-30x CPU budget)
- **`handle_external_tool`** cleaned up: removed vestigial `_registry` parameter and dummy `McpProviderRegistry::new()` at call site
- **Unmapped surfaces surveyed**: confirmed `ConstraintSolver`/`Verb` traits are visualization-only (not dead), `LedgerOperation`/`SemanticRuleSelector`/`MultiModelVerifier` are future-feature stubs
- **461 tests pass**, `cargo check` clean

### Files changed: 16
</details>