### PR TITLE
fix: restore b00t-reflect-types crate with serde derives

### DIFF
--- a/crates/b00t-reflect-types/Cargo.toml
+++ b/crates/b00t-reflect-types/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "b00t-reflect-types"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Shared output types for #[derive(HolonEmit)] — HolonNode and friends"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/b00t-reflect-types/src/lib.rs
+++ b/crates/b00t-reflect-types/src/lib.rs
@@ -1,0 +1,13 @@
+/// A type-graph node emitted by `#[derive(HolonEmit)]`.
+///
+/// Consumers convert to their own graph node type via `From<HolonNode>`.
+/// Defined in this companion crate (not the proc-macro crate itself) because
+/// Rust proc-macro crates cannot export non-macro items.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct HolonNode {
+    pub id: String,
+    pub label: String,
+    pub kind: String,
+    pub z_layer: Option<String>,
+    pub semantic_type: Option<String>,
+}


### PR DESCRIPTION
Cherry-picked serde Serialize/Deserialize derives for HolonNode from PR #105 after rebase conflicts.

- crates/b00t-reflect-types/ restored with serde support
- Unblocks b00t workspace build (b00t-cli, b00t-mcp depend on this crate)
- Compatible with existing  throughout codebase