### PR TITLE
fix(ledger-core): remove conflicting From impl in ingest.rs

### DIFF
--- a/crates/ledger-core/src/ingest.rs
+++ b/crates/ledger-core/src/ingest.rs
@@ -108,13 +108,6 @@ pub fn deterministic_tx_id(row: &TransactionInput) -> String {
     blake3::hash(canonical.as_bytes()).to_hex().to_string()
 }
 
-impl From<&TransactionInput> for crate::pipeline::DocumentFields {
-    fn from(row: &TransactionInput) -> Self {
-        Self {
-            amount: row.amount.trim().parse().ok(),
-            ..Self::default()
-        }
-      
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DocumentFieldsParseError {
     pub field: String,


### PR DESCRIPTION
## Summary

- Removes `impl From<&TransactionInput> for DocumentFields` which conflicted with Rust's blanket `TryFrom<U> for T where U: Into<T>` — both impls resolved to `TryFrom<&TransactionInput>` for `DocumentFields`, producing E0119
- The `TryFrom` impl (added in the same commit as `From`) is the correct, fallible version: it parses `amount` from string to `Decimal` and returns `DocumentFieldsParseError` on failure — so `From` was redundant and incorrect

## Test plan

- [x] `cargo build --workspace` — clean, no E0119
- [x] `cargo test -p ledger-core` — all tests pass including `transaction_input_to_document_fields_parses_amount` and `transaction_input_to_document_fields_rejects_invalid_amount`

@copilot please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)