### PR TITLE
feat(tauri): surface EvidenceState/TodayQueue in Dashboard panel

### DIFF
--- a/crates/arc-kit-au/src/graph.rs
+++ b/crates/arc-kit-au/src/graph.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::edge::{EdgeType, EvidenceEdge};
-use crate::missing::{ProvenanceScanner, ProvenanceGap};
+use crate::missing::ProvenanceScanner;
 use crate::node::{EvidenceNode, NodeId, NodeType};
 
 /// Summary of the evidence graph's work queue state.

--- a/crates/ledgerr-host/src/evidence.rs
+++ b/crates/ledgerr-host/src/evidence.rs
@@ -48,6 +48,8 @@ pub struct TodayQueue {
     pub ready_to_review: usize,
     pub blocked: usize,
     pub exported: usize,
+    /// Transactions that have ValidationIssue nodes attached.
+    pub with_validation_issues: usize,
     pub last_action_summary: String,
     pub next_actions: Vec<String>,
 }
@@ -62,7 +64,7 @@ impl TodayQueue {
         let validation = summary.with_validation_issues;
 
         let last_action_summary = if evidence.checked {
-            if blocked == 0 && ready == 0 {
+            if blocked == 0 && ready == 0 && validation == 0 {
                 "All evidence chains are complete.".to_string()
             } else {
                 let mut parts = vec![];
@@ -112,6 +114,7 @@ impl TodayQueue {
             ready_to_review: ready,
             blocked,
             exported,
+            with_validation_issues: validation,
             last_action_summary,
             next_actions,
         }
@@ -174,5 +177,39 @@ mod tests {
             .iter()
             .any(|a| a.contains("Model setup needed") || a.contains("Configure"));
         assert!(has_model_action);
+    }
+
+    #[test]
+    fn with_validation_issues_field_is_populated() {
+        use arc_kit_au::node::{EvidenceNode, ValidationIssue};
+        use chrono::Utc;
+        let mut state = EvidenceState::new();
+        let vi = ValidationIssue {
+            tx_id: "tx_abc".to_string(),
+            rule: "amount_check".to_string(),
+            severity: "error".to_string(),
+            message: "amount out of range".to_string(),
+            actor: "pipeline".to_string(),
+            raised_at: Utc::now(),
+            resolved: false,
+        };
+        state.graph.add_node(EvidenceNode::ValidationIssue(vi)).unwrap();
+        state.refresh_gaps();
+        let queue = TodayQueue::from_state(&state, &test_settings());
+        assert_eq!(queue.with_validation_issues, 1);
+        // All chains are not "complete" while validation issues remain
+        assert!(!queue.last_action_summary.contains("All evidence chains are complete"));
+    }
+
+    #[test]
+    fn all_complete_requires_zero_validation_issues() {
+        let mut state = EvidenceState::new();
+        state.refresh_gaps();
+        let queue = TodayQueue::from_state(&state, &test_settings());
+        // Empty graph has no gaps and no validation issues — should report all complete
+        assert_eq!(queue.with_validation_issues, 0);
+        assert_eq!(queue.blocked, 0);
+        assert_eq!(queue.ready_to_review, 0);
+        assert!(queue.last_action_summary.contains("All evidence chains are complete"));
     }
 }

--- a/crates/ledgerr-tauri/src/commands.rs
+++ b/crates/ledgerr-tauri/src/commands.rs
@@ -106,11 +106,13 @@ pub fn ensure_internal_endpoint(
 
 #[tauri::command]
 pub fn get_evidence_dashboard(state: tauri::State<'_, AppState>) -> Result<EvidenceDashboardPayload, String> {
+    // Load settings before acquiring the evidence lock to keep the critical
+    // section as short as possible and avoid lock-ordering issues.
+    let settings = state.store.load().map_err(|e| e.to_string())?;
     let mut evidence = state
         .evidence
         .lock()
         .map_err(|_| "evidence state is poisoned".to_string())?;
-    let settings = state.store.load().map_err(|e| e.to_string())?;
     evidence.refresh_gaps();
     let queue = ledgerr_host::evidence::TodayQueue::from_state(&evidence, &settings);
     Ok(EvidenceDashboardPayload {

--- a/crates/ledgerr-tauri/src/commands.rs
+++ b/crates/ledgerr-tauri/src/commands.rs
@@ -35,6 +35,18 @@ pub struct InitialState {
 }
 
 #[derive(serde::Serialize, Clone)]
+pub struct EvidenceDashboardPayload {
+    pub today_queue: serde_json::Value,
+}
+
+#[derive(serde::Serialize, Clone)]
+pub struct TxProvenancePayload {
+    pub tx_id: String,
+    pub badge: String,
+    pub badge_class: String,
+}
+
+#[derive(serde::Serialize, Clone)]
 pub struct ChatSettingsPayload {
     pub endpoint_text: String,
     pub model_text: String,
@@ -88,6 +100,41 @@ pub fn ensure_internal_endpoint(
         }
         Err(error) => Err(error.to_string()),
     }
+}
+
+// ── Evidence / Dashboard Commands ─────────────────────────────────────────────
+
+#[tauri::command]
+pub fn get_evidence_dashboard(state: tauri::State<'_, AppState>) -> Result<EvidenceDashboardPayload, String> {
+    let mut evidence = state
+        .evidence
+        .lock()
+        .map_err(|_| "evidence state is poisoned".to_string())?;
+    let settings = state.store.load().map_err(|e| e.to_string())?;
+    evidence.refresh_gaps();
+    let queue = ledgerr_host::evidence::TodayQueue::from_state(&evidence, &settings);
+    Ok(EvidenceDashboardPayload {
+        today_queue: serde_json::to_value(queue).map_err(|e| e.to_string())?,
+    })
+}
+
+#[tauri::command]
+pub fn get_tx_provenance(
+    tx_id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<TxProvenancePayload, String> {
+    let evidence = state
+        .evidence
+        .lock()
+        .map_err(|_| "evidence state is poisoned".to_string())?;
+    let badge = evidence.provenance_badge(&tx_id);
+    let label = badge.label().to_string();
+    let css_class = badge.css_class().to_string();
+    Ok(TxProvenancePayload {
+        tx_id,
+        badge: label,
+        badge_class: css_class,
+    })
 }
 
 // ── Commands ──────────────────────────────────────────────────────────────────

--- a/crates/ledgerr-tauri/src/main.rs
+++ b/crates/ledgerr-tauri/src/main.rs
@@ -9,6 +9,7 @@ mod state;
 use std::sync::{Arc, Mutex};
 
 use ledgerr_host::chat::{ChatTurn, ReviewLog};
+use ledgerr_host::evidence::EvidenceState;
 use ledgerr_host::internal_openai::InternalOpenAiHandle;
 use ledgerr_host::settings::{default_settings_path, SettingsStore};
 
@@ -19,12 +20,14 @@ fn main() {
     let history: Arc<Mutex<Vec<ChatTurn>>> = Arc::new(Mutex::new(Vec::new()));
     let review_log: Arc<Mutex<ReviewLog>> = Arc::new(Mutex::new(ReviewLog::default()));
     let internal_endpoint: Arc<Mutex<Option<InternalOpenAiHandle>>> = Arc::new(Mutex::new(None));
+    let evidence: Arc<Mutex<EvidenceState>> = Arc::new(Mutex::new(EvidenceState::new()));
 
     let app_state = AppState {
         store,
         history,
         review_log,
         internal_endpoint,
+        evidence,
     };
 
     tauri::Builder::default()
@@ -39,6 +42,8 @@ fn main() {
             commands::use_foundry_local,
             commands::use_cloud_model,
             commands::open_docs_playbook,
+            commands::get_evidence_dashboard,
+            commands::get_tx_provenance,
         ])
         .run(tauri::generate_context!())
         .expect("error while running ledgerr-tauri application");

--- a/crates/ledgerr-tauri/src/state.rs
+++ b/crates/ledgerr-tauri/src/state.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use ledgerr_host::chat::{ChatTurn, ReviewLog};
+use ledgerr_host::evidence::EvidenceState;
 use ledgerr_host::internal_openai::InternalOpenAiHandle;
 use ledgerr_host::settings::SettingsStore;
 
@@ -9,4 +10,5 @@ pub struct AppState {
     pub history: Arc<Mutex<Vec<ChatTurn>>>,
     pub review_log: Arc<Mutex<ReviewLog>>,
     pub internal_endpoint: Arc<Mutex<Option<InternalOpenAiHandle>>>,
+    pub evidence: Arc<Mutex<EvidenceState>>,
 }

--- a/crates/ledgerr-tauri/ui/index.html
+++ b/crates/ledgerr-tauri/ui/index.html
@@ -26,11 +26,16 @@
       </button>
 
       <button class="nav-item" data-panel="2">
+        <span class="mark">DB</span>
+        <span class="label">Dashboard</span>
+      </button>
+
+      <button class="nav-item" data-panel="3">
         <span class="mark">ST</span>
         <span class="label">Settings</span>
       </button>
 
-      <button class="nav-item" data-panel="3">
+      <button class="nav-item" data-panel="4">
         <span class="mark">DK</span>
         <span class="label">Docs Playbook</span>
       </button>
@@ -108,8 +113,46 @@
         </div>
       </div>
 
-      <!-- Panel 2: Settings -->
-      <div id="panel-2" class="panel card hidden settings-bg">
+      <!-- Panel 2: Dashboard -->
+      <div id="panel-2" class="panel card hidden">
+        <span class="panel-title">Dashboard</span>
+        <div id="evidence-summary" class="evidence-summary">
+          <div id="blocked-card" class="ev-card ev-card-blocked">
+            <div class="ev-card-value" id="blocked-value">-</div>
+            <div class="ev-card-label">Blocked</div>
+          </div>
+          <div id="ready-card" class="ev-card ev-card-ready">
+            <div class="ev-card-value" id="ready-value">-</div>
+            <div class="ev-card-label">Ready to Review</div>
+          </div>
+          <div id="exported-card" class="ev-card ev-card-exported">
+            <div class="ev-card-value" id="exported-value">-</div>
+            <div class="ev-card-label">Exported</div>
+          </div>
+          <div id="issues-card" class="ev-card ev-card-issues">
+            <div class="ev-card-value" id="issues-value">-</div>
+            <div class="ev-card-label">Validation Issues</div>
+          </div>
+        </div>
+        <div class="ev-section">
+          <div class="ev-section-title">Last Action</div>
+          <div id="ev-last-action" class="ev-last-action">Loading...</div>
+        </div>
+        <div class="ev-section">
+          <div class="ev-section-title">Next Actions</div>
+          <ul id="ev-next-actions" class="ev-next-actions"></ul>
+        </div>
+        <div class="ev-section">
+          <div class="ev-section-title">Provider Status</div>
+          <div id="ev-provider-status" class="ev-provider-status">Loading...</div>
+        </div>
+        <div class="ev-refresh-row">
+          <button id="btn-refresh-dashboard" class="ev-refresh-btn">Refresh Dashboard</button>
+        </div>
+      </div>
+
+      <!-- Panel 3: Settings -->
+      <div id="panel-3" class="panel card hidden settings-bg">
         <span class="panel-title">Settings</span>
 
         <label class="field-label" for="input-endpoint">Endpoint URL</label>
@@ -132,8 +175,8 @@
         </div>
       </div>
 
-      <!-- Panel 3: Docs Playbook -->
-      <div id="panel-3" class="panel card hidden">
+      <!-- Panel 4: Docs Playbook -->
+      <div id="panel-4" class="panel card hidden">
         <span class="panel-title">Docs Playbook</span>
         <p id="docs-status-text" class="docs-status"></p>
         <div class="docs-actions">

--- a/crates/ledgerr-tauri/ui/main.js
+++ b/crates/ledgerr-tauri/ui/main.js
@@ -11,7 +11,7 @@ let busy = false;
 const sidebar        = document.getElementById('sidebar');
 const collapseBtn    = document.getElementById('collapse-btn');
 const navItems       = document.querySelectorAll('.nav-item[data-panel]');
-const panels         = [0,1,2,3].map(i => document.getElementById(`panel-${i}`));
+const panels         = [0,1,2,3,4].map(i => document.getElementById(`panel-${i}`));
 
 const versionText    = document.getElementById('version-text');
 const statusBar      = document.getElementById('status-bar');
@@ -49,6 +49,15 @@ const btnSave        = document.getElementById('btn-save-settings');
 const docsStatusText = document.getElementById('docs-status-text');
 const btnOpenDocs    = document.getElementById('btn-open-docs');
 const btnLoadRhai    = document.getElementById('btn-load-rhai-mutation');
+
+const btnRefreshDash = document.getElementById('btn-refresh-dashboard');
+const blockedValue   = document.getElementById('blocked-value');
+const readyValue     = document.getElementById('ready-value');
+const exportedValue  = document.getElementById('exported-value');
+const issuesValue    = document.getElementById('issues-value');
+const evLastAction   = document.getElementById('ev-last-action');
+const evNextActions  = document.getElementById('ev-next-actions');
+const evProviderStat = document.getElementById('ev-provider-status');
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -323,6 +332,38 @@ btnLoadRhai.addEventListener('click', async () => {
   }
 });
 
+// ── Dashboard: Refresh ────────────────────────────────────────────────────────
+
+async function refreshDashboard() {
+  try {
+    const payload = await invoke('get_evidence_dashboard');
+    const q = payload.today_queue;
+    blockedValue.textContent  = q.blocked ?? '-';
+    readyValue.textContent    = q.ready_to_review ?? '-';
+    exportedValue.textContent = q.exported ?? '-';
+    issuesValue.textContent   = q.with_validation_issues ?? '-';
+    evLastAction.textContent  = q.last_action_summary ?? '';
+    evNextActions.innerHTML   = (q.next_actions || []).map(a => `<li>${a}</li>`).join('');
+    evProviderStat.innerHTML  = (q.providers || []).map(p => {
+      const r = p.readiness || {};
+      const status = r.status || r.kind || 'unknown';
+      const icon = status === 'ready' ? '✓' : (status === 'diagnostic' ? '⚠' : '?');
+      return `<div class="ev-provider-line">${icon} ${p.label}: ${status}</div>`;
+    }).join('') || '<div class="ev-provider-line">No providers configured</div>';
+  } catch (err) {
+    evLastAction.textContent = `Error: ${err}`;
+  }
+}
+
+// Refresh dashboard when its panel becomes visible
+const origShowPanel = showPanel;
+showPanel = function(index) {
+  origShowPanel(index);
+  if (index === 2) refreshDashboard();
+};
+
+btnRefreshDash.addEventListener('click', refreshDashboard);
+
 // ── Initialise on load ────────────────────────────────────────────────────────
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -367,4 +408,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   } catch (err) {
     setStatus(`Init error: ${err}`);
   }
+
+  // Pre-load dashboard data
+  refreshDashboard();
 });

--- a/crates/ledgerr-tauri/ui/main.js
+++ b/crates/ledgerr-tauri/ui/main.js
@@ -61,6 +61,15 @@ const evProviderStat = document.getElementById('ev-provider-status');
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 function setStatus(text) {
   statusBar.textContent = text;
 }
@@ -79,6 +88,7 @@ function setBusy(val) {
   btnSave.disabled       = val;
   btnOpenDocs.disabled   = val;
   btnLoadRhai.disabled   = val;
+  btnRefreshDash.disabled = val;
   sendBtn.textContent    = val ? 'Sending…' : 'Send';
   btnSave.textContent    = val ? 'Working…' : 'Save Settings';
   inputEndpoint.disabled = val;
@@ -343,15 +353,22 @@ async function refreshDashboard() {
     exportedValue.textContent = q.exported ?? '-';
     issuesValue.textContent   = q.with_validation_issues ?? '-';
     evLastAction.textContent  = q.last_action_summary ?? '';
-    evNextActions.innerHTML   = (q.next_actions || []).map(a => `<li>${a}</li>`).join('');
+    evNextActions.innerHTML   = (q.next_actions || [])
+      .map(a => `<li>${escapeHtml(a)}</li>`).join('');
     evProviderStat.innerHTML  = (q.providers || []).map(p => {
       const r = p.readiness || {};
       const status = r.status || r.kind || 'unknown';
       const icon = status === 'ready' ? '✓' : (status === 'diagnostic' ? '⚠' : '?');
-      return `<div class="ev-provider-line">${icon} ${p.label}: ${status}</div>`;
+      return `<div class="ev-provider-line">${escapeHtml(icon)} ${escapeHtml(String(p.label))}: ${escapeHtml(status)}</div>`;
     }).join('') || '<div class="ev-provider-line">No providers configured</div>';
   } catch (err) {
-    evLastAction.textContent = `Error: ${err}`;
+    blockedValue.textContent  = '-';
+    readyValue.textContent    = '-';
+    exportedValue.textContent = '-';
+    issuesValue.textContent   = '-';
+    evLastAction.textContent  = `Error: ${err}`;
+    evNextActions.innerHTML   = '';
+    evProviderStat.textContent = '';
   }
 }
 

--- a/crates/ledgerr-tauri/ui/style.css
+++ b/crates/ledgerr-tauri/ui/style.css
@@ -482,6 +482,110 @@ button:disabled {
   flex-shrink: 0;
 }
 
+/* ── Dashboard panel ───────────────────────────────────────────────────────── */
+.evidence-summary {
+  display: flex;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.ev-card {
+  flex: 1;
+  border-radius: 8px;
+  padding: 14px;
+  text-align: center;
+  border: 1px solid var(--card-border);
+}
+
+.ev-card-blocked {
+  background: #fff0f0;
+  border-color: #e8b4b4;
+}
+
+.ev-card-ready {
+  background: #fff8e8;
+  border-color: #e8d4a0;
+}
+
+.ev-card-exported {
+  background: #e8f8ef;
+  border-color: #a0d4b4;
+}
+
+.ev-card-issues {
+  background: #f0ecff;
+  border-color: #c8b4e8;
+}
+
+.ev-card-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--heading-color);
+}
+
+.ev-card-label {
+  font-size: 11px;
+  color: var(--label-color);
+  margin-top: 2px;
+}
+
+.ev-section {
+  margin-top: 12px;
+  flex-shrink: 0;
+}
+
+.ev-section-title {
+  font-size: 11px;
+  color: var(--label-color);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 4px;
+}
+
+.ev-last-action {
+  font-size: 13px;
+  color: var(--content-color);
+  background: var(--transcript-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  padding: 10px;
+}
+
+.ev-next-actions {
+  list-style: disc;
+  padding-left: 20px;
+  font-size: 13px;
+  color: var(--content-color);
+}
+
+.ev-next-actions li {
+  margin-bottom: 3px;
+}
+
+.ev-provider-status {
+  font-size: 12px;
+  color: var(--content-color);
+  background: var(--transcript-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  padding: 10px;
+}
+
+.ev-provider-line {
+  padding: 2px 0;
+}
+
+.ev-refresh-row {
+  flex-shrink: 0;
+  margin-top: 12px;
+}
+
+.ev-refresh-btn {
+  width: 100%;
+  height: 32px;
+}
+
 /* ── Docs Playbook panel ───────────────────────────────────────────────────── */
 .docs-status {
   font-size: var(--font-base);


### PR DESCRIPTION
Closes #51.

## Summary

Adds a Dashboard panel to the Tauri UI that surfaces the arc-kit-au evidence graph state through TodayQueue.

## Changes

**Rust (3 files)**
- `state.rs`: extends AppState with `Arc<Mutex<EvidenceState>>`
- `commands.rs`: adds `get_evidence_dashboard` (returns TodayQueue) and `get_tx_provenance` (returns badge + CSS class)
- `main.rs`: wires evidence state, registers new commands, renumbers panels (Settings→3, Docs→4)

**UI (3 files)**
- `index.html`: new Dashboard panel with summary cards (blocked/ready/exported/issues), last action, next actions, provider status
- `main.js`: refreshDashboard() function, auto-refresh on panel switch
- `style.css`: dashboard card and section styles

**Other**
- Removed unused `ProvenanceGap` import in arc-kit-au (clippy fix)