### PR TITLE
fix: add missing PathBuf import in query_transactions_tests

### DIFF
--- a/crates/ledgerr-mcp/tests/query_transactions_tests.rs
+++ b/crates/ledgerr-mcp/tests/query_transactions_tests.rs
@@ -2,6 +2,7 @@
 
 mod common;
 
+use std::path::PathBuf;
 use ledgerr_mcp::{
     contract::{DateRange, SortDirection, SortField, SortSpec, PaginationSpec, TransactionFilters},
     TurboLedgerService, TurboLedgerTools, QueryTransactionsRequest, IngestStatementRowsRequest,


### PR DESCRIPTION
Fixes CI failure on main:



The test file `query_transactions_tests.rs` uses `PathBuf::from()` at lines 5, 203, and 282 but was missing the import. Trivial one-line fix.